### PR TITLE
Do not cache registry/src

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,6 +1653,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "float-cmp",
+ "itertools 0.10.0",
  "maplit",
  "mockall",
  "ndarray",
@@ -1661,6 +1662,7 @@ dependencies = [
  "rand_distr",
  "rubert",
  "serde",
+ "smallvec",
  "thiserror",
 ]
 


### PR DESCRIPTION
We can avoid to cache `.cargo/registry/src`, it contains the working trees of the dependencies. Cargo can quickly create them again starting from `.carg/registry/git` if they are missing. On my system to build this project `.cargo/registry/src` is 200Mb big but not caching it save only 21Mb (-10%) because of compression.