### PR TITLE
Add DocumentId to DocumentsRank

### DIFF
--- a/xayn-ai/src/reranker.rs
+++ b/xayn-ai/src/reranker.rs
@@ -13,9 +13,10 @@ use crate::{
     error::Error,
     reranker_systems::{CoiSystemData, CommonSystems},
     to_vec_of_ref_of,
+    DocumentId,
 };
 
-pub type DocumentsRank = Vec<usize>;
+pub type DocumentsRank = Vec<(DocumentId, usize)>;
 
 /// Update cois from user feedback
 fn learn_user_interests<CS>(
@@ -88,7 +89,10 @@ where
         .mab()
         .compute_mab(documents, user_interests)?;
 
-    let rank = documents.iter().map(|document| document.mab.rank).collect();
+    let rank = documents
+        .iter()
+        .map(|document| (document.document_id.id.clone(), document.mab.rank))
+        .collect();
 
     Ok((documents, user_interests, rank))
 }
@@ -200,7 +204,10 @@ where
                     .unwrap_or_default();
                 self.data.prev_documents = PreviousDocuments::Embedding(prev_documents);
 
-                documents.iter().map(|document| document.rank).collect()
+                documents
+                    .iter()
+                    .map(|document| (document.id.clone(), document.rank))
+                    .collect()
             })
     }
 }


### PR DESCRIPTION
`rerank` only returns the rank but not the `DocumentId`s so the returned `DocumentsRank` will always be:

```
rank: 0
rank: 1
rank: 2
rank: 3
rank: 4
```

This pr adds the `DocumentId` to the `DocumentsRank` so that the app knows how to rearrange the documents.

```
doc_id: 4, rank: 0
doc_id: 2, rank: 1
doc_id: 0, rank: 2
doc_id: 1, rank: 3
doc_id: 3, rank: 4
```