### PR TITLE
TY-1792 exclude wasm ffi from tarpaulin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.16.0'
-          args: '-v --all-features --force-clean --lib --ignore-tests --fail-under 70'
+          args: '-v --all-features --force-clean --lib --ignore-tests --fail-under 70 --workspace --exclude xayn-ai-ffi-wasm'
 
   install-cargo-lipo:
     # we use the latest stable rustc + cargo version that is already installed on the image

--- a/xayn-ai-ffi-wasm/src/lib.rs
+++ b/xayn-ai-ffi-wasm/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(tarpaulin))]
 mod ai;
+#[cfg(not(tarpaulin))]
 mod error;
+#[cfg(not(tarpaulin))]
 mod utils;


### PR DESCRIPTION
**References**

- [TY-1792]

**Summary**

- exclude `xayn-ai-ffi-wasm` from the `cargo tarpaulin` job: 1) in the ci to exclude it from running 2) in the crate to exclude it from counting (unfortunately this has to be done by module because a global feature flag is ignored)


[TY-1792]: https://xainag.atlassian.net/browse/TY-1792