### PR TITLE
TY-1788 reconcile FE with soundgarden

### DIFF
--- a/xayn-ai/src/ltr/features/dataiku.rs
+++ b/xayn-ai/src/ltr/features/dataiku.rs
@@ -58,6 +58,7 @@ pub(crate) enum DayOfWeek {
     Sun,
 }
 
+/// Data pertaining to a single result from a search.
 pub struct SearchResult {
     /// Session identifier.
     pub(crate) session_id: i32,
@@ -386,6 +387,10 @@ pub(crate) fn snippet_quality(hist: &[SearchResult], res: &SearchResult, pred: F
         .filter(|r| r.relevance == ClickSat::Miss || r.relevance == ClickSat::Skip)
         .count() as f32;
 
+    if denom == 0. {
+        return 0.;
+    }
+
     let numer = pred_filtered
         .group_by(|r| (r.session_id, r.query_counter))
         .into_iter()
@@ -395,11 +400,7 @@ pub(crate) fn snippet_quality(hist: &[SearchResult], res: &SearchResult, pred: F
         })
         .sum::<f32>();
 
-    if denom == 0. {
-        0.
-    } else {
-        numer / denom
-    }
+    numer / denom
 }
 
 /// Scores the search result ranked at position `pos` in the result set `rs`.


### PR DESCRIPTION
#42 attempts to faithfully implement Dataiku's spec (notwithstanding ambiguities in the spec itself). As such, it departs from soundgarden's implementation in some places. However, we are already using a model trained on the soundgarden implementation. Thus to now use the newer rust FE with this model could lead to bad predictions. We could re-train the model from scratch with the rust FE, but it would be difficult to quantify the level of improvement this would bring without more knowledge of how the current model performs.

Hence, Pink's preference is to bring the rust FE more in line with soundgarden's. At a later date, when we have a more complete "baseline" of the current model's performance to compare against, we can once again consider the effect of re-training the model with a more faithful Dataiku FE. 