### PR TITLE
fix context calculation for f32:MAX

### DIFF
--- a/xayn-ai/src/context.rs
+++ b/xayn-ai/src/context.rs
@@ -118,7 +118,6 @@ mod tests {
     fn test_calculate_neg_max_f32_max() {
         // when calculating the negative distance in the `CoiSystem`,
         // we assign `f32::MAX` if we don't have negative cois
-
         let calc = ContextCalc {
             pos_avg: 4.,
             neg_max: f32::MAX,


### PR DESCRIPTION
Fixes a small issue in the context calculation. 
In the current implementation the context value becomes `inf` if `self.neg_max` and `neg` are `f32:MAX`. 

[Playgound](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=bed8d6408e2d71b2b3e0016912920e56)