### PR TITLE
Set env.RUST_STABLE as default toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ env.RUST_STABLE }}
+          default: true
 
       # We want to create a new cache after a week. Otherwise, the cache will
       # take up too much space by caching old dependencies
@@ -95,6 +96,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ env.RUST_STABLE }}
+          default: true
 
       - name: Use cached cargo registry
         uses: actions/cache@v2
@@ -134,6 +136,7 @@ jobs:
           profile: minimal
           toolchain: ${{ env.RUST_STABLE }}
           components: clippy
+          default: true
 
       - name: Use cached cargo registry
         uses: actions/cache@v2
@@ -170,6 +173,7 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ env.RUST_STABLE }}
+          default: true
 
       - name: Use cached cargo registry
         uses: actions/cache@v2


### PR DESCRIPTION
Set env.RUST_STABLE as default toolchain. without default: true cargo 1.50 is used