### PR TITLE
TY-1895/6 synchronizable reranker data

### DIFF
--- a/xayn-ai-ffi-c/src/reranker/ai.rs
+++ b/xayn-ai-ffi-c/src/reranker/ai.rs
@@ -1304,7 +1304,7 @@ mod tests {
         assert_eq!(
             error.message.as_ref().unwrap().as_str(),
             format!(
-                "Failed to deserialize the reranker database: Unsupported serialized data. Found version {} expected 0",
+                "Failed to deserialize the reranker database: Unsupported serialized data. Found version {} expected 1",
                 version,
             ),
         );

--- a/xayn-ai-ffi-wasm/src/ai.rs
+++ b/xayn-ai-ffi-wasm/src/ai.rs
@@ -648,7 +648,7 @@ mod tests {
             QAMBERT_VOCAB,
             QAMBERT_MODEL,
             LTR_MODEL,
-            Some(Box::new([1, 2, 3])),
+            Some(Box::new([2, 3, 4])),
         )
         .unwrap_err()
         .into_serde::<Error>()

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -1,0 +1,148 @@
+use itertools::Itertools;
+
+use crate::{
+    data::{CoiPoint, NegativeCoi, PositiveCoi},
+    embedding::utils::{l2_distance, mean},
+    utils::nan_safe_f32_cmp_high,
+    CoiId,
+};
+
+const MERGE_THRESHOLD_DIST: f32 = 4.5;
+
+impl PositiveCoi {
+    pub fn merge(self, other: Self, id: usize) -> Self {
+        let point = mean(&self.point, &other.point);
+        let (alpha, beta) = merge_params(self.alpha, self.beta, other.alpha, other.beta);
+        Self {
+            id: CoiId(id),
+            point,
+            alpha,
+            beta,
+        }
+    }
+}
+
+impl NegativeCoi {
+    pub fn merge(self, other: Self, id: usize) -> Self {
+        let point = mean(&self.point, &other.point);
+        Self {
+            id: CoiId(id),
+            point,
+        }
+    }
+}
+
+/// A pair of CoIs.
+#[derive(Clone)]
+struct CoiPair<C>(C, C);
+
+impl<C> CoiPair<C>
+where
+    C: CoiPoint,
+{
+    /// Merges the CoI pair, assigning it the smaller of the two ids.
+    fn merge(self) -> C {
+        let CoiId(id1) = self.0.id();
+        let CoiId(id2) = self.1.id();
+        self.0.merge(self.1, id1.min(id2))
+    }
+
+    /// True iff either CoI has the given id.
+    fn contains(&self, id: CoiId) -> bool {
+        self.0.id() == id || self.1.id() == id
+    }
+
+    /// True iff either CoI is one of the given pair.
+    fn contains_any(&self, other: &Self) -> bool {
+        self.contains(other.0.id()) || self.contains(other.1.id())
+    }
+}
+
+/// A `Coiple` is a pair of CoIs and the distance between them.
+#[derive(Clone)]
+struct Coiple<C> {
+    cois: CoiPair<C>,
+    dist: f32,
+}
+
+impl<C> Coiple<C> {
+    fn new(coi1: C, coi2: C, dist: f32) -> Self {
+        let cois = CoiPair(coi1, coi2);
+        Self { cois, dist }
+    }
+}
+
+/// Computes the l2 distance between two CoI points.
+fn dist<C>(coi1: &C, coi2: &C) -> f32
+where
+    C: CoiPoint,
+{
+    l2_distance(coi1.point(), coi2.point())
+}
+
+/// Reduces the given collection of CoIs by successively merging the pair in closest
+/// proximity to each other.
+///
+/// <https://xainag.atlassian.net/wiki/spaces/XAY/pages/2029944833/CoI+synchronisation>
+/// outlines the core of the algorithm.
+pub(crate) fn reduce_cois<C>(cois: &mut Vec<C>)
+where
+    C: CoiPoint + Clone,
+{
+    // initialize collection of close coiples
+    let cois_iter = cois.iter();
+    let mut coiples = cois_iter
+        .clone()
+        .cartesian_product(cois_iter)
+        .filter(|(coi1, coi2)| coi1.id() < coi2.id())
+        .filter_map(|(coi1, coi2)| -> Option<Coiple<C>> {
+            let dist = dist(coi1, coi2);
+            (dist < MERGE_THRESHOLD_DIST).then(|| Coiple::new(coi1.clone(), coi2.clone(), dist))
+        })
+        .collect_vec();
+
+    while !coiples.is_empty() {
+        // find the minimum i.e. closest pair of cois
+        let min_pair = coiples
+            .iter()
+            .cloned()
+            .min_by(|cpl1, cpl2| nan_safe_f32_cmp_high(&cpl1.dist, &cpl2.dist))
+            .unwrap() // safe: nonempty coiples
+            .cois;
+
+        // discard pair from collections
+        cois.retain(|coi| !min_pair.contains(coi.id()));
+        coiples.retain(|cpl| !cpl.cois.contains_any(&min_pair));
+
+        let merged_coi = min_pair.merge();
+
+        // record close coiples featuring the merged coi
+        let mut new_coiples = cois
+            .iter()
+            .filter_map(|coi| {
+                let dist = dist(&merged_coi, coi);
+                (dist < MERGE_THRESHOLD_DIST)
+                    .then(|| Coiple::new(merged_coi.clone(), coi.clone(), dist))
+            })
+            .collect_vec();
+        coiples.append(&mut new_coiples);
+
+        cois.push(merged_coi);
+    }
+}
+
+/// Calculates an "average" beta distribution ~B(a, b) from the given two ~B(`a1`, `b1`), ~B(`a2`, `b2`).
+///
+/// <https://xainag.atlassian.net/wiki/spaces/XAY/pages/2029944833/CoI+synchronisation>
+/// outlines the calculation.
+fn merge_params(a1: f32, b1: f32, a2: f32, b2: f32) -> (f32, f32) {
+    let mean = |a, b| a / (a + b);
+    let var = |a, b| a * b / (f32::powi(a + b, 2) * (a + b + 1.));
+
+    // geometric average of the mean and variance
+    let avg_mean = f32::sqrt(mean(a1, b1) * mean(a2, b2));
+    let avg_var = f32::sqrt(var(a1, b1) * var(a2, b2));
+
+    let factor = avg_mean * (1. - avg_mean) / avg_var - 1.;
+    (avg_mean * factor, (1. - avg_mean) * factor)
+}

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -1,8 +1,10 @@
 mod config;
+mod merge;
 mod system;
 mod utils;
 
 pub(crate) use config::Configuration;
+pub(crate) use merge::reduce_cois;
 pub(crate) use system::CoiSystem;
 
 #[cfg(test)]

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -37,7 +37,7 @@ impl PositiveCoi {
         }
     }
 
-    pub(crate) fn merge(&self, other: &Self, id: usize) -> Self {
+    pub(crate) fn merge(self, other: Self, id: usize) -> Self {
         let point = mean(&self.point, &other.point);
         let (alpha, beta) = merge_params(self.alpha, self.beta, other.alpha, other.beta);
         Self {
@@ -50,6 +50,9 @@ impl PositiveCoi {
 }
 
 /// Calculates an "average" beta distribution ~B(a, b) from the given two ~B(`a1`, `b1`), ~B(`a2`, `b2`).
+///
+/// <https://xainag.atlassian.net/wiki/spaces/XAY/pages/2029944833/CoI+synchronisation>
+/// outlines the calculation.
 fn merge_params(a1: f32, b1: f32, a2: f32, b2: f32) -> (f32, f32) {
     let mean = |a, b| a / (a + b);
     let var = |a, b| a * b / (f32::powi(a + b, 2) * (a + b + 1.));
@@ -70,18 +73,16 @@ impl NegativeCoi {
         }
     }
 
-    pub fn merge(&self, other: &Self, id: usize) -> Self {
+    pub fn merge(self, other: Self, id: usize) -> Self {
+        let id = CoiId(id);
         let point = mean(&self.point, &other.point);
-        Self {
-            id: CoiId(id),
-            point,
-        }
+        Self { id, point }
     }
 }
 
 pub(crate) trait CoiPoint {
     fn new(id: usize, embedding: Embedding) -> Self;
-    fn merge(&self, other: &Self, id: usize) -> Self;
+    fn merge(self, other: Self, id: usize) -> Self;
     fn id(&self) -> CoiId;
     fn set_id(&mut self, id: usize);
     fn point(&self) -> &Embedding;
@@ -95,7 +96,7 @@ macro_rules! impl_coi_point {
                 <$type>::new(id, embedding)
             }
 
-            fn merge(&self, other: &Self, id: usize) -> Self {
+            fn merge(self, other: Self, id: usize) -> Self {
                 self.merge(other, id)
             }
 

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -7,7 +7,7 @@ use crate::embedding::utils::Embedding;
 
 // Hint: We use this id new-type in FFI so repr(transparent) needs to be kept
 #[repr(transparent)]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, PartialOrd)]
 pub struct CoiId(pub usize);
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
@@ -35,6 +35,55 @@ impl PositiveCoi {
             beta: 1.,
         }
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn merge(self, _id: usize, _other: Self) -> Self {
+        todo!()
+    }
+
+    pub(crate) fn _merge_into(self, other: &mut Self) {
+        let Self {
+            point, alpha, beta, ..
+        } = self;
+
+        merge_point(point, &mut other.point);
+        let (alpha, beta) = merge_params(alpha, beta, other.alpha, other.beta);
+        other.alpha = alpha;
+        other.beta = beta;
+    }
+
+    pub(crate) fn from_merge(&self, other: &Self, id: usize) -> Self {
+        let point = average_point(&self.point, &other.point);
+        let (alpha, beta) = merge_params(self.alpha, self.beta, other.alpha, other.beta);
+        Self {
+            id: CoiId(id),
+            point,
+            alpha,
+            beta,
+        }
+    }
+}
+
+/// Merges two points by taking their pointwise arithmetic mean.
+fn average_point(_p1: &Embedding, _p2: &Embedding) -> Embedding {
+    todo!()
+}
+
+#[allow(dead_code)]
+fn merge_point(_p1: Embedding, _p2: &mut Embedding) {
+    todo!()
+}
+
+/// Merges two beta distributions X ~ B(a1, b1), Y ~ B(a2, b2) into an "average" Z ~ B(a, b).
+fn merge_params(a1: f32, b1: f32, a2: f32, b2: f32) -> (f32, f32) {
+    let mean = |a, b| a / (a + b);
+    let var = |a, b| a * b / (f32::powi(a + b, 2) * (a + b + 1.));
+
+    let avg_mean = f32::sqrt(mean(a1, b1) * mean(a2, b2));
+    let avg_var = f32::sqrt(var(a1, b1) * var(a2, b2));
+
+    let factor = avg_mean * (1. - avg_mean) / avg_var - 1.;
+    (avg_mean * factor, (1. - avg_mean) * factor)
 }
 
 impl NegativeCoi {
@@ -86,6 +135,13 @@ impl UserInterests {
             positive: Vec::new(),
             negative: Vec::new(),
         }
+    }
+
+    /// Moves all user interests of `other` into `Self`.
+    pub(crate) fn append(&mut self, mut other: Self) {
+        self.positive.append(&mut other.positive);
+        self.negative.append(&mut other.negative);
+        // TODO drop dupe points, scheme for clashing ids
     }
 }
 

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod document_data;
 
 use serde::{Deserialize, Serialize};
 
-use crate::embedding::utils::Embedding;
+use crate::embedding::utils::{mean, Embedding};
 
 // Hint: We use this id new-type in FFI so repr(transparent) needs to be kept
 #[repr(transparent)]
@@ -36,24 +36,8 @@ impl PositiveCoi {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn merge(self, _id: usize, _other: Self) -> Self {
-        todo!()
-    }
-
-    pub(crate) fn _merge_into(self, other: &mut Self) {
-        let Self {
-            point, alpha, beta, ..
-        } = self;
-
-        merge_point(point, &mut other.point);
-        let (alpha, beta) = merge_params(alpha, beta, other.alpha, other.beta);
-        other.alpha = alpha;
-        other.beta = beta;
-    }
-
     pub(crate) fn from_merge(&self, other: &Self, id: usize) -> Self {
-        let point = average_point(&self.point, &other.point);
+        let point = mean(&self.point, &other.point);
         let (alpha, beta) = merge_params(self.alpha, self.beta, other.alpha, other.beta);
         Self {
             id: CoiId(id),
@@ -62,16 +46,6 @@ impl PositiveCoi {
             beta,
         }
     }
-}
-
-/// Merges two points by taking their pointwise arithmetic mean.
-fn average_point(_p1: &Embedding, _p2: &Embedding) -> Embedding {
-    todo!()
-}
-
-#[allow(dead_code)]
-fn merge_point(_p1: Embedding, _p2: &mut Embedding) {
-    todo!()
 }
 
 /// Merges two beta distributions X ~ B(a1, b1), Y ~ B(a2, b2) into an "average" Z ~ B(a, b).

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -1,10 +1,9 @@
 pub mod document;
 pub(crate) mod document_data;
 
-use itertools::izip;
 use serde::{Deserialize, Serialize};
 
-use crate::embedding::utils::{mean, Embedding};
+use crate::embedding::utils::Embedding;
 
 // Hint: We use this id new-type in FFI so repr(transparent) needs to be kept
 #[repr(transparent)]
@@ -36,33 +35,6 @@ impl PositiveCoi {
             beta: 1.,
         }
     }
-
-    pub(crate) fn merge(self, other: Self, id: usize) -> Self {
-        let point = mean(&self.point, &other.point);
-        let (alpha, beta) = merge_params(self.alpha, self.beta, other.alpha, other.beta);
-        Self {
-            id: CoiId(id),
-            point,
-            alpha,
-            beta,
-        }
-    }
-}
-
-/// Calculates an "average" beta distribution ~B(a, b) from the given two ~B(`a1`, `b1`), ~B(`a2`, `b2`).
-///
-/// <https://xainag.atlassian.net/wiki/spaces/XAY/pages/2029944833/CoI+synchronisation>
-/// outlines the calculation.
-fn merge_params(a1: f32, b1: f32, a2: f32, b2: f32) -> (f32, f32) {
-    let mean = |a, b| a / (a + b);
-    let var = |a, b| a * b / (f32::powi(a + b, 2) * (a + b + 1.));
-
-    // geometric average of the mean and variance
-    let avg_mean = f32::sqrt(mean(a1, b1) * mean(a2, b2));
-    let avg_var = f32::sqrt(var(a1, b1) * var(a2, b2));
-
-    let factor = avg_mean * (1. - avg_mean) / avg_var - 1.;
-    (avg_mean * factor, (1. - avg_mean) * factor)
 }
 
 impl NegativeCoi {
@@ -71,12 +43,6 @@ impl NegativeCoi {
             id: CoiId(id),
             point,
         }
-    }
-
-    pub fn merge(self, other: Self, id: usize) -> Self {
-        let id = CoiId(id);
-        let point = mean(&self.point, &other.point);
-        Self { id, point }
     }
 }
 
@@ -135,38 +101,6 @@ impl UserInterests {
             positive: Vec::new(),
             negative: Vec::new(),
         }
-    }
-
-    /// Moves all user interests of `other` into `Self`.
-    pub(crate) fn append(&mut self, mut other: Self) {
-        // TODO drop dupes in other
-        append_cois(&mut self.positive, &mut other.positive);
-        append_cois(&mut self.negative, &mut other.negative);
-    }
-
-    /// Re-assigns CoI ids for normalization.
-    pub(crate) fn reassign_ids(&mut self) {
-        reassign_coi_ids(&mut self.positive);
-        reassign_coi_ids(&mut self.negative);
-    }
-}
-
-fn append_cois<C>(locals: &mut Vec<C>, remotes: &mut Vec<C>)
-where
-    C: CoiPoint,
-{
-    // shift remote ids to avoid clashes with local ids
-    let max_local_id = locals.iter().map(|coi| coi.id().0).max().unwrap_or(0);
-    remotes
-        .iter_mut()
-        .for_each(|coi| coi.set_id(max_local_id + coi.id().0));
-
-    locals.append(remotes);
-}
-
-fn reassign_coi_ids(cois: &mut Vec<impl CoiPoint>) {
-    for (id, coi) in izip!(1..cois.len() + 1, cois) {
-        coi.set_id(id)
     }
 }
 

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -7,7 +7,7 @@ use crate::embedding::utils::Embedding;
 
 // Hint: We use this id new-type in FFI so repr(transparent) needs to be kept
 #[repr(transparent)]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, PartialOrd, Ord)]
 pub struct CoiId(pub usize);
 
 #[cfg_attr(test, derive(Debug, PartialEq))]

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -29,6 +29,18 @@ where
     distance
 }
 
+/// Computes the arithmetic mean of two vectors.
+///
+/// # Panics
+/// Panics if the vectors do not consist solely of real values.
+pub fn mean<A, S>(a: &A, b: &A) -> Embedding
+where
+    A: Deref<Target = ArrayBase<S, Ix1>>,
+    S: Data<Elem = f32>,
+{
+    (0.5 * (a.deref() + b.deref())).into()
+}
+
 #[cfg(test)]
 mod tests {
     use ndarray::arr1;

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -38,7 +38,16 @@ where
     A: Deref<Target = ArrayBase<S, Ix1>>,
     S: Data<Elem = f32>,
 {
-    (0.5 * (a.deref() + b.deref())).into()
+    let mean = 0.5 * (a.deref() + b.deref());
+    if mean.iter().any(|elt| elt.is_nan() || elt.is_infinite()) {
+        panic!(
+            "vectors must consist of real values only, but got\na: {:?}\nb: {:?}",
+            a.deref(),
+            b.deref(),
+        );
+    }
+
+    mean.into()
 }
 
 #[cfg(test)]

--- a/xayn-ai/src/reranker/database.rs
+++ b/xayn-ai/src/reranker/database.rs
@@ -27,9 +27,8 @@ struct RerankerData0 {
 
 impl From<RerankerData0> for RerankerData {
     fn from(data0: RerankerData0) -> Self {
-        let sync_data = SyncData {
-            user_interests: data0.user_interests,
-        };
+        let user_interests = data0.user_interests;
+        let sync_data = SyncData { user_interests };
         Self {
             sync_data,
             prev_documents: data0.prev_documents,
@@ -48,7 +47,7 @@ impl Db {
 
         // version is encoded in the first byte
         let version = bytes[0];
-        if version != CURRENT_SCHEMA_VERSION && version != 0 {
+        if version > CURRENT_SCHEMA_VERSION {
             bail!(
                 "Unsupported serialized data. Found version {} expected {}",
                 version,

--- a/xayn-ai/src/reranker/database.rs
+++ b/xayn-ai/src/reranker/database.rs
@@ -57,8 +57,7 @@ impl Db {
 
         // migration from version 0 to current
         let data = if version == 0 {
-            let data0: RerankerData0 = bincode::deserialize(&bytes[1..])?;
-            data0.into()
+            bincode::deserialize::<RerankerData0>(&bytes[1..])?.into()
         } else {
             bincode::deserialize(&bytes[1..])?
         };

--- a/xayn-ai/src/reranker/database.rs
+++ b/xayn-ai/src/reranker/database.rs
@@ -12,7 +12,7 @@ pub(crate) trait Database {
     fn serialize(&self, data: &RerankerData) -> Result<Vec<u8>, Error>;
 }
 
-const CURRENT_SCHEMA_VERSION: u8 = 0;
+const CURRENT_SCHEMA_VERSION: u8 = 1;
 
 #[derive(Default)]
 pub(super) struct Db(RefCell<Option<RerankerData>>);
@@ -28,14 +28,14 @@ impl Db {
 
         // version is encoded in the first byte
         let version = bytes[0];
-        if version != CURRENT_SCHEMA_VERSION {
+        if version != CURRENT_SCHEMA_VERSION && version != 0 {
             bail!(
                 "Unsupported serialized data. Found version {} expected {}",
                 version,
                 CURRENT_SCHEMA_VERSION
             );
         }
-
+        // TODO migration from version 0 to current
         let data = bincode::deserialize(&bytes[1..])?;
 
         Ok(Self(RefCell::new(Some(data))))

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -343,9 +343,7 @@ mod tests {
     }
 
     mod car_interest_example {
-        use super::from_ids;
-
-        use std::ops::Range;
+        use super::{from_ids, sync::SyncData};
 
         use crate::{
             data::{
@@ -360,6 +358,7 @@ mod tests {
                 pos_cois_from_words,
             },
         };
+        use std::ops::Range;
 
         pub(super) fn reranker_data_with_mab_from_ids(ids: Range<u32>) -> RerankerData {
             let docs = data_with_mab(from_ids(ids));
@@ -384,9 +383,11 @@ mod tests {
         fn reranker_data(docs: impl Into<PreviousDocuments>) -> RerankerData {
             RerankerData {
                 prev_documents: docs.into(),
-                user_interests: UserInterests {
-                    positive: pos_cois_from_words(&["vehicle"], mocked_smbert_system()),
-                    ..Default::default()
+                sync_data: SyncData {
+                    user_interests: UserInterests {
+                        positive: pos_cois_from_words(&["vehicle"], mocked_smbert_system()),
+                        ..Default::default()
+                    },
                 },
             }
         }
@@ -425,8 +426,8 @@ mod tests {
 
         assert_eq!(outcome.final_ranking, expected_rerank_unchanged(&documents));
         assert_eq!(reranker.data.prev_documents.len(), documents.len());
-        assert!(reranker.data.user_interests.positive.is_empty());
-        assert!(reranker.data.user_interests.negative.is_empty());
+        assert!(reranker.data.sync_data.user_interests.positive.is_empty());
+        assert!(reranker.data.sync_data.user_interests.negative.is_empty());
 
         check_error!(reranker, CoiSystemError::NoCoi);
     }
@@ -465,8 +466,8 @@ mod tests {
         assert!(reranker.errors().is_empty());
         assert_eq!(reranker.data.prev_documents.len(), documents.len());
 
-        assert_eq!(reranker.data.user_interests.positive.len(), 3);
-        assert_eq!(reranker.data.user_interests.negative.len(), 3);
+        assert_eq!(reranker.data.sync_data.user_interests.positive.len(), 3);
+        assert_eq!(reranker.data.sync_data.user_interests.negative.len(), 3);
     }
 
     /// A user performed a couple of searches. The `Reranker` data holds the
@@ -547,8 +548,8 @@ mod tests {
 
         assert_eq!(outcome.final_ranking, expected_rerank_unchanged(&documents));
         assert_eq!(reranker.data.prev_documents.len(), documents.len());
-        assert!(reranker.data.user_interests.positive.is_empty());
-        assert!(reranker.data.user_interests.negative.is_empty());
+        assert!(reranker.data.sync_data.user_interests.positive.is_empty());
+        assert!(reranker.data.sync_data.user_interests.negative.is_empty());
 
         check_error!(reranker, CoiSystemError::NoMatchingDocuments);
     }
@@ -574,8 +575,8 @@ mod tests {
 
         assert_eq!(outcome.final_ranking, expected_rerank_unchanged(&documents));
         assert_eq!(reranker.data.prev_documents.len(), documents.len());
-        assert!(reranker.data.user_interests.positive.is_empty());
-        assert!(reranker.data.user_interests.negative.is_empty());
+        assert!(reranker.data.sync_data.user_interests.positive.is_empty());
+        assert!(reranker.data.sync_data.user_interests.negative.is_empty());
 
         check_error!(reranker, CoiSystemError::NoMatchingDocuments);
         check_error!(reranker, CoiSystemError::NoCoi);

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -236,7 +236,7 @@ where
     #[allow(dead_code)] // TEMP
     pub(crate) fn synchronize(&mut self, bytes: &[u8]) -> Result<(), Error> {
         let remote_data = SyncData::deserialize(bytes)?;
-        self.data.sync_data.merge(remote_data);
+        self.data.sync_data.synchronize(remote_data);
         Ok(())
     }
 

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -386,7 +386,7 @@ mod tests {
                 sync_data: SyncData {
                     user_interests: UserInterests {
                         positive: pos_cois_from_words(&["vehicle"], mocked_smbert_system()),
-                        ..Default::default()
+                        ..UserInterests::default()
                     },
                 },
             }

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -1,5 +1,14 @@
-use crate::{data::UserInterests, error::Error};
+use crate::{
+    data::{CoiPoint, PositiveCoi, UserInterests},
+    embedding::utils::l2_distance,
+    error::Error,
+    utils::nan_safe_f32_cmp_high,
+    CoiId,
+};
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+
+const SOCIAL_DIST: f32 = 8.0;
 
 /// Synchronizable data of the reranker.
 #[cfg_attr(test, derive(Clone, PartialEq, Debug))]
@@ -9,6 +18,7 @@ pub(crate) struct SyncData {
 }
 
 impl SyncData {
+    /// Deserializes a `SyncData` from `bytes`.
     pub(crate) fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
         if bytes.is_empty() {
             return Ok(Self::default());
@@ -17,11 +27,92 @@ impl SyncData {
         Ok(bincode::deserialize(&bytes)?)
     }
 
+    /// Serializes a `SyncData` to a byte representation.
     pub(crate) fn serialize(&self) -> Result<Vec<u8>, Error> {
         Ok(bincode::serialize(self)?)
     }
 
-    pub(crate) fn merge(&mut self, _other: SyncData) {
-        todo!()
+    /// Merge another `SyncData` into the current one.
+    pub(crate) fn merge(&mut self, other: SyncData) {
+        let Self { user_interests } = other;
+        self.user_interests.append(user_interests);
+
+        let cois_iter = self.user_interests.positive.iter();
+        let mut coiples = cois_iter
+            .clone()
+            .cartesian_product(cois_iter)
+            .filter_map(|(coi1, coi2)| {
+                (coi1.id < coi2.id).then(|| Coiple::new(coi1, coi2, dist(coi1, coi2)))
+            })
+            .filter(|coiple| coiple.dist < SOCIAL_DIST)
+            .collect_vec();
+
+        while !coiples.is_empty() {
+            let min_coiple = coiples
+                .iter()
+                .cloned()
+                .min_by(|cpl1, cpl2| nan_safe_f32_cmp_high(&cpl1.dist, &cpl2.dist))
+                .unwrap(); // safe: nonempty coiples
+
+            let merged_coi = min_coiple.cois.merge();
+
+            self.user_interests
+                .positive
+                .retain(|coi| coi.id != min_coiple.cois.0.id || coi.id != min_coiple.cois.1.id);
+
+            coiples.retain(|cpl| {
+                !cpl.contains(min_coiple.cois.0.id) && !cpl.contains(min_coiple.cois.1.id)
+            });
+
+            let mut new_coiples = self
+                .user_interests
+                .positive
+                .iter()
+                .filter_map(|coi| {
+                    let dist = dist(&merged_coi, coi);
+                    (dist < SOCIAL_DIST).then(|| Coiple::new(&merged_coi, coi, dist))
+                })
+                .collect_vec();
+            coiples.append(&mut new_coiples);
+
+            self.user_interests.positive.push(merged_coi);
+        }
     }
+}
+
+#[derive(Clone)]
+struct CoiPair(PositiveCoi, PositiveCoi); // TODO impl Eq
+
+impl CoiPair {
+    /// Merges the CoI pair, assigning it the smaller of the two ids.
+    fn merge(&self) -> PositiveCoi {
+        let min_id = self.0.id.0.min(self.1.id.0);
+        self.0.from_merge(&self.1, min_id)
+    }
+}
+
+/// A `Coiple` is a pair of CoIs and the distance between them.
+#[derive(Clone)]
+struct Coiple {
+    cois: CoiPair,
+    dist: f32,
+}
+
+impl Coiple {
+    fn new(coi1: &PositiveCoi, coi2: &PositiveCoi, dist: f32) -> Self {
+        let cois = CoiPair(coi1.clone(), coi2.clone());
+        Self { cois, dist }
+    }
+
+    fn contains(&self, id: CoiId) -> bool {
+        self.cois.0.id == id || self.cois.1.id == id
+    }
+}
+
+/// Computes the l2 distance between two CoI points.
+fn dist<C>(coi1: &C, coi2: &C) -> f32
+where
+    C: CoiPoint,
+{
+    l2_distance(coi1.point(), coi2.point())
 }

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -1,0 +1,27 @@
+use crate::{data::UserInterests, error::Error};
+use serde::{Deserialize, Serialize};
+
+/// Synchronizable data of the reranker.
+#[cfg_attr(test, derive(Clone, PartialEq, Debug))]
+#[derive(Default, Serialize, Deserialize)]
+pub(crate) struct SyncData {
+    pub(crate) user_interests: UserInterests,
+}
+
+impl SyncData {
+    pub(crate) fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.is_empty() {
+            return Ok(Self::default());
+        }
+
+        Ok(bincode::deserialize(&bytes)?)
+    }
+
+    pub(crate) fn serialize(&self) -> Result<Vec<u8>, Error> {
+        Ok(bincode::serialize(self)?)
+    }
+
+    pub(crate) fn merge(&mut self, _other: SyncData) {
+        todo!()
+    }
+}

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -1,15 +1,12 @@
 use crate::{
+    coi::reduce_cois,
     data::{CoiPoint, UserInterests},
-    embedding::utils::l2_distance,
     error::Error,
-    utils::nan_safe_f32_cmp_high,
-    CoiId,
 };
 use anyhow::bail;
-use itertools::Itertools;
+use itertools::izip;
 use serde::{Deserialize, Serialize};
 
-const MERGE_THRESHOLD_DIST: f32 = 4.5;
 const CURRENT_SCHEMA_VERSION: u8 = 0;
 
 /// Synchronizable data of the reranker.
@@ -59,101 +56,36 @@ impl SyncData {
     }
 }
 
-/// A pair of CoIs.
-#[derive(Clone)]
-struct CoiPair<C>(C, C);
+impl UserInterests {
+    /// Moves all user interests of `other` into `Self`.
+    pub(crate) fn append(&mut self, mut other: Self) {
+        // TODO drop dupes in other
+        append_cois(&mut self.positive, &mut other.positive);
+        append_cois(&mut self.negative, &mut other.negative);
+    }
 
-impl<C> CoiPair<C>
+    /// Re-assigns CoI ids for normalization.
+    pub(crate) fn reassign_ids(&mut self) {
+        reassign_coi_ids(&mut self.positive);
+        reassign_coi_ids(&mut self.negative);
+    }
+}
+
+fn append_cois<C>(locals: &mut Vec<C>, remotes: &mut Vec<C>)
 where
     C: CoiPoint,
 {
-    /// Merges the CoI pair, assigning it the smaller of the two ids.
-    fn merge(self) -> C {
-        let CoiId(id1) = self.0.id();
-        let CoiId(id2) = self.1.id();
-        self.0.merge(self.1, id1.min(id2))
-    }
+    // shift remote ids to avoid clashes with local ids
+    let max_local_id = locals.iter().map(|coi| coi.id().0).max().unwrap_or(0);
+    remotes
+        .iter_mut()
+        .for_each(|coi| coi.set_id(max_local_id + coi.id().0));
 
-    /// True iff either CoI has the given id.
-    fn contains(&self, id: CoiId) -> bool {
-        self.0.id() == id || self.1.id() == id
-    }
-
-    /// True iff either CoI is one of the given pair.
-    fn contains_any(&self, other: &Self) -> bool {
-        self.contains(other.0.id()) || self.contains(other.1.id())
-    }
+    locals.append(remotes);
 }
 
-/// A `Coiple` is a pair of CoIs and the distance between them.
-#[derive(Clone)]
-struct Coiple<C> {
-    cois: CoiPair<C>,
-    dist: f32,
-}
-
-impl<C> Coiple<C> {
-    fn new(coi1: C, coi2: C, dist: f32) -> Self {
-        let cois = CoiPair(coi1, coi2);
-        Self { cois, dist }
-    }
-}
-
-/// Computes the l2 distance between two CoI points.
-fn dist<C>(coi1: &C, coi2: &C) -> f32
-where
-    C: CoiPoint,
-{
-    l2_distance(coi1.point(), coi2.point())
-}
-
-/// Reduces the given collection of CoIs by successively merging the pair in closest
-/// proximity to each other.
-///
-/// <https://xainag.atlassian.net/wiki/spaces/XAY/pages/2029944833/CoI+synchronisation>
-/// outlines the core of the algorithm.
-fn reduce_cois<C>(cois: &mut Vec<C>)
-where
-    C: CoiPoint + Clone,
-{
-    // initialize collection of close coiples
-    let cois_iter = cois.iter();
-    let mut coiples = cois_iter
-        .clone()
-        .cartesian_product(cois_iter)
-        .filter(|(coi1, coi2)| coi1.id() < coi2.id())
-        .filter_map(|(coi1, coi2)| {
-            let dist = dist(coi1, coi2);
-            (dist < MERGE_THRESHOLD_DIST).then(|| Coiple::new(coi1.clone(), coi2.clone(), dist))
-        })
-        .collect_vec();
-
-    while !coiples.is_empty() {
-        // find the minimum i.e. closest pair of cois
-        let min_pair = coiples
-            .iter()
-            .cloned()
-            .min_by(|cpl1, cpl2| nan_safe_f32_cmp_high(&cpl1.dist, &cpl2.dist))
-            .unwrap() // safe: nonempty coiples
-            .cois;
-
-        // discard pair from collections
-        cois.retain(|coi| !min_pair.contains(coi.id()));
-        coiples.retain(|cpl| !cpl.cois.contains_any(&min_pair));
-
-        let merged_coi = min_pair.merge();
-
-        // record close coiples featuring the merged coi
-        let mut new_coiples = cois
-            .iter()
-            .filter_map(|coi| {
-                let dist = dist(&merged_coi, coi);
-                (dist < MERGE_THRESHOLD_DIST)
-                    .then(|| Coiple::new(merged_coi.clone(), coi.clone(), dist))
-            })
-            .collect_vec();
-        coiples.append(&mut new_coiples);
-
-        cois.push(merged_coi);
+fn reassign_coi_ids(cois: &mut Vec<impl CoiPoint>) {
+    for (id, coi) in izip!(1..cois.len() + 1, cois) {
+        coi.set_id(id)
     }
 }

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -35,13 +35,15 @@ impl SyncData {
     /// Synchronizes with another `SyncData`.
     ///
     /// <https://xainag.atlassian.net/wiki/spaces/XAY/pages/2029944833/CoI+synchronisation>
-    /// outlines the algorithm.
+    /// outlines the core of the algorithm.
     pub(crate) fn synchronize(&mut self, other: SyncData) {
         let Self { user_interests } = other;
         self.user_interests.append(user_interests);
 
         reduce_cois(&mut self.user_interests.positive);
         reduce_cois(&mut self.user_interests.negative);
+
+        self.user_interests.reassign_ids();
     }
 }
 

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -16,6 +16,29 @@ macro_rules! to_vec_of_ref_of {
 ///
 /// Pretend that f32 has a total ordering.
 ///
+/// `NaN` is treated as the lowest possible value if `nan_min`, similar to what [`f32::max`] does.
+/// Otherwise it is treated as the highest possible value, similar to what [`f32::min`] does.
+pub(crate) fn nan_safe_f32_cmp_base(a: &f32, b: &f32, nan_min: bool) -> Ordering {
+    a.partial_cmp(&b).unwrap_or_else(|| {
+        // if `partial_cmp` returns None we have at least one `NaN`,
+        let cmp = match (a.is_nan(), b.is_nan()) {
+            (true, true) => Ordering::Equal,
+            (true, _) => Ordering::Less,
+            (_, true) => Ordering::Greater,
+            _ => unreachable!("partial_cmp returned None but both numbers are not NaN"),
+        };
+        if nan_min {
+            cmp
+        } else {
+            cmp.reverse()
+        }
+    })
+}
+
+/// Allows comparing and sorting f32 even if `NaN` is involved.
+///
+/// Pretend that f32 has a total ordering.
+///
 /// `NaN` is treated as the lowest possible value, similar to what [`f32::max`] does.
 ///
 /// If this is used for sorting this will lead to an ascending order, like
@@ -24,16 +47,7 @@ macro_rules! to_vec_of_ref_of {
 /// By switching the input parameters around this can be used to create a
 /// descending sorted order, like e.g.: `[2.0, 1.5, 0.5, NaN]`.
 pub(crate) fn nan_safe_f32_cmp(a: &f32, b: &f32) -> Ordering {
-    a.partial_cmp(&b).unwrap_or_else(|| {
-        // if `partial_cmp` returns None we have at least one `NaN`,
-        // we treat it as the lowest value
-        match (a.is_nan(), b.is_nan()) {
-            (true, true) => Ordering::Equal,
-            (true, _) => Ordering::Less,
-            (_, true) => Ordering::Greater,
-            _ => unreachable!("partial_cmp returned None but both numbers are not NaN"),
-        }
-    })
+    nan_safe_f32_cmp_base(a, b, true)
 }
 
 /// Allows comparing and sorting f32 even if `NaN` is involved.
@@ -48,16 +62,7 @@ pub(crate) fn nan_safe_f32_cmp(a: &f32, b: &f32) -> Ordering {
 /// By switching the input parameters around this can be used to create a
 /// descending sorted order, like e.g.: `[NaN, 2.0, 1.5, 0.5]`.
 pub(crate) fn nan_safe_f32_cmp_high(a: &f32, b: &f32) -> Ordering {
-    a.partial_cmp(&b).unwrap_or_else(|| {
-        // if `partial_cmp` returns None we have at least one `NaN`,
-        // we treat it as the highest value
-        match (a.is_nan(), b.is_nan()) {
-            (true, true) => Ordering::Equal,
-            (true, _) => Ordering::Greater,
-            (_, true) => Ordering::Less,
-            _ => unreachable!("partial_cmp returned None but both numbers are not NaN"),
-        }
-    })
+    nan_safe_f32_cmp_base(a, b, false)
 }
 
 /// `nan_safe_f32_cmp_desc(a,b)` is syntax suggar for `nan_safe_f32_cmp(b, a)`


### PR DESCRIPTION
**Summary**

adds the ability to sync the internal state of the reranker (currently consists of just the CoIs) between devices.

new `reranker::sync` module:
* reranker data's user interests (i.e. CoIs) now wrapped in a `SyncData`, a new serializable struct.
* `SyncData` exposes a `synchronize` method to sync with another.
* the core of the synchronization algorithm involves _merging_ local CoIs with remote CoIs (see below).

new `coi::merge` module:
* a function `reduce_cois` that reduces a collection of CoIs by successively merging the closest _coiple_.
    * a coiple (represented by the struct `Coiple`) is a pair of CoIs considered "close" to each other.
* ability to `merge` added to CoIs (specifically, the `CoiPoint` trait).

**Follow up**

* when synchronizing local with remote CoIs, currently clashing ids are handled by shifting the ids of the remote CoIs. then after the merging, all ids are "re-normalized". while the CoIs end up the same on both devices, the ids are not globally consistent.
* the synchronization can be further streamlined by removing CoIs duplicated between local and remote. 