### PR TITLE
fix float ndarray comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ version = "0.1.0"
 dependencies = [
  "derive_more",
  "displaydoc",
+ "float-cmp",
  "rubert-tokenizer",
  "thiserror",
  "tract-onnx",

--- a/rubert/Cargo.toml
+++ b/rubert/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 derive_more = { version = "0.99.11", default-features = false, features = ["deref", "from"] }
 displaydoc = "0.2.0"
+float-cmp = "0.8.0"
 rubert-tokenizer = { path = "../rubert-tokenizer" }
 thiserror = "1.0.24"
 tract-onnx = { git = "https://github.com/xaynetwork/tract", branch = "master" }

--- a/rubert/src/lib.rs
+++ b/rubert/src/lib.rs
@@ -16,7 +16,7 @@
 //!         .build()?;
 //!
 //!     let embedding = rubert.run("This is a sequence.")?;
-//!     assert_eq!(embedding.shape(), &[rubert.embedding_size()]);
+//!     assert_eq!(embedding.shape(), [rubert.embedding_size()]);
 //!
 //!     Ok(())
 //! }
@@ -28,16 +28,19 @@ mod pipeline;
 mod pooler;
 mod tokenizer;
 
-#[doc(hidden)]
-pub use tract_onnx::prelude::tract_ndarray as ndarray;
-
 pub use crate::{
     builder::{Builder, BuilderError},
-    model::ModelError,
     pipeline::{RuBert, RuBertError},
-    pooler::{AveragePooler, Embedding1, Embedding2, FirstPooler, NonePooler, PoolerError},
+    pooler::{AveragePooler, Embedding1, Embedding2, FirstPooler, NonePooler},
+};
+#[cfg(doc)]
+pub use crate::{
+    model::ModelError,
+    pooler::{Embedding, PoolerError},
     tokenizer::TokenizerError,
 };
+#[doc(hidden)]
+pub use tract_onnx::prelude::tract_ndarray as ndarray;
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -313,7 +313,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::float_cmp)] // false positive, it actually compares ndarrays
     fn test_update_coi_update_point() {
         let cois = create_cois(&[[1., 1., 1.], [10., 10., 10.], [20., 20., 20.]]);
         let embedding = arr1(&[2., 3., 4.]).into();
@@ -321,24 +320,22 @@ mod tests {
         let cois = CoiSystem::default().update_coi(&embedding, cois);
 
         assert_eq!(cois.len(), 3);
-        assert_eq!(cois[0].point, [1.1, 1.2, 1.3]);
-        assert_eq!(cois[1].point, [10., 10., 10.]);
-        assert_eq!(cois[2].point, [20., 20., 20.]);
+        assert_eq!(cois[0].point, arr1(&[1.1, 1.2, 1.3]));
+        assert_eq!(cois[1].point, arr1(&[10., 10., 10.]));
+        assert_eq!(cois[2].point, arr1(&[20., 20., 20.]));
     }
 
     #[test]
-    #[allow(clippy::float_cmp)] // false positive, it actually compares ndarrays
     fn test_shift_coi_point() {
         let coi = Coi::new(0, arr1(&[1., 1., 1.]).into());
         let embedding = arr1(&[2., 3., 4.]).into();
 
         let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi.point);
 
-        assert_eq!(updated_coi, [1.1, 1.2, 1.3]);
+        assert_eq!(updated_coi, arr1(&[1.1, 1.2, 1.3]));
     }
 
     #[test]
-    #[allow(clippy::float_cmp)] // false positive, it actually compares ndarrays
     fn test_update_coi_threshold_exclusive() {
         let cois = create_cois(&[[0., 0., 0.]]);
         let embedding = arr1(&[0., 0., 12.]).into();
@@ -346,12 +343,11 @@ mod tests {
         let cois = CoiSystem::default().update_coi(&embedding, cois);
 
         assert_eq!(cois.len(), 2);
-        assert_eq!(cois[0].point, [0., 0., 0.]);
-        assert_eq!(cois[1].point, [0., 0., 12.]);
+        assert_eq!(cois[0].point, arr1(&[0., 0., 0.]));
+        assert_eq!(cois[1].point, arr1(&[0., 0., 12.]));
     }
 
     #[test]
-    #[allow(clippy::float_cmp)] // false positive, it actually compares ndarrays
     fn test_update_cois_update_the_same_point_twice() {
         // checks that an updated coi is used in the next iteration
         let cois = create_cois(&[[0., 0., 0.]]);
@@ -367,7 +363,7 @@ mod tests {
         assert_eq!(cois.len(), 1);
         // updated coi after first embedding = [0., 0., 0.49]
         // updated coi after second embedding = [0., 0., 0.941]
-        assert_eq!(cois[0].point, [0., 0., 0.941]);
+        assert_eq!(cois[0].point, arr1(&[0., 0., 0.941]));
     }
 
     #[test]
@@ -457,7 +453,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::float_cmp)] // false positive, it actually compares ndarrays
     fn test_update_user_interests() {
         let positive = create_cois(&[[3., 2., 1.], [1., 2., 3.]]);
         let negative = create_cois(&[[4., 5., 6.]]);
@@ -483,20 +478,20 @@ mod tests {
 
         assert!(approx_eq!(f32, positive[0].alpha, 1.));
         assert!(approx_eq!(f32, positive[0].beta, 1.));
-        assert_eq!(positive[0].point, [2.7999997, 1.9, 1.]);
+        assert_eq!(positive[0].point, arr1(&[2.7999997, 1.9, 1.]));
 
         assert!(approx_eq!(f32, positive[1].alpha, 1.21));
         assert!(approx_eq!(f32, positive[1].beta, 1.));
-        assert_eq!(positive[1].point, [1., 2., 3.]);
+        assert_eq!(positive[1].point, arr1(&[1., 2., 3.]));
 
         assert!(approx_eq!(f32, positive[2].alpha, 1.));
         assert!(approx_eq!(f32, positive[2].beta, 1.));
-        assert_eq!(positive[2].point, [3., 6., 6.]);
+        assert_eq!(positive[2].point, arr1(&[3., 6., 6.]));
 
         assert_eq!(negative.len(), 1);
         assert!(approx_eq!(f32, negative[0].alpha, 1.));
         assert!(approx_eq!(f32, negative[0].beta, 1.));
-        assert_eq!(negative[0].point, [3.6999998, 4.9, 5.7999997]);
+        assert_eq!(negative[0].point, arr1(&[3.6999998, 4.9, 5.7999997]));
     }
 
     #[test]

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -306,7 +306,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    #[allow(clippy::float_cmp)] // false positive, it actually compares ndarrays
     fn test_classify_documents_based_on_user_feedback() {
         let history = create_document_history(vec![
             (Relevance::Low, UserFeedback::Irrelevant),
@@ -320,11 +319,11 @@ pub(crate) mod tests {
             classify_documents_based_on_user_feedback(matching_documents);
 
         assert_eq!(positive_docs.len(), 2);
-        assert_eq!(positive_docs[0].embedding.embedding, [3., 2., 1.]);
-        assert_eq!(positive_docs[1].embedding.embedding, [4., 5., 6.]);
+        assert_eq!(positive_docs[0].embedding.embedding, arr1(&[3., 2., 1.]));
+        assert_eq!(positive_docs[1].embedding.embedding, arr1(&[4., 5., 6.]));
 
         assert_eq!(negative_docs.len(), 1);
-        assert_eq!(negative_docs[0].embedding.embedding, [1., 2., 3.]);
+        assert_eq!(negative_docs[0].embedding.embedding, arr1(&[1., 2., 3.]));
     }
 
     #[test]


### PR DESCRIPTION
**Summary**

- use `float-cmp`'s implementation for `ApproxEq` to implement `PartialEq` for our `Embedding`. i also looked into `approx`'s implementation, which would have the nice benefit that it's already implemented on `ndarray` with a feature, but after all the comparison strategy of `float-cmp` seems better. essentially `float-cmp` uses an escalation of exact, epsilon and ulps comparison, whereas `approx` only uses epsilon comparison. it provides the means for the other comparisons as well, but one has to combine them by hand, which would lead to a more involved custom impl than we now have for the embeddings.
- clean up the clippy comments on the tests. we now compare ndarrays instead of float arrays against the embeddings, because there is no way to convince clippy that the comparison is ok. funny enough, clippy is ok with `assert!(embedding.eq(slice))` but it throws an error for `assert!(embedding == slice)` and `assert_eq!(embedding, slice)` even though all of them call the same `PartialEq` impl.