### PR TITLE
TY 1838 Update qambert to 1 layer model

### DIFF
--- a/bindings/dart/example/pubspec.yaml
+++ b/bindings/dart/example/pubspec.yaml
@@ -47,4 +47,4 @@ flutter:
   # To add assets to your plugin package, add an assets section, like this:
   assets:
     - assets/smbert_v0000/
-    - assets/qambert_v0000/
+    - assets/qambert_v0001/

--- a/bindings/dart/lib/src/common/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/common/reranker/data_provider.dart
@@ -10,10 +10,10 @@ final baseAssets = <AssetType, Asset>{
       'ffb2398810fa977ee39e8a0103b07f9c2614f1f9825df53a2c99e71569e3451c'),
   AssetType.smbertModel: Asset('smbert_v0000/smbert.onnx',
       'c07653a3cc568876071de157f0fb8ccc1a302197ddad9ead069a86140e19d913'),
-  AssetType.qambertVocab: Asset('qambert_v0000/vocab.txt',
+  AssetType.qambertVocab: Asset('qambert_v0001/vocab.txt',
       'ffb2398810fa977ee39e8a0103b07f9c2614f1f9825df53a2c99e71569e3451c'),
-  AssetType.qambertModel: Asset('qambert_v0000/qambert.onnx',
-      'f67cd8719a93e1f32402fc6051d829d6fbf53e70e85c772434aa1e01b0b1c1b3'),
+  AssetType.qambertModel: Asset('qambert_v0001/qambert.onnx',
+      '030e7d68cc82f59640c6b989f145d6eaa7609c8615bd6ae9e7890e1a68be5b71'),
 };
 
 enum AssetType {

--- a/bindings/dart/test/mobile/utils.dart
+++ b/bindings/dart/test/mobile/utils.dart
@@ -13,8 +13,8 @@ import 'package:xayn_ai_ffi_dart/src/mobile/reranker/data_provider.dart'
 
 const smbertVocab = '../../data/smbert_v0000/vocab.txt';
 const smbertModel = '../../data/smbert_v0000/smbert.onnx';
-const qambertVocab = '../../data/qambert_v0000/vocab.txt';
-const qambertModel = '../../data/qambert_v0000/qambert.onnx';
+const qambertVocab = '../../data/qambert_v0001/vocab.txt';
+const qambertModel = '../../data/qambert_v0001/qambert.onnx';
 
 SetupData mkSetupData(String smbertVocab, String smbertModel,
     String qambertVocab, String qambertModel) {

--- a/download_data.sh
+++ b/download_data.sh
@@ -35,5 +35,5 @@ download()
 }
 
 download smbert v0000
-download qambert v0000
+download qambert v0001
 download ltr v0000

--- a/xayn-ai-ffi-c/src/lib.rs
+++ b/xayn-ai-ffi-c/src/lib.rs
@@ -17,8 +17,8 @@ pub(crate) mod tests {
     pub const SMBERT_MODEL: &str = "../data/smbert_v0000/smbert.onnx";
 
     /// Path to the current qambert vocabulary file.
-    pub const QAMBERT_VOCAB: &str = "../data/qambert_v0000/vocab.txt";
+    pub const QAMBERT_VOCAB: &str = "../data/qambert_v0001/vocab.txt";
 
     /// Path to the current qambert onnx model file.
-    pub const QAMBERT_MODEL: &str = "../data/qambert_v0000/qambert.onnx";
+    pub const QAMBERT_MODEL: &str = "../data/qambert_v0001/qambert.onnx";
 }

--- a/xayn-ai-ffi-wasm/example/index.html
+++ b/xayn-ai-ffi-wasm/example/index.html
@@ -12,9 +12,9 @@
         console.time("load_data");
         let smbert_vocab = await window.fetch("data/smbert_v0000/vocab.txt");
         let smbert_model = await window.fetch("data/smbert_v0000/smbert.onnx");
-        let qambert_vocab = await window.fetch("data/qambert_v0000/vocab.txt");
+        let qambert_vocab = await window.fetch("data/qambert_v0001/vocab.txt");
         let qambert_model = await window.fetch(
-          "data/qambert_v0000/qambert.onnx"
+          "data/qambert_v0001/qambert.onnx"
         );
         let smbert_vocab_buf = new Uint8Array(await smbert_vocab.arrayBuffer());
         let smbert_model_buf = new Uint8Array(await smbert_model.arrayBuffer());

--- a/xayn-ai-ffi-wasm/src/ai.rs
+++ b/xayn-ai-ffi-wasm/src/ai.rs
@@ -158,10 +158,10 @@ mod tests {
     const SMBERT_MODEL: &[u8] = include_bytes!("../../data/smbert_v0000/smbert.onnx");
 
     /// Path to the current qambert vocabulary file.
-    const QAMBERT_VOCAB: &[u8] = include_bytes!("../../data/qambert_v0000/vocab.txt");
+    const QAMBERT_VOCAB: &[u8] = include_bytes!("../../data/qambert_v0001/vocab.txt");
 
     /// Path to the current qambert onnx model file.
-    const QAMBERT_MODEL: &[u8] = include_bytes!("../../data/qambert_v0000/qambert.onnx");
+    const QAMBERT_MODEL: &[u8] = include_bytes!("../../data/qambert_v0001/qambert.onnx");
 
     impl std::fmt::Debug for WXaynAi {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {

--- a/xayn-ai/src/embedding/qambert.rs
+++ b/xayn-ai/src/embedding/qambert.rs
@@ -64,8 +64,8 @@ mod tests {
 
     use super::*;
 
-    const VOCAB: &str = "../data/qambert_v0000/vocab.txt";
-    const QAMBERT_MODEL: &str = "../data/qambert_v0000/qambert.onnx";
+    const VOCAB: &str = "../data/qambert_v0001/vocab.txt";
+    const QAMBERT_MODEL: &str = "../data/qambert_v0001/qambert.onnx";
 
     fn qambert() -> QAMBert {
         QAMBertBuilder::from_files(VOCAB, QAMBERT_MODEL)
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_similarity() {
-        check_similarity(qambert(), &[15.445126, 10.795474, 17.740929, 15.862612]);
+        check_similarity(qambert(), &[14.395557, 11.348355, 16.711432, 14.539247]);
     }
 
     #[test]


### PR DESCRIPTION
The current model has 2 layers instead of 1. Having 2 layers make the model too slow (20ms per document instead of 10).
The vocabulary is the same.