### PR TITLE
Fix web assets path

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -93,7 +93,7 @@ dependencies = [ "build-dart" ]
 script_runner = "@duckscript"
 env = { WASM_SUFFIX="wasm_bindings" }
 script = ["""
-  wasm_rel_path = set "bindings/dart/example/${WASM_SUFFIX}"
+  wasm_rel_path = set "bindings/dart/example/assets/${WASM_SUFFIX}"
   set_env WASM_REL_PATH "${wasm_rel_path}"
   cm_run_task build-wasm
   cm_run_task gen-assets
@@ -121,9 +121,9 @@ script = ["""
   rm -f ios/Classes/XaynAiFFiDart.h
   rm -f lib/src/common/ffi/genesis.dart
   rm -f lib/src/mobile/ffi/genesis.dart
-  rm -f example/wasm_bindings/genesis_bg.wasm
-  rm -f example/wasm_bindings/genesis.js
-  rm -f example/wasm_bindings/package.json
+  rm -f example/assets/wasm_bindings/genesis_bg.wasm
+  rm -f example/assets/wasm_bindings/genesis.js
+  rm -f example/assets/wasm_bindings/package.json
 """]
 
 [tasks.clean-codegen]

--- a/bindings/dart/example/.gitignore
+++ b/bindings/dart/example/.gitignore
@@ -46,5 +46,5 @@ app.*.map.json
 /android/app/release
 
 # wasm bindings
-/wasm_bindings/*
-!/wasm_bindings/.gitkeep
+assets/wasm_bindings/*
+!assets/wasm_bindings/.gitkeep

--- a/bindings/dart/example/lib/data_provider/web.dart
+++ b/bindings/dart/example/lib/data_provider/web.dart
@@ -7,7 +7,7 @@ import 'package:xayn_ai_ffi_dart/package.dart'
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     show joinPaths;
 
-const _baseAssetUrl = 'assets';
+const _baseAssetUrl = 'assets/assets';
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
 Future<SetupData> getInputData() async {

--- a/bindings/dart/example/pubspec.yaml
+++ b/bindings/dart/example/pubspec.yaml
@@ -49,5 +49,5 @@ flutter:
     - 'assets/qambert_v0001/'
     - 'assets/ltr_v0000/'
     - 'assets/call_data/'
-    - 'wasm_bindings/'
+    - 'assets/wasm_bindings/'
 

--- a/bindings/dart/example/web/index.html
+++ b/bindings/dart/example/web/index.html
@@ -8,7 +8,7 @@
   <body>
     <script type="module">
       // Exposes the xayn_ffi js wrapper for wasm to the global scope for Dart interop
-      import * as xayn_ai_ffi_wasm from './assets/wasm_bindings/genesis.js';
+      import * as xayn_ai_ffi_wasm from './assets/assets/wasm_bindings/genesis.js';
       window.xayn_ai_ffi_wasm = xayn_ai_ffi_wasm;
     </script>
   </body>


### PR DESCRIPTION
`flutter build web` and `flutter run -d chrome` behave differently when bundling the web assets. In `flutter run -d chrome` we can access an asset via `http://localhost:56864/assets/assets/qambert_v0001/qambert.onnx` or `http://localhost:56864/assets/qambert_v0001/qambert.onnx`. With `flutter build web`, on the other hand, we can only access an asset via `http://localhost:56864/assets/assets/qambert_v0001/qambert.onnx`. 

There are several tickets that relate to this problem:
- https://github.com/flutter/flutter/issues/80784
- https://github.com/flutter/flutter/issues/67655

In this PR we change the `_baseAssetUrl` from `/assets` to `/assets/assets` so that it works for both commands.
