### PR TITLE
TY-1871 use github.job in cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  registry-cache:
+  cargo-registry-cache:
     # we use the latest stable rustc + cargo version that is already installed on the image
     # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#rust-tools
-    name: cargo-fetch
+    name: cargo-registry-cache
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     outputs:
@@ -58,7 +58,7 @@ jobs:
       - name: Generate cargo registry cache key
         id: cache-key
         shell: bash
-        run: echo "::set-output name=key::$(echo ${{ runner.os }}-cargo-registry-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/Cargo.lock') }})"
+        run: echo "::set-output name=key::$(echo ${{ runner.os }}-${{ github.job }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/Cargo.lock') }})"
 
       - name: Restore cargo registry ${{ steps.cache-key.outputs.key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -68,14 +68,14 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ steps.cache-key.outputs.key }}
-          restore-keys: ${{ runner.os }}-cargo-registry-${{ steps.get-date.outputs.date }}-
+          restore-keys: ${{ runner.os }}-${{ github.job }}-${{ steps.get-date.outputs.date }}-
 
       - name: Fetch dependencies
         run: cargo fetch
 
-  format:
-    name: cargo-fmt
-    needs: registry-cache
+  cargo-format:
+    name: cargo-format
+    needs: cargo-registry-cache
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -97,15 +97,15 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       # cargo fmt does not create any artifacts, therefore we don't need to cache the target folder
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
-  check:
+  cargo-check:
     name: cargo-check
-    needs: registry-cache
+    needs: cargo-registry-cache
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
@@ -127,14 +127,14 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Cache build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-check-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-check-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: cargo check
         env:
@@ -143,9 +143,9 @@ jobs:
           cargo check --all-targets
           cargo check --all-targets --all-features
 
-  clippy:
+  cargo-clippy:
     name: cargo-clippy
-    needs: [registry-cache, check]
+    needs: [cargo-registry-cache, cargo-check]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
@@ -168,23 +168,23 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Cache build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-clippy-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-clippy-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: cargo clippy
         run: |
           cargo clippy --all-targets -- --deny warnings
           cargo clippy --all-targets --all-features -- --deny warnings
 
-  test:
+  cargo-test:
     name: cargo-test
-    needs: [registry-cache, check]
+    needs: [cargo-registry-cache, cargo-check]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     outputs:
@@ -208,19 +208,19 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Generate build artifacts key
         id: cache-key
         shell: bash
-        run: echo "::set-output name=key::$(echo "${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-tests-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}")"
+        run: echo "::set-output name=key::$(echo "${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}")"
 
       - name: Cache build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
           key: ${{ steps.cache-key.outputs.key }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-tests-${{ needs.registry-cache.outputs.cache-date }}-
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Download data
         run: sh download_data.sh
@@ -233,9 +233,9 @@ jobs:
           cargo test --all-targets --all-features
           cargo test --all-features --doc
 
-  coverage:
+  cargo-tarpaulin:
     name: cargo-tarpaulin
-    needs: [registry-cache, test]
+    needs: [cargo-registry-cache, cargo-test]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
@@ -257,14 +257,14 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Cache build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-tarpaulin-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-tarpaulin-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Download data
         run: sh download_data.sh
@@ -287,7 +287,7 @@ jobs:
       - name: Generate cargo-lipo cache key
         id: cache-key
         shell: bash
-        run: echo "::set-output name=key::$(echo ${{ runner.os }}-cargo-lipo-bin-${{ env.CARGO_LIPO }})"
+        run: echo "::set-output name=key::$(echo ${{ runner.os }}-${{ github.job }}-${{ env.CARGO_LIPO }})"
 
       - name: Restore ${{ steps.cache-key.outputs.key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -302,7 +302,7 @@ jobs:
 
   test-android-libs:
     name: test-android-libs
-    needs: [registry-cache, test]
+    needs: [cargo-registry-cache, cargo-test]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     strategy:
@@ -322,14 +322,14 @@ jobs:
           target: ${{ matrix.target }}
           default: true
 
-      - name: Restore ${{ needs.registry-cache.outputs.cache-key }} cache
+      - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Install Cross
         shell: bash
@@ -345,8 +345,8 @@ jobs:
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-test-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-test-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Test Android library ${{ matrix.target }}
         env:
@@ -355,7 +355,7 @@ jobs:
 
   build-ios-libs:
     name: build-ios-libs
-    needs: [registry-cache, install-cargo-lipo, test]
+    needs: [cargo-registry-cache, install-cargo-lipo, cargo-test]
     runs-on: macos-10.15
     timeout-minutes: 20
     strategy:
@@ -375,14 +375,14 @@ jobs:
           target: ${{ matrix.target }}
           default: true
 
-      - name: Restore ${{ needs.registry-cache.outputs.cache-key }} cache
+      - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Restore ${{ needs.install-cargo-lipo.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -394,8 +394,8 @@ jobs:
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-build-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-build-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Build iOS library ${{ matrix.target }}
         working-directory: ./xayn-ai-ffi-c
@@ -416,7 +416,7 @@ jobs:
 
   test-wasm-lib:
     name: test-wasm-lib
-    needs: [registry-cache, test]
+    needs: [cargo-registry-cache, cargo-test]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
@@ -432,14 +432,14 @@ jobs:
           target: wasm32-unknown-unknown
           default: true
 
-      - name: Restore ${{ needs.registry-cache.outputs.cache-key }} cache
+      - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Install wasm-pack
         uses: ./.ci/install-wasm-pack
@@ -455,7 +455,7 @@ jobs:
 
   build-linux-lib:
     name: build-linux-lib
-    needs: [registry-cache, test]
+    needs: [cargo-registry-cache, cargo-test]
     runs-on: ubuntu-20.04
     outputs:
       cache-key: ${{ steps.cache-key.outputs.key }}
@@ -479,13 +479,13 @@ jobs:
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Restore build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ needs.test.outputs.cache-key }}
+          key: ${{ needs.cargo-test.outputs.cache-key }}
 
       - name: Build linux lib
         # We have to use the same RUSTFLAGS that are used in the test
@@ -498,7 +498,7 @@ jobs:
       - name: Generate lib artifacts key
         id: cache-key
         shell: bash
-        run: echo "::set-output name=key::$(echo build-x86_64-unknown-linux-gnu-${{ hashFiles('target/debug/libxayn_ai_ffi_c.so', '${{ env.DART_WORKSPACE }}/ios/Classes/XaynAiFfiCommon.h', '${{ env.DART_WORKSPACE }}/ios/Classes/XaynAiFfiDart.h') }})"
+        run: echo "::set-output name=key::$(echo ${{ github.job }}-x86_64-unknown-linux-gnu-${{ hashFiles('target/debug/libxayn_ai_ffi_c.so', '${{ env.DART_WORKSPACE }}/ios/Classes/XaynAiFfiCommon.h', '${{ env.DART_WORKSPACE }}/ios/Classes/XaynAiFfiDart.h') }})"
 
       - name: Upload library artifacts
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
@@ -712,7 +712,13 @@ jobs:
   # for this job
   one-leaf:
     name: ignore-me
-    needs: [flutter-format, coverage, test-wasm-lib, test-android-libs, flutter-checks, flutter-build-example]
+    needs:
+      - flutter-format
+      - cargo-tarpaulin
+      - test-wasm-lib
+      - test-android-libs
+      - flutter-checks
+      - flutter-build-example
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -720,7 +726,7 @@ jobs:
 
   notify-staging-failure:
     name: notify-staging-failure
-    needs: [one-leaf]
+    needs: one-leaf
     # always() allows to run even if one-leaf is not successful
     # we only want this to run on the staging branch
     if: always() && github.ref == 'refs/heads/staging'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,8 +414,8 @@ jobs:
           if-no-files-found: error
           path: target/${{ matrix.target}}/debug/libxayn_ai_ffi_c_${{ matrix.target }}.a
 
-  test-wasm-lib:
-    name: test-wasm-lib
+  test-wasm-libs:
+    name: test-wasm-libs
     needs: [cargo-registry-cache, cargo-test]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
@@ -715,7 +715,7 @@ jobs:
     needs:
       - flutter-format
       - cargo-tarpaulin
-      - test-wasm-lib
+      - test-wasm-libs
       - test-android-libs
       - flutter-checks
       - flutter-build-example

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,10 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 
-  registry-cache:
+  cargo-registry-cache:
     # we use the latest stable rustc + cargo version that is already installed on the image
     # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#rust-tools
-    name: cargo-fetch
+    name: cargo-registry-cache
     runs-on: ubuntu-20.04
     timeout-minutes: 5
     outputs:
@@ -61,7 +61,7 @@ jobs:
       - name: Generate cargo registry cache key
         id: cache-key
         shell: bash
-        run: echo "::set-output name=key::$(echo ${{ runner.os }}-cargo-registry-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/Cargo.lock') }})"
+        run: echo "::set-output name=key::$(echo ${{ runner.os }}-${{ github.job }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/Cargo.lock') }})"
 
       - name: Restore cargo registry ${{ steps.cache-key.outputs.key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -71,7 +71,7 @@ jobs:
             ~/.cargo/registry/cache
             ~/.cargo/git/db
           key: ${{ steps.cache-key.outputs.key }}
-          restore-keys: ${{ runner.os }}-cargo-registry-${{ steps.get-date.outputs.date }}-
+          restore-keys: ${{ runner.os }}-${{ github.job }}-${{ steps.get-date.outputs.date }}-
 
       - name: Fetch dependencies
         run: cargo fetch
@@ -86,7 +86,7 @@ jobs:
       - name: Generate cargo-ndk cache key
         id: cache-key
         shell: bash
-        run: echo "::set-output name=key::$(echo ${{ runner.os }}-cargo-ndk-bin-${{ env.CARGO_NDK }})"
+        run: echo "::set-output name=key::$(echo ${{ runner.os }}-${{ github.job }}-${{ env.CARGO_NDK }})"
 
       - name: Restore ${{ steps.cache-key.outputs.key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -111,7 +111,7 @@ jobs:
       - name: Generate cargo-lipo cache key
         id: cache-key
         shell: bash
-        run: echo "::set-output name=key::$(echo ${{ runner.os }}-cargo-lipo-bin-${{ env.CARGO_LIPO }})"
+        run: echo "::set-output name=key::$(echo ${{ runner.os }}-${{ github.job }}-${{ env.CARGO_LIPO }})"
 
       - name: Restore ${{ steps.cache-key.outputs.key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -124,9 +124,9 @@ jobs:
         if: ${{ !steps.cargo-lipo-cache.outputs.cache-hit }}
         run: cargo install cargo-lipo --version ${{ env.CARGO_LIPO }}
 
-  build-headers:
-    name: build-headers
-    needs: [registry-cache]
+  build-release-headers:
+    name: build-release-headers
+    needs: [cargo-registry-cache]
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
@@ -156,21 +156,21 @@ jobs:
           target: ${{ matrix.target }}
           default: true
 
-      - name: Restore ${{ needs.registry-cache.outputs.cache-key }} cache
+      - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Restore build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-release-headers-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-release-headers-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Build headers
         run: cargo check
@@ -207,9 +207,9 @@ jobs:
             ${{ env.DART_WORKSPACE }}/lib/src/mobile/ffi/genesis.dart
             ${{ steps.find_g_dart_artifacts.outputs.artifacts }}
 
-  build-android-libs:
-    name: build-android-libs
-    needs: [registry-cache, install-cargo-ndk]
+  build-release-android-libs:
+    name: build-release-android-libs
+    needs: [cargo-registry-cache, install-cargo-ndk]
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
@@ -228,21 +228,21 @@ jobs:
           target: ${{ matrix.target }}
           default: true
 
-      - name: Restore ${{ needs.registry-cache.outputs.cache-key }} cache
+      - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Restore build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-release-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-release-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Restore ${{ needs.install-cargo-ndk.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -268,9 +268,9 @@ jobs:
           if-no-files-found: error
           path: ${{ env.ANDROID_LIBS_DIR }}
 
-  build-ios-libs:
-    name: build-ios-libs
-    needs: [registry-cache, install-cargo-lipo]
+  build-release-ios-libs:
+    name: build-release-ios-libs
+    needs: [cargo-registry-cache, install-cargo-lipo]
     runs-on: macos-10.15
     timeout-minutes: 25
     strategy:
@@ -289,21 +289,21 @@ jobs:
           target: ${{ matrix.target }}
           default: true
 
-      - name: Restore ${{ needs.registry-cache.outputs.cache-key }} cache
+      - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Restore build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-release-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-release-${{ matrix.target }}-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.target }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Restore ${{ needs.install-cargo-lipo.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
@@ -333,9 +333,9 @@ jobs:
           if-no-files-found: error
           path: target/${{ matrix.target}}/release/libxayn_ai_ffi_c_${{ matrix.target }}.a
 
-  build-wasm-lib-release:
-    name: build-wasm-lib-release
-    needs: registry-cache
+  build-release-wasm-lib:
+    name: build-release-wasm-lib
+    needs: cargo-registry-cache
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     outputs:
@@ -358,21 +358,21 @@ jobs:
       - name: Install wasm-pack
         uses: ./.ci/install-wasm-pack
 
-      - name: Restore ${{ needs.registry-cache.outputs.cache-key }} cache
+      - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: |
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
             ~/.cargo/git/db
-          key: ${{ needs.registry-cache.outputs.cache-key }}
+          key: ${{ needs.cargo-registry-cache.outputs.cache-key }}
 
       - name: Restore build artifacts
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
           path: ${{ github.workspace }}/target
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.registry-cache.outputs.cache-date }}-
+          key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
       - name: Build WASM library
         run: |
@@ -399,7 +399,7 @@ jobs:
   build-asset-artifacts:
     name: build-asset-artifacts
     runs-on: ubuntu-20.04
-    needs: build-wasm-lib-release
+    needs: build-release-wasm-lib
     timeout-minutes: 20
     outputs:
       upload-name: ${{ steps.asset-artifacts.outputs.upload-name }}
@@ -425,8 +425,8 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
-          name: ${{ needs.build-wasm-lib-release.outputs.upload-name }}
-          path: ${{ needs.build-wasm-lib-release.outputs.upload-path }}
+          name: ${{ needs.build-release-wasm-lib.outputs.upload-name }}
+          path: ${{ needs.build-release-wasm-lib.outputs.upload-path }}
 
       - name: Download data
         run: sh download_data.sh
@@ -436,8 +436,8 @@ jobs:
         uses: ./.ci/build-asset-artifacts
         with:
           dart-ws: ${{ env.DART_WORKSPACE }}
-          wasm-suffix: ${{ needs.build-wasm-lib-release.outputs.dir-name }}
-          wasm-rel-path: ${{ needs.build-wasm-lib-release.outputs.upload-path }}
+          wasm-suffix: ${{ needs.build-release-wasm-lib.outputs.dir-name }}
+          wasm-rel-path: ${{ needs.build-release-wasm-lib.outputs.upload-path }}
           release: "true"
 
       - name: Generate asset artifacts name
@@ -457,7 +457,7 @@ jobs:
   publish-asset-artifacts:
     name: publish-asset-artifacts
     runs-on: ubuntu-20.04
-    needs: [build-wasm-lib-release, build-asset-artifacts]
+    needs: [build-release-wasm-lib, build-asset-artifacts]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -472,8 +472,8 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
-          name: ${{ needs.build-wasm-lib-release.outputs.upload-name }}
-          path: ${{ needs.build-wasm-lib-release.outputs.upload-path }}
+          name: ${{ needs.build-release-wasm-lib.outputs.upload-name }}
+          path: ${{ needs.build-release-wasm-lib.outputs.upload-path }}
 
       - name: Download data
         run: sh download_data.sh
@@ -538,7 +538,12 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-20.04
-    needs: [build-headers, build-android-libs, build-ios-libs, build-asset-artifacts, publish-asset-artifacts]
+    needs:
+      - build-release-headers
+      - build-release-android-libs
+      - build-release-ios-libs
+      - build-asset-artifacts
+      - publish-asset-artifacts
     timeout-minutes: 60
     steps:
       - name: Install SSH key

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -333,7 +333,7 @@ jobs:
           if-no-files-found: error
           path: target/${{ matrix.target}}/release/libxayn_ai_ffi_c_${{ matrix.target }}.a
 
-  build-release-wasm-lib:
+  build-release-wasm-libs:
     name: build-release-wasm-lib
     needs: cargo-registry-cache
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -334,7 +334,7 @@ jobs:
           path: target/${{ matrix.target}}/release/libxayn_ai_ffi_c_${{ matrix.target }}.a
 
   build-release-wasm-libs:
-    name: build-release-wasm-lib
+    name: build-release-wasm-libs
     needs: cargo-registry-cache
     runs-on: ubuntu-20.04
     timeout-minutes: 30
@@ -399,7 +399,7 @@ jobs:
   build-asset-artifacts:
     name: build-asset-artifacts
     runs-on: ubuntu-20.04
-    needs: build-release-wasm-lib
+    needs: build-release-wasm-libs
     timeout-minutes: 20
     outputs:
       upload-name: ${{ steps.asset-artifacts.outputs.upload-name }}
@@ -425,8 +425,8 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
-          name: ${{ needs.build-release-wasm-lib.outputs.upload-name }}
-          path: ${{ needs.build-release-wasm-lib.outputs.upload-path }}
+          name: ${{ needs.build-release-wasm-libs.outputs.upload-name }}
+          path: ${{ needs.build-release-wasm-libs.outputs.upload-path }}
 
       - name: Download data
         run: sh download_data.sh
@@ -436,8 +436,8 @@ jobs:
         uses: ./.ci/build-asset-artifacts
         with:
           dart-ws: ${{ env.DART_WORKSPACE }}
-          wasm-suffix: ${{ needs.build-release-wasm-lib.outputs.dir-name }}
-          wasm-rel-path: ${{ needs.build-release-wasm-lib.outputs.upload-path }}
+          wasm-suffix: ${{ needs.build-release-wasm-libs.outputs.dir-name }}
+          wasm-rel-path: ${{ needs.build-release-wasm-libs.outputs.upload-path }}
           release: "true"
 
       - name: Generate asset artifacts name
@@ -457,7 +457,7 @@ jobs:
   publish-asset-artifacts:
     name: publish-asset-artifacts
     runs-on: ubuntu-20.04
-    needs: [build-release-wasm-lib, build-asset-artifacts]
+    needs: [build-release-wasm-libs, build-asset-artifacts]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -472,8 +472,8 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
-          name: ${{ needs.build-release-wasm-lib.outputs.upload-name }}
-          path: ${{ needs.build-release-wasm-lib.outputs.upload-path }}
+          name: ${{ needs.build-release-wasm-libs.outputs.upload-name }}
+          path: ${{ needs.build-release-wasm-libs.outputs.upload-path }}
 
       - name: Download data
         run: sh download_data.sh


### PR DESCRIPTION
**Ticket**

[TY-1871]

**Summary**
- use `github.job` instead of a hardcoded string to make it less error-prone when copying an exisiting job to use it as a template for a new job 

[TY-1871]: https://xainag.atlassian.net/browse/TY-1871