### PR TITLE
TY-1778 Use similarity to compute the context value

### DIFF
--- a/xayn-ai/src/context.rs
+++ b/xayn-ai/src/context.rs
@@ -60,7 +60,6 @@ impl ContextCalc {
         let frac_neg = (1. + (self.neg_max - neg)).recip();
         let frac_similarity = (1. + similarity / self.similarity_avg).recip();
 
-        dbg!(frac_pos, frac_neg, frac_similarity, ltr_score);
         (frac_pos + frac_neg + frac_similarity + ltr_score) / 4.
     }
 }
@@ -134,7 +133,6 @@ mod tests {
         assert!(approx_eq!(f32, cxt, 1.)); // 1/4 * 4
 
         let cxt = calc.calculate(0., calc.pos_avg, calc.neg_max, calc.similarity_avg);
-        dbg!(cxt);
         assert!(approx_eq!(f32, cxt, 0.5)); // 2/8 + 1/4
 
         let cxt = calc.calculate(0., 8., 7., 4.);


### PR DESCRIPTION
The similarity is the distance between the query and the result so we treat it as `pos_avg`. Since we normalize the value between `0` and `1` returning the default of `0.5` is ok.