### PR TITLE
Run tests for all rerank mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "041bb0202c14f6a158bbbf086afb03d0c6e975c2dec7d4912f8061ed44f290af"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rstest_reuse"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c6cfaae58c048728261723a72b80a0aa9f3768e9a7da3b302a24d262525219"
+dependencies = [
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "rubert"
 version = "0.1.0"
 dependencies = [
@@ -1160,6 +1184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1212,24 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1787,6 +1838,8 @@ dependencies = [
  "paste",
  "rand",
  "rand_distr",
+ "rstest",
+ "rstest_reuse",
  "rubert",
  "serde",
  "serde_repr",

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -24,9 +24,11 @@ thiserror = "1.0.25"
 uuid = { version = "0.8.2", features = ["serde", "wasm-bindgen"] }
 
 [dev-dependencies]
+csv = "1.1.6"
 float-cmp = "0.8.0"
 maplit = "1.0.2"
 mockall = "0.9.1"
 once_cell = "1.7.2"
 paste = "1.0.5"
-csv = "1.1.6"
+rstest = "0.10.0"
+rstest_reuse = "0.1.3"

--- a/xayn-ai/src/lib.rs
+++ b/xayn-ai/src/lib.rs
@@ -43,6 +43,7 @@ mod tests;
 // which is not possible to silence.
 #[cfg(test)]
 #[allow(unused_imports)]
+#[rustfmt::skip]
 pub(crate) use rstest_reuse as rstest_reuse;
 
 // Reexport for assert_approx_eq for usage in FFI crates.

--- a/xayn-ai/src/lib.rs
+++ b/xayn-ai/src/lib.rs
@@ -38,6 +38,13 @@ pub use crate::{
 #[cfg(test)]
 mod tests;
 
+// we need to export rstest_reuse from the root for it to works.
+// `use rstest_reuse` will trigger clippy::single_component_path_imports
+// that is not possible to silence.
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use rstest_reuse as rstest_reuse;
+
 // Reexport for assert_approx_eq for usage in FFI crates.
 #[doc(hidden)]
 pub use self::utils::ApproxAssertIterHelper;

--- a/xayn-ai/src/lib.rs
+++ b/xayn-ai/src/lib.rs
@@ -38,9 +38,9 @@ pub use crate::{
 #[cfg(test)]
 mod tests;
 
-// we need to export rstest_reuse from the root for it to works.
-// `use rstest_reuse` will trigger clippy::single_component_path_imports
-// that is not possible to silence.
+// we need to export rstest_reuse from the root for it to work.
+// `use rstest_reuse` will trigger `clippy::single_component_path_imports`
+// which is not possible to silence.
 #[cfg(test)]
 #[allow(unused_imports)]
 pub(crate) use rstest_reuse as rstest_reuse;


### PR DESCRIPTION
Run tests on the reranker with both `Search` and `News` mode.