### PR TITLE
TY 1928 With QA-mBert use title if snippet is empty.

### DIFF
--- a/xayn-ai/src/embedding/qambert.rs
+++ b/xayn-ai/src/embedding/qambert.rs
@@ -20,10 +20,10 @@ impl QAMBertSystem for QAMBert {
                 .map(|document| {
                     let snippet = &document.document_content.snippet;
                     // not all documents have a snippet, if snippet is empty we use the title
-                    let data = if !snippet.is_empty() {
-                        snippet
-                    } else {
+                    let data = if snippet.is_empty() {
                         &document.document_content.title
+                    } else {
+                        snippet
                     };
 
                     self.run(&data)


### PR DESCRIPTION
For some type of result (video, images, ...) we don't have snippets but only the title.
When running QA-mBert we use the title if the snippet is empty.