### PR TITLE
TY-1877 exclude dart example in release repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -615,7 +615,7 @@ jobs:
           # --ignore-unmatch avoid to fail if the repository is empty
           git rm --ignore-unmatch -r .
 
-          rsync -a --exclude example ${{ env.DART_WORKSPACE}}/ .
+          rsync -a --exclude example ${{ env.DART_WORKSPACE }}/ .
 
           # Remove files from .gitignore that needs to be uploaded to the release repo
           sed -i -e '/DELETE_AFTER_THIS_IN_RELEASE/,$d' .gitignore

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -258,7 +258,7 @@ jobs:
             -t ${{ matrix.target }} \
             -p ${{ env.ANDROID_PLATFORM_VERSION }} \
             -o ${{ env.ANDROID_LIBS_DIR }} \
-            build --release
+            build --release --workspace --exclude xayn-ai-ffi-wasm
 
       - name: Upload artifact
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -615,7 +615,7 @@ jobs:
           # --ignore-unmatch avoid to fail if the repository is empty
           git rm --ignore-unmatch -r .
 
-          rsync -a ${{ env.DART_WORKSPACE}}/ .
+          rsync -a --exclude example ${{ env.DART_WORKSPACE}}/ .
 
           # Remove files from .gitignore that needs to be uploaded to the release repo
           sed -i -e '/DELETE_AFTER_THIS_IN_RELEASE/,$d' .gitignore


### PR DESCRIPTION
**Ticket:**

[TY-1877]

**Summary**

- exclude dart example 
- exclude building [wasm android library](https://github.com/xaynetwork/xayn_ai_release/tree/staging/android/src/main/jniLibs/arm64-v8a)
  - if we were to create a new release now, the wasm lib would still appear as it is in the build cache (the `target` folder)
  - however i will change the cache key in [TY-1871] so no need to do it in this pr

[TY-1877]: https://xainag.atlassian.net/browse/TY-1877

[TY-1871]: https://xainag.atlassian.net/browse/TY-1871