### PR TITLE
TY-1911 remove flutter cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,15 +522,7 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
 
-      - name: Restore flutter ${{ env.FLUTTER_VERSION }} cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
-        with:
-          path: /opt/hostedtoolcache/flutter
-          key: ${{ runner.os }}-flutter-cache-${{ env.FLUTTER_VERSION }}
-
-      - name: Set path or install flutter
-        # if there is a cache hit, this step will append the `bin` directory of
-        # flutter to `PATH`, otherwise it installs flutter
+      - name: Install flutter
         uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -565,13 +557,7 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
 
-      - name: Restore flutter ${{ env.FLUTTER_VERSION }} cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
-        with:
-          path: /opt/hostedtoolcache/flutter
-          key: ${{ runner.os }}-flutter-cache-${{ env.FLUTTER_VERSION }}
-
-      - name: Set path or install flutter
+      - name: Install flutter
         uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -683,7 +669,7 @@ jobs:
           cd ${{ runner.temp }}/build-ios-${{ github.sha }}
           find . -iname '*.a' -exec cp \{\} ${{ env.DART_WORKSPACE }}/ios \;
 
-      - name: Set path or install flutter
+      - name: Install flutter
         uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,13 +137,7 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
 
-      - name: Restore flutter ${{ env.FLUTTER_VERSION }} cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
-        with:
-          path: /opt/hostedtoolcache/flutter
-          key: ${{ runner.os }}-flutter-cache-${{ env.FLUTTER_VERSION }}
-
-      - name: Set path or install flutter
+      - name: Install flutter
         uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -412,13 +406,7 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ env.JAVA_VERSION }}
 
-      - name: Restore flutter ${{ env.FLUTTER_VERSION }} cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
-        with:
-          path: /opt/hostedtoolcache/flutter
-          key: ${{ runner.os }}-flutter-cache-${{ env.FLUTTER_VERSION }}
-
-      - name: Set path or install flutter
+      - name: Install flutter
         uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}


### PR DESCRIPTION
**Ticktet**

[TY-1911]


**Summary**

We are already exceeding the limit of the cache of 5GB per run, so the cache has no effect. We remove the flutter cache to make some space (714MB). All flutter jobs will take ~30 sec longer after this change.

[TY-1911]: https://xainag.atlassian.net/browse/TY-1911