### PR TITLE
XN-1721 move dummy analytics

### DIFF
--- a/xayn-ai/src/analytics.rs
+++ b/xayn-ai/src/analytics.rs
@@ -1,0 +1,19 @@
+use crate::{
+    data::{document::DocumentHistory, document_data::DocumentDataWithMab},
+    error::Error,
+    reranker_systems::AnalyticsSystem,
+};
+
+pub struct Analytics;
+
+pub struct DummyAnalytics;
+
+impl AnalyticsSystem for DummyAnalytics {
+    fn compute_analytics(
+        &self,
+        _history: &[DocumentHistory],
+        _documents: &[DocumentDataWithMab],
+    ) -> Result<Analytics, Error> {
+        Ok(Analytics)
+    }
+}

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -47,5 +47,3 @@ impl Default for UserInterests {
         UserInterests::new()
     }
 }
-
-pub struct Analytics {}

--- a/xayn-ai/src/database.rs
+++ b/xayn-ai/src/database.rs
@@ -1,4 +1,4 @@
-use crate::{data::Analytics, error::Error, reranker::RerankerData};
+use crate::{analytics::Analytics, error::Error, reranker::RerankerData};
 
 pub trait Database {
     fn save_data(&self, state: &RerankerData) -> Result<(), Error>;

--- a/xayn-ai/src/lib.rs
+++ b/xayn-ai/src/lib.rs
@@ -1,3 +1,4 @@
+mod analytics;
 mod bert;
 mod coi;
 mod context;
@@ -11,6 +12,8 @@ mod reranker_systems;
 
 pub(crate) use rubert::ndarray;
 
-pub use data::document::{Document, DocumentHistory, DocumentId};
-pub use error::Error;
-pub use reranker::Reranker;
+pub use crate::{
+    data::document::{Document, DocumentHistory, DocumentId},
+    error::Error,
+    reranker::Reranker,
+};

--- a/xayn-ai/src/reranker_systems.rs
+++ b/xayn-ai/src/reranker_systems.rs
@@ -1,4 +1,5 @@
 use crate::{
+    analytics::Analytics,
     data::{
         document::DocumentHistory,
         document_data::{
@@ -9,7 +10,6 @@ use crate::{
             DocumentDataWithLtr,
             DocumentDataWithMab,
         },
-        Analytics,
         UserInterests,
     },
     database::Database,


### PR DESCRIPTION
**References**

- [XN-1721](https://xainag.atlassian.net/browse/XAYNET-1721)

**Summary**

- move the `DummyAnalytics` into xayn-ai
