### PR TITLE
Ty 1921 list net training random weights init

### DIFF
--- a/xayn-ai/src/ltr/list_net/mod.rs
+++ b/xayn-ai/src/ltr/list_net/mod.rs
@@ -133,28 +133,31 @@ impl ListNet {
         let mut rng = rand::thread_rng();
 
         let dense1 = Dense::new(
-            he_normal_weights_init(&mut rng, Self::INPUT_NR_FEATURES, 48),
+            he_normal_weights_init(&mut rng, (Self::INPUT_NR_FEATURES, 48)),
             Array1::zeros((48,)),
             Relu,
         )
         .unwrap();
 
         let dense2 = Dense::new(
-            he_normal_weights_init(&mut rng, 48, 8),
+            he_normal_weights_init(&mut rng, (48, 8)),
             Array1::zeros((8,)),
             Relu,
         )
         .unwrap();
 
         let scores = Dense::new(
-            he_normal_weights_init(&mut rng, 8, 1),
+            he_normal_weights_init(&mut rng, (8, 1)),
             Array1::zeros((1,)),
             Linear,
         )
         .unwrap();
 
         let prob_dist = Dense::new(
-            he_normal_weights_init(&mut rng, Self::INPUT_NR_DOCUMENTS, Self::INPUT_NR_DOCUMENTS),
+            he_normal_weights_init(
+                &mut rng,
+                (Self::INPUT_NR_DOCUMENTS, Self::INPUT_NR_DOCUMENTS),
+            ),
             Array1::zeros((Self::INPUT_NR_DOCUMENTS,)),
             Softmax::default(),
         )

--- a/xayn-ai/src/ltr/list_net/mod.rs
+++ b/xayn-ai/src/ltr/list_net/mod.rs
@@ -126,8 +126,6 @@ impl ListNet {
     ///
     /// The weights are initialized using the He-Normal weight
     /// initializer, the biases are initialized to 0.
-    //TODO[maybe] run some tests to see weather or not Glorot or He
-    //            Uniform/Normal initialization works better for us.
     #[allow(dead_code)] //FIXME
     pub fn new_with_random_weights() -> Self {
         let mut rng = rand::thread_rng();

--- a/xayn-ai/src/ltr/list_net/ndlayers/dense.rs
+++ b/xayn-ai/src/ltr/list_net/ndlayers/dense.rs
@@ -196,6 +196,11 @@ where
     pub(crate) fn weights(&self) -> ArrayView2<f32> {
         self.weights.view()
     }
+
+    #[cfg(test)]
+    pub(crate) fn bias(&self) -> &Array1<f32> {
+        &self.bias
+    }
 }
 
 /// A gradient set containing gradients for all parameters in a dense layer.

--- a/xayn-ai/src/ltr/list_net/ndutils/mod.rs
+++ b/xayn-ai/src/ltr/list_net/ndutils/mod.rs
@@ -365,7 +365,7 @@ mod tests {
         // wrt. the truncating of values outside of +-2std. We accept this
         // to be true if the found percentage is around +-5% of the expected
         // percentage.
-        assert_approx_eq!(f32, prob_1std, 0.713_389_1, epsilon = 0.05);
-        assert_approx_eq!(f32, prob_2std, 0.284_518_84, epsilon = 0.05);
+        assert_approx_eq!(f32, prob_1std, 0.715_232_8, epsilon = 0.05);
+        assert_approx_eq!(f32, prob_2std, 0.284_767_2, epsilon = 0.05);
     }
 }


### PR DESCRIPTION
Implemented initialization of ListNet based on random weights.

Weights are initialized using the He-Normal initialization and
biases are initialized  to 0.

This is based on PR #142, but can be separately reviewed (select to only show changes of the last commit).