### PR TITLE
PR workflow concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
       # a snapshot of staging in a given point in time
       - 'release'
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   RUST_STABLE: 1.51
   RUST_NIGHTLY: nightly-2021-05-10


### PR DESCRIPTION
Github has added a new [feature](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) that we can use to ensure that only one workflow is running at a time.
For example, if we push new changes to a pr branch and the ci is still running the workflow of the old commit, github automatically aborts the current run and starts the workflow for the new commit. It works like `styfle/cancel-workflow-action@0.9.0` that we use in the release workflow. It is still beta but I think we can use it for our `pr` workflow.

There is also a video that explains it in more detail https://youtu.be/JMHs5lYpvAM?t=277