### PR TITLE
Rename Nil to avoid conflicts with Objective-C

### DIFF
--- a/bindings/dart/lib/src/data/history.dart
+++ b/bindings/dart/lib/src/data/history.dart
@@ -47,7 +47,7 @@ extension RelevanceInt on Relevance {
 enum Feedback {
   relevant,
   irrelevant,
-  nil,
+  notGiven,
 }
 
 extension FeedbackInt on Feedback {
@@ -58,8 +58,8 @@ extension FeedbackInt on Feedback {
         return CFeedback.Relevant;
       case Feedback.irrelevant:
         return CFeedback.Irrelevant;
-      case Feedback.nil:
-        return CFeedback.Nil;
+      case Feedback.notGiven:
+        return CFeedback.NotGiven;
       default:
         throw UnsupportedError('Undefined enum variant.');
     }
@@ -72,8 +72,8 @@ extension FeedbackInt on Feedback {
         return Feedback.relevant;
       case CFeedback.Irrelevant:
         return Feedback.irrelevant;
-      case CFeedback.Nil:
-        return Feedback.nil;
+      case CFeedback.NotGiven:
+        return Feedback.notGiven;
       default:
         throw UnsupportedError('Undefined enum variant.');
     }

--- a/xayn-ai-ffi-c/src/data/history.rs
+++ b/xayn-ai-ffi-c/src/data/history.rs
@@ -34,7 +34,9 @@ impl From<CRelevance> for Relevance {
 pub enum CFeedback {
     Relevant = 0,
     Irrelevant = 1,
-    Nil = 2,
+    // We cannot use None nor Nil because they are reserved
+    // keyword in dart or objective-C
+    NotGiven = 2,
 }
 
 impl From<CFeedback> for UserFeedback {
@@ -42,7 +44,7 @@ impl From<CFeedback> for UserFeedback {
         match feedback {
             CFeedback::Relevant => Self::Relevant,
             CFeedback::Irrelevant => Self::Irrelevant,
-            CFeedback::Nil => Self::None,
+            CFeedback::NotGiven => Self::None,
         }
     }
 }


### PR DESCRIPTION
Blue CI broke with the following error when building the app for iOS:
```
Xcode's output:
↳
    <module-includes>:1:9: note: in file included from <module-includes>:1:
    #import "Headers/xayn_ai_ffi_dart-umbrella.h"
            ^
    /Users/robert/projects/xayn-ai/bindings/dart/example/ios/Pods/Target Support Files/xayn_ai_ffi_dart/xayn_ai_ffi_dart-umbrella.h:13:9: note: in file included from
    /Users/robert/projects/xayn-ai/bindings/dart/example/ios/Pods/Target Support Files/xayn_ai_ffi_dart/xayn_ai_ffi_dart-umbrella.h:13:
    #import "XaynAiFfiDartPlugin.h"
            ^
    /Users/robert/flutter/.pub-cache/git/xayn_ai_release-c22529a31f9adb6698301028fcea2e1f26d15506/ios/Classes/XaynAiFfiDartPlugin.h:84:3: error: expected identifier
      Nil = 2,
      ^
    /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/usr/include/objc/objc.h:100:16: note: expanded from macro
    'Nil'
    #   define Nil __DARWIN_NULL
                   ^
    /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro
    '__DARWIN_NULL'
    #define __DARWIN_NULL ((void *)0)
                          ^
    <unknown>:0: error: could not build Objective-C module 'xayn_ai_ffi_dart'
    <module-includes>:1:9: note: in file included from <module-includes>:1:
    #import "Headers/xayn_ai_ffi_dart-umbrella.h"
            ^
    /Users/robert/projects/xayn-ai/bindings/dart/example/ios/Pods/Target Support Files/xayn_ai_ffi_dart/xayn_ai_ffi_dart-umbrella.h:13:9: note: in file included from
    /Users/robert/projects/xayn-ai/bindings/dart/example/ios/Pods/Target Support Files/xayn_ai_ffi_dart/xayn_ai_ffi_dart-umbrella.h:13:
    #import "XaynAiFfiDartPlugin.h"
            ^
    /Users/robert/flutter/.pub-cache/git/xayn_ai_release-c22529a31f9adb6698301028fcea2e1f26d15506/ios/Classes/XaynAiFfiDartPlugin.h:84:3: error: expected identifier
      Nil = 2,
      ^
    /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/usr/include/objc/objc.h:100:16: note: expanded from macro
    'Nil'
    #   define Nil __DARWIN_NULL
                   ^
    /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.5.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro
    '__DARWIN_NULL'
    #define __DARWIN_NULL ((void *)0)
                          ^
    <unknown>:0: error: could not build Objective-C module 'xayn_ai_ffi_dart'
```
`Nil` is a keyword in Objective-C so we cannot use it in code that is exported in the C header.
