### PR TITLE
pass cargo env to cross

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,2 @@
 [build.env]
-passthrough = ["RUSTFLAGS"]
+passthrough = ["CARGO_INCREMENTAL", "RUSTFLAGS"]


### PR DESCRIPTION
**Summary**

Pass through `CARGO_INCREMENTAL` to cross. Unfortunately it does not fix the error that appeared in #142 