### PR TITLE
Fix ltr model path

### DIFF
--- a/data/asset_templates/assets.json.tmpl
+++ b/data/asset_templates/assets.json.tmpl
@@ -38,7 +38,8 @@
     {
       "name": "ltrModel",
       "suffix": "{{ $ltr_model }}",
-      "checksum": "{{ print $data_dir "/" $ltr_model | file.Read | crypto.SHA256 }}"
+      "checksum": "{{ print $data_dir "/" $ltr_model | file.Read | crypto.SHA256 }}",
+      "path": "{{ $data_dir }}/{{ $ltr_model }}"
     },
     {
       "name": "wasmModule",


### PR DESCRIPTION
The upload job in the release ci was failing because we forgot to add the `path`.
https://github.com/xaynetwork/xayn_ai/runs/2883585775?check_suite_focus=true