### PR TITLE
TY 1827 Don't copy asset on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -352,20 +352,6 @@ jobs:
           cd /tmp/artifacts
           cp -r ios-*/* ${{ env.DART_WORKSPACE }}/ios
 
-      - name: Copy data to assets
-        run: |
-          sh download_data.sh
-          cd ${{ env.DART_WORKSPACE }}/assets
-          # substitute symlink to data with the actual data
-          for file in ./*; do
-            # if file is a symlink
-            if [[ -L $file ]]; then
-              src=$(readlink $file);
-              rm $file;
-              cp -r $src $file;
-            fi;
-          done
-
       - name: Copy headers
         run: |
           cd /tmp/artifacts/headers-${{ github.sha }}


### PR DESCRIPTION
Now that the assets are downloaded by the app we don't need to provide them on the release repository.