### PR TITLE
TY-1952 sync coi ids

### DIFF
--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.126", features = ["derive"] }
 serde_repr = "0.1.7"
 smallvec = "1.6.1"
 thiserror = "1.0.25"
-uuid = { version = "0.8.2", features = ["serde", "wasm-bindgen"] }
+uuid = { version = "0.8.2", features = ["serde", "wasm-bindgen", "v4"] }
 
 [dev-dependencies]
 csv = "1.1.6"

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -35,10 +35,7 @@ impl NegativeCoi {
 #[derive(Clone)]
 struct CoiPair<C>(C, C);
 
-impl<C> CoiPair<C>
-where
-    C: CoiPoint,
-{
+impl<C: CoiPoint> CoiPair<C> {
     /// Creates a new CoI pair.
     ///
     /// The CoI with the smaller id (or `coi0` if the ids are equal) occupies position 0.
@@ -84,10 +81,7 @@ struct Coiple<C> {
     dist: f32,
 }
 
-impl<C> Coiple<C>
-where
-    C: CoiPoint,
-{
+impl<C: CoiPoint> Coiple<C> {
     /// Creates a new coiple.
     fn new(coi1: C, coi2: C, dist: f32) -> Self {
         let cois = CoiPair::new(coi1, coi2);
@@ -106,10 +100,7 @@ where
 }
 
 /// Computes the l2 distance between two CoI points.
-fn dist<C>(coi1: &C, coi2: &C) -> f32
-where
-    C: CoiPoint,
-{
+fn dist<C: CoiPoint>(coi1: &C, coi2: &C) -> f32 {
     l2_distance(coi1.point(), coi2.point())
 }
 

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -119,7 +119,7 @@ where
         .clone()
         .cartesian_product(cois_iter)
         .filter(|(coi1, coi2)| coi1.id() < coi2.id())
-        .filter_map(|(coi1, coi2)| -> Option<Coiple<C>> {
+        .filter_map(|(coi1, coi2)| {
             let dist = dist(coi1, coi2);
             (dist < MERGE_THRESHOLD_DIST).then(|| Coiple::new(coi1.clone(), coi2.clone(), dist))
         })

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -12,11 +12,11 @@ use crate::{
 const MERGE_THRESHOLD_DIST: f32 = 4.5;
 
 impl PositiveCoi {
-    pub fn merge(self, other: Self, id: usize) -> Self {
+    pub fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(&self.point, &other.point);
         let (alpha, beta) = merge_params(self.alpha, self.beta, other.alpha, other.beta);
         Self {
-            id: CoiId(id),
+            id,
             point,
             alpha,
             beta,
@@ -25,12 +25,9 @@ impl PositiveCoi {
 }
 
 impl NegativeCoi {
-    pub fn merge(self, other: Self, id: usize) -> Self {
+    pub fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(&self.point, &other.point);
-        Self {
-            id: CoiId(id),
-            point,
-        }
+        Self { id, point }
     }
 }
 
@@ -55,7 +52,7 @@ where
 
     /// Merges the CoI pair, assigning it the smaller of the two ids.
     fn merge_min(self) -> C {
-        let CoiId(min_id) = self.0.id();
+        let min_id = self.0.id();
         self.0.merge(self.1, min_id)
     }
 

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -232,7 +232,7 @@ mod tests {
         },
         reranker::systems::CoiSystem as CoiSystemTrait,
         to_vec_of_ref_of,
-        utils::mock_coiid,
+        utils::mock_coi_id,
     };
 
     pub(crate) fn create_data_with_mab(
@@ -251,7 +251,7 @@ mod tests {
                 },
                 qambert: QAMBertComponent { similarity: 0.5 },
                 coi: CoiComponent {
-                    id: mock_coiid(1),
+                    id: mock_coi_id(1),
                     pos_distance: 0.1,
                     neg_distance: 0.1,
                 },
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn test_shift_coi_point() {
-        let coi = PositiveCoi::new(mock_coiid(0), arr1(&[1., 1., 1.]).into());
+        let coi = PositiveCoi::new(mock_coi_id(0), arr1(&[1., 1., 1.]).into());
         let embedding = arr1(&[2., 3., 4.]).into();
 
         let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi.point);
@@ -409,7 +409,7 @@ mod tests {
             .compute_coi_for_embedding(&embedding, &user_interests)
             .unwrap();
 
-        assert_eq!(coi_comp.id, mock_coiid(2));
+        assert_eq!(coi_comp.id, mock_coi_id(2));
         assert_approx_eq!(f32, coi_comp.pos_distance, 4.8904557);
         assert_approx_eq!(f32, coi_comp.neg_distance, 8.1273575);
     }
@@ -428,7 +428,7 @@ mod tests {
             .compute_coi_for_embedding(&embedding, &user_interests)
             .unwrap();
 
-        assert_eq!(coi_comp.id, mock_coiid(2));
+        assert_eq!(coi_comp.id, mock_coi_id(2));
         assert_approx_eq!(f32, coi_comp.pos_distance, 4.8904557);
         assert_approx_eq!(f32, coi_comp.neg_distance, f32::MAX, ulps = 0);
     }
@@ -444,11 +444,11 @@ mod tests {
             .compute_coi(documents, &user_interests)
             .unwrap();
 
-        assert_eq!(documents_coi[0].coi.id, mock_coiid(1));
+        assert_eq!(documents_coi[0].coi.id, mock_coi_id(1));
         assert_approx_eq!(f32, documents_coi[0].coi.pos_distance, 2.8996046);
         assert_approx_eq!(f32, documents_coi[0].coi.neg_distance, 3.7416575);
 
-        assert_eq!(documents_coi[1].coi.id, mock_coiid(1));
+        assert_eq!(documents_coi[1].coi.id, mock_coi_id(1));
         assert_approx_eq!(f32, documents_coi[1].coi.pos_distance, 5.8501925);
         assert_approx_eq!(f32, documents_coi[1].coi.neg_distance, SQRT_2);
     }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -2,6 +2,7 @@ use std::ops::Deref;
 
 use displaydoc::Display;
 use thiserror::Error;
+use uuid::Uuid;
 
 use crate::{
     coi::{
@@ -124,8 +125,9 @@ impl CoiSystem {
         match self.find_closest_coi_mut(embedding, &mut cois) {
             Some((coi, distance)) if distance < self.config.threshold => {
                 coi.set_point(self.shift_coi_point(embedding, &coi.point()));
+                coi.set_id(Uuid::new_v4().into());
             }
-            _ => cois.push(CP::new((cois.len() + 1).into(), embedding.clone())),
+            _ => cois.push(CP::new(Uuid::new_v4().into(), embedding.clone())),
         }
         cois
     }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -228,11 +228,11 @@ mod tests {
                 QAMBertComponent,
                 SMBertComponent,
             },
-            CoiId,
             PositiveCoi,
         },
         reranker::systems::CoiSystem as CoiSystemTrait,
         to_vec_of_ref_of,
+        utils::mock_uuid,
     };
 
     pub(crate) fn create_data_with_mab(
@@ -251,7 +251,7 @@ mod tests {
                 },
                 qambert: QAMBertComponent { similarity: 0.5 },
                 coi: CoiComponent {
-                    id: CoiId(1),
+                    id: mock_uuid(1).into(),
                     pos_distance: 0.1,
                     neg_distance: 0.1,
                 },
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn test_shift_coi_point() {
-        let coi = PositiveCoi::new(0, arr1(&[1., 1., 1.]).into());
+        let coi = PositiveCoi::new(Uuid::nil().into(), arr1(&[1., 1., 1.]).into());
         let embedding = arr1(&[2., 3., 4.]).into();
 
         let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi.point);
@@ -409,7 +409,7 @@ mod tests {
             .compute_coi_for_embedding(&embedding, &user_interests)
             .unwrap();
 
-        assert_eq!(coi_comp.id, CoiId(2));
+        assert_eq!(coi_comp.id, mock_uuid(2).into());
         assert_approx_eq!(f32, coi_comp.pos_distance, 4.8904557);
         assert_approx_eq!(f32, coi_comp.neg_distance, 8.1273575);
     }
@@ -428,7 +428,7 @@ mod tests {
             .compute_coi_for_embedding(&embedding, &user_interests)
             .unwrap();
 
-        assert_eq!(coi_comp.id, CoiId(2));
+        assert_eq!(coi_comp.id, mock_uuid(2).into());
         assert_approx_eq!(f32, coi_comp.pos_distance, 4.8904557);
         assert_approx_eq!(f32, coi_comp.neg_distance, f32::MAX, ulps = 0);
     }
@@ -444,11 +444,11 @@ mod tests {
             .compute_coi(documents, &user_interests)
             .unwrap();
 
-        assert_eq!(documents_coi[0].coi.id.0, 1);
+        assert_eq!(documents_coi[0].coi.id.0, mock_uuid(1));
         assert_approx_eq!(f32, documents_coi[0].coi.pos_distance, 2.8996046);
         assert_approx_eq!(f32, documents_coi[0].coi.neg_distance, 3.7416575);
 
-        assert_eq!(documents_coi[1].coi.id.0, 1);
+        assert_eq!(documents_coi[1].coi.id.0, mock_uuid(1));
         assert_approx_eq!(f32, documents_coi[1].coi.pos_distance, 5.8501925);
         assert_approx_eq!(f32, documents_coi[1].coi.neg_distance, SQRT_2);
     }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -232,7 +232,7 @@ mod tests {
         },
         reranker::systems::CoiSystem as CoiSystemTrait,
         to_vec_of_ref_of,
-        utils::mock_uuid,
+        utils::mock_coiid,
     };
 
     pub(crate) fn create_data_with_mab(
@@ -251,7 +251,7 @@ mod tests {
                 },
                 qambert: QAMBertComponent { similarity: 0.5 },
                 coi: CoiComponent {
-                    id: mock_uuid(1).into(),
+                    id: mock_coiid(1),
                     pos_distance: 0.1,
                     neg_distance: 0.1,
                 },
@@ -358,7 +358,7 @@ mod tests {
 
     #[test]
     fn test_shift_coi_point() {
-        let coi = PositiveCoi::new(Uuid::nil().into(), arr1(&[1., 1., 1.]).into());
+        let coi = PositiveCoi::new(mock_coiid(0), arr1(&[1., 1., 1.]).into());
         let embedding = arr1(&[2., 3., 4.]).into();
 
         let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi.point);
@@ -409,7 +409,7 @@ mod tests {
             .compute_coi_for_embedding(&embedding, &user_interests)
             .unwrap();
 
-        assert_eq!(coi_comp.id, mock_uuid(2).into());
+        assert_eq!(coi_comp.id, mock_coiid(2));
         assert_approx_eq!(f32, coi_comp.pos_distance, 4.8904557);
         assert_approx_eq!(f32, coi_comp.neg_distance, 8.1273575);
     }
@@ -428,7 +428,7 @@ mod tests {
             .compute_coi_for_embedding(&embedding, &user_interests)
             .unwrap();
 
-        assert_eq!(coi_comp.id, mock_uuid(2).into());
+        assert_eq!(coi_comp.id, mock_coiid(2));
         assert_approx_eq!(f32, coi_comp.pos_distance, 4.8904557);
         assert_approx_eq!(f32, coi_comp.neg_distance, f32::MAX, ulps = 0);
     }
@@ -444,11 +444,11 @@ mod tests {
             .compute_coi(documents, &user_interests)
             .unwrap();
 
-        assert_eq!(documents_coi[0].coi.id.0, mock_uuid(1));
+        assert_eq!(documents_coi[0].coi.id, mock_coiid(1));
         assert_approx_eq!(f32, documents_coi[0].coi.pos_distance, 2.8996046);
         assert_approx_eq!(f32, documents_coi[0].coi.neg_distance, 3.7416575);
 
-        assert_eq!(documents_coi[1].coi.id.0, mock_uuid(1));
+        assert_eq!(documents_coi[1].coi.id, mock_coiid(1));
         assert_approx_eq!(f32, documents_coi[1].coi.pos_distance, 5.8501925);
         assert_approx_eq!(f32, documents_coi[1].coi.neg_distance, SQRT_2);
     }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -125,7 +125,7 @@ impl CoiSystem {
             Some((coi, distance)) if distance < self.config.threshold => {
                 coi.set_point(self.shift_coi_point(embedding, &coi.point()));
             }
-            _ => cois.push(CP::new(cois.len() + 1, embedding.clone())),
+            _ => cois.push(CP::new((cois.len() + 1).into(), embedding.clone())),
         }
         cois
     }

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -6,6 +6,7 @@ use crate::{
         PositiveCoi,
     },
     reranker::systems::CoiSystemData,
+    CoiId,
     DocumentHistory,
     DocumentId,
 };
@@ -73,7 +74,7 @@ where
 {
     let counts = count_coi_ids(docs);
     for coi in cois.iter_mut() {
-        if let Some(count) = counts.get(&coi.id.0) {
+        if let Some(count) = counts.get(&coi.id) {
             let adjustment = 1.1f32.powi(*count as i32);
             f(coi, adjustment);
         }
@@ -108,7 +109,7 @@ pub(super) fn update_beta(
 /// documents = [d_1(coi_id_1), d_2(coi_id_2), d_3(coi_id_1)]
 /// count_coi_ids(documents) -> {coi_id_1: 2, coi_id_2: 1}
 /// ```
-fn count_coi_ids(documents: &[&dyn CoiSystemData]) -> HashMap<usize, u16> {
+fn count_coi_ids(documents: &[&dyn CoiSystemData]) -> HashMap<CoiId, u16> {
     documents
         .iter()
         .filter_map(|doc| doc.coi().map(|coi| coi.id))
@@ -116,7 +117,7 @@ fn count_coi_ids(documents: &[&dyn CoiSystemData]) -> HashMap<usize, u16> {
             HashMap::with_capacity(documents.len()),
             |mut counts, coi_id| {
                 counts
-                    .entry(coi_id.0)
+                    .entry(coi_id)
                     .and_modify(|count| *count += 1)
                     .or_insert(1);
                 counts

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -145,7 +145,7 @@ pub(super) mod tests {
             NegativeCoi,
         },
         to_vec_of_ref_of,
-        utils::{mock_coiid, mock_uuid},
+        utils::{mock_coi_id, mock_uuid},
     };
 
     pub(crate) struct MockCoiDoc {
@@ -188,7 +188,7 @@ pub(super) mod tests {
         points
             .iter()
             .enumerate()
-            .map(|(id, point)| CP::new(mock_coiid(id), arr1(point.as_init_slice()).into()))
+            .map(|(id, point)| CP::new(mock_coi_id(id), arr1(point.as_init_slice()).into()))
             .collect()
     }
 

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -128,6 +128,7 @@ fn count_coi_ids(documents: &[&dyn CoiSystemData]) -> HashMap<CoiId, u16> {
 #[cfg(test)]
 pub(super) mod tests {
     use ndarray::{arr1, FixedInitializer};
+    use uuid::Uuid;
 
     use super::*;
     use crate::{
@@ -145,6 +146,7 @@ pub(super) mod tests {
             NegativeCoi,
         },
         to_vec_of_ref_of,
+        utils::mock_uuid,
     };
 
     pub(crate) struct MockCoiDoc {
@@ -167,7 +169,7 @@ pub(super) mod tests {
         }
     }
 
-    fn create_docs_from_coi_id(ids: &[usize]) -> Vec<MockCoiDoc> {
+    fn create_docs_from_coi_id(ids: &[Uuid]) -> Vec<MockCoiDoc> {
         ids.iter()
             .map(|id| MockCoiDoc {
                 id: DocumentId::from_u128(0),
@@ -187,7 +189,7 @@ pub(super) mod tests {
         points
             .iter()
             .enumerate()
-            .map(|(id, point)| CP::new(id, arr1(point.as_init_slice()).into()))
+            .map(|(id, point)| CP::new(mock_uuid(id).into(), arr1(point.as_init_slice()).into()))
             .collect()
     }
 
@@ -253,7 +255,7 @@ pub(super) mod tests {
     #[test]
     fn test_update_alpha_and_beta() {
         let cois = create_cois(&[[1., 0., 0.], [1., 0., 0.]]);
-        let docs = create_docs_from_coi_id(&[0, 1, 1]);
+        let docs = create_docs_from_coi_id(&[mock_uuid(0), mock_uuid(1), mock_uuid(1)]);
         let docs = to_vec_of_ref_of!(docs, &dyn CoiSystemData);
 
         let updated_cois = update_alpha(&docs, cois.clone());
@@ -272,7 +274,7 @@ pub(super) mod tests {
     #[test]
     fn test_update_alpha_or_beta() {
         let cois = create_cois(&[[1., 0., 0.], [1., 0., 0.], [1., 0., 0.]]);
-        let docs = create_docs_from_coi_id(&[0, 1, 1]);
+        let docs = create_docs_from_coi_id(&[mock_uuid(0), mock_uuid(1), mock_uuid(1)]);
         let docs = to_vec_of_ref_of!(docs, &dyn CoiSystemData);
 
         // only update the alpha of coi_id 1 and 2

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -141,12 +141,11 @@ pub(super) mod tests {
                 QAMBertComponent,
                 SMBertComponent,
             },
-            CoiId,
             CoiPoint,
             NegativeCoi,
         },
         to_vec_of_ref_of,
-        utils::mock_uuid,
+        utils::{mock_coiid, mock_uuid},
     };
 
     pub(crate) struct MockCoiDoc {
@@ -177,7 +176,7 @@ pub(super) mod tests {
                     embedding: arr1(&[]).into(),
                 },
                 coi: Some(CoiComponent {
-                    id: CoiId(*id),
+                    id: (*id).into(),
                     pos_distance: 1.,
                     neg_distance: 1.,
                 }),
@@ -189,7 +188,7 @@ pub(super) mod tests {
         points
             .iter()
             .enumerate()
-            .map(|(id, point)| CP::new(mock_uuid(id).into(), arr1(point.as_init_slice()).into()))
+            .map(|(id, point)| CP::new(mock_coiid(id), arr1(point.as_init_slice()).into()))
             .collect()
     }
 

--- a/xayn-ai/src/context.rs
+++ b/xayn-ai/src/context.rs
@@ -68,18 +68,20 @@ impl ContextCalc {
 #[cfg(test)]
 mod tests {
     use ndarray::arr1;
-    use uuid::Uuid;
 
     use super::*;
-    use crate::data::{
-        document::DocumentId,
-        document_data::{
-            CoiComponent,
-            DocumentBaseComponent,
-            LtrComponent,
-            QAMBertComponent,
-            SMBertComponent,
+    use crate::{
+        data::{
+            document::DocumentId,
+            document_data::{
+                CoiComponent,
+                DocumentBaseComponent,
+                LtrComponent,
+                QAMBertComponent,
+                SMBertComponent,
+            },
         },
+        utils::mock_coiid,
     };
 
     struct LtrDocBuilder {
@@ -109,7 +111,7 @@ mod tests {
                 smbert: SMBertComponent { embedding },
                 qambert: QAMBertComponent { similarity },
                 coi: CoiComponent {
-                    id: Uuid::nil().into(),
+                    id: mock_coiid(0),
                     pos_distance,
                     neg_distance,
                 },

--- a/xayn-ai/src/context.rs
+++ b/xayn-ai/src/context.rs
@@ -68,6 +68,7 @@ impl ContextCalc {
 #[cfg(test)]
 mod tests {
     use ndarray::arr1;
+    use uuid::Uuid;
 
     use super::*;
     use crate::data::{
@@ -79,7 +80,6 @@ mod tests {
             QAMBertComponent,
             SMBertComponent,
         },
-        CoiId,
     };
 
     struct LtrDocBuilder {
@@ -109,7 +109,7 @@ mod tests {
                 smbert: SMBertComponent { embedding },
                 qambert: QAMBertComponent { similarity },
                 coi: CoiComponent {
-                    id: CoiId(0),
+                    id: Uuid::nil().into(),
                     pos_distance,
                     neg_distance,
                 },

--- a/xayn-ai/src/context.rs
+++ b/xayn-ai/src/context.rs
@@ -81,7 +81,7 @@ mod tests {
                 SMBertComponent,
             },
         },
-        utils::mock_coiid,
+        utils::mock_coi_id,
     };
 
     struct LtrDocBuilder {
@@ -111,7 +111,7 @@ mod tests {
                 smbert: SMBertComponent { embedding },
                 qambert: QAMBertComponent { similarity },
                 coi: CoiComponent {
-                    id: mock_coiid(0),
+                    id: mock_coi_id(0),
                     pos_distance,
                     neg_distance,
                 },

--- a/xayn-ai/src/data/document_data.rs
+++ b/xayn-ai/src/data/document_data.rs
@@ -259,7 +259,7 @@ impl CoiSystemData for DocumentDataWithMab {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::mock_uuid;
+    use crate::utils::mock_coiid;
 
     use super::*;
     use ndarray::arr1;
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(document_data.qambert, qambert);
 
         let coi = CoiComponent {
-            id: mock_uuid(9).into(),
+            id: mock_coiid(9),
             pos_distance: 0.7,
             neg_distance: 0.2,
         };

--- a/xayn-ai/src/data/document_data.rs
+++ b/xayn-ai/src/data/document_data.rs
@@ -259,7 +259,7 @@ impl CoiSystemData for DocumentDataWithMab {
 
 #[cfg(test)]
 mod tests {
-    use crate::utils::mock_coiid;
+    use crate::utils::mock_coi_id;
 
     use super::*;
     use ndarray::arr1;
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(document_data.qambert, qambert);
 
         let coi = CoiComponent {
-            id: mock_coiid(9),
+            id: mock_coi_id(9),
             pos_distance: 0.7,
             neg_distance: 0.2,
         };

--- a/xayn-ai/src/data/document_data.rs
+++ b/xayn-ai/src/data/document_data.rs
@@ -259,6 +259,8 @@ impl CoiSystemData for DocumentDataWithMab {
 
 #[cfg(test)]
 mod tests {
+    use crate::utils::mock_uuid;
+
     use super::*;
     use ndarray::arr1;
 
@@ -295,7 +297,7 @@ mod tests {
         assert_eq!(document_data.qambert, qambert);
 
         let coi = CoiComponent {
-            id: CoiId(9),
+            id: mock_uuid(9).into(),
             pos_distance: 0.7,
             neg_distance: 0.2,
         };

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -12,7 +12,7 @@ use crate::embedding::utils::Embedding;
 #[derive(
     Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Serialize, Deserialize, From,
 )]
-pub struct CoiId(pub Uuid);
+pub struct CoiId(Uuid);
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Clone, Serialize, Deserialize)]

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -1,13 +1,16 @@
 pub mod document;
 pub(crate) mod document_data;
 
+use derive_more::From;
 use serde::{Deserialize, Serialize};
 
 use crate::embedding::utils::Embedding;
 
 // Hint: We use this id new-type in FFI so repr(transparent) needs to be kept
 #[repr(transparent)]
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(
+    Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Serialize, Deserialize, From,
+)]
 pub struct CoiId(pub usize);
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
@@ -27,9 +30,9 @@ pub(crate) struct NegativeCoi {
 }
 
 impl PositiveCoi {
-    pub fn new(id: usize, point: Embedding) -> Self {
+    pub fn new(id: CoiId, point: Embedding) -> Self {
         Self {
-            id: CoiId(id),
+            id,
             point,
             alpha: 1.,
             beta: 1.,
@@ -38,19 +41,16 @@ impl PositiveCoi {
 }
 
 impl NegativeCoi {
-    pub fn new(id: usize, point: Embedding) -> Self {
-        Self {
-            id: CoiId(id),
-            point,
-        }
+    pub fn new(id: CoiId, point: Embedding) -> Self {
+        Self { id, point }
     }
 }
 
 pub(crate) trait CoiPoint {
-    fn new(id: usize, embedding: Embedding) -> Self;
-    fn merge(self, other: Self, id: usize) -> Self;
+    fn new(id: CoiId, embedding: Embedding) -> Self;
+    fn merge(self, other: Self, id: CoiId) -> Self;
     fn id(&self) -> CoiId;
-    fn set_id(&mut self, id: usize);
+    fn set_id(&mut self, id: CoiId);
     fn point(&self) -> &Embedding;
     fn set_point(&mut self, embedding: Embedding);
 }
@@ -58,11 +58,11 @@ pub(crate) trait CoiPoint {
 macro_rules! impl_coi_point {
     ($type:ty) => {
         impl CoiPoint for $type {
-            fn new(id: usize, embedding: Embedding) -> Self {
+            fn new(id: CoiId, embedding: Embedding) -> Self {
                 <$type>::new(id, embedding)
             }
 
-            fn merge(self, other: Self, id: usize) -> Self {
+            fn merge(self, other: Self, id: CoiId) -> Self {
                 self.merge(other, id)
             }
 
@@ -70,8 +70,8 @@ macro_rules! impl_coi_point {
                 self.id
             }
 
-            fn set_id(&mut self, id: usize) {
-                self.id = CoiId(id);
+            fn set_id(&mut self, id: CoiId) {
+                self.id = id;
             }
 
             fn point(&self) -> &Embedding {

--- a/xayn-ai/src/data/mod.rs
+++ b/xayn-ai/src/data/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod document_data;
 
 use derive_more::From;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::embedding::utils::Embedding;
 
@@ -11,7 +12,7 @@ use crate::embedding::utils::Embedding;
 #[derive(
     Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord, Serialize, Deserialize, From,
 )]
-pub struct CoiId(pub usize);
+pub struct CoiId(pub Uuid);
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Clone, Serialize, Deserialize)]

--- a/xayn-ai/src/ltr/mod.rs
+++ b/xayn-ai/src/ltr/mod.rs
@@ -121,16 +121,18 @@ mod tests {
     use ndarray::arr1;
 
     use super::*;
-    use crate::data::{
-        document::DocumentId,
-        document_data::{
-            CoiComponent,
-            DocumentBaseComponent,
-            DocumentContentComponent,
-            QAMBertComponent,
-            SMBertComponent,
+    use crate::{
+        data::{
+            document::DocumentId,
+            document_data::{
+                CoiComponent,
+                DocumentBaseComponent,
+                DocumentContentComponent,
+                QAMBertComponent,
+                SMBertComponent,
+            },
         },
-        CoiId,
+        utils::mock_uuid,
     };
 
     #[test]
@@ -138,7 +140,7 @@ mod tests {
         let id = DocumentId::from_u128(0);
         let embedding = arr1(&[1., 2., 3., 4.]).into();
         let coi = CoiComponent {
-            id: CoiId(9),
+            id: mock_uuid(9).into(),
             pos_distance: 0.7,
             neg_distance: 0.2,
         };
@@ -158,7 +160,7 @@ mod tests {
         let id = DocumentId::from_u128(1);
         let embedding = arr1(&[5., 6., 7.]).into();
         let coi = CoiComponent {
-            id: CoiId(5),
+            id: mock_uuid(5).into(),
             pos_distance: 0.3,
             neg_distance: 0.9,
         };

--- a/xayn-ai/src/ltr/mod.rs
+++ b/xayn-ai/src/ltr/mod.rs
@@ -132,7 +132,7 @@ mod tests {
                 SMBertComponent,
             },
         },
-        utils::mock_coiid,
+        utils::mock_coi_id,
     };
 
     #[test]
@@ -140,7 +140,7 @@ mod tests {
         let id = DocumentId::from_u128(0);
         let embedding = arr1(&[1., 2., 3., 4.]).into();
         let coi = CoiComponent {
-            id: mock_coiid(9),
+            id: mock_coi_id(9),
             pos_distance: 0.7,
             neg_distance: 0.2,
         };
@@ -160,7 +160,7 @@ mod tests {
         let id = DocumentId::from_u128(1);
         let embedding = arr1(&[5., 6., 7.]).into();
         let coi = CoiComponent {
-            id: mock_coiid(5),
+            id: mock_coi_id(5),
             pos_distance: 0.3,
             neg_distance: 0.9,
         };

--- a/xayn-ai/src/ltr/mod.rs
+++ b/xayn-ai/src/ltr/mod.rs
@@ -132,7 +132,7 @@ mod tests {
                 SMBertComponent,
             },
         },
-        utils::mock_uuid,
+        utils::mock_coiid,
     };
 
     #[test]
@@ -140,7 +140,7 @@ mod tests {
         let id = DocumentId::from_u128(0);
         let embedding = arr1(&[1., 2., 3., 4.]).into();
         let coi = CoiComponent {
-            id: mock_uuid(9).into(),
+            id: mock_coiid(9),
             pos_distance: 0.7,
             neg_distance: 0.2,
         };
@@ -160,7 +160,7 @@ mod tests {
         let id = DocumentId::from_u128(1);
         let embedding = arr1(&[5., 6., 7.]).into();
         let coi = CoiComponent {
-            id: mock_uuid(5).into(),
+            id: mock_coiid(5),
             pos_distance: 0.3,
             neg_distance: 0.9,
         };

--- a/xayn-ai/src/mab.rs
+++ b/xayn-ai/src/mab.rs
@@ -285,7 +285,7 @@ mod tests {
                 SMBertComponent,
             },
         },
-        utils::mock_coiid,
+        utils::mock_coi_id,
     };
     use ndarray::arr1;
 
@@ -344,11 +344,11 @@ mod tests {
         let doc_id_4 = DocumentId::from_u128(4);
 
         let group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.),
-            with_ctx(doc_id_1.clone(), mock_coiid(4), 0.),
-            with_ctx(doc_id_2.clone(), mock_coiid(9), 0.),
-            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.),
-            with_ctx(doc_id_4.clone(), mock_coiid(9), 0.),
+            with_ctx(doc_id_0.clone(), mock_coi_id(0), 0.),
+            with_ctx(doc_id_1.clone(), mock_coi_id(4), 0.),
+            with_ctx(doc_id_2.clone(), mock_coi_id(9), 0.),
+            with_ctx(doc_id_3.clone(), mock_coi_id(4), 0.),
+            with_ctx(doc_id_4.clone(), mock_coi_id(9), 0.),
         ]);
 
         let check_contains = |coi_id: CoiId, docs_id_ok: Vec<DocumentId>| {
@@ -366,9 +366,9 @@ mod tests {
             }
         };
 
-        check_contains(mock_coiid(0), vec![doc_id_0]);
-        check_contains(mock_coiid(4), vec![doc_id_1, doc_id_3]);
-        check_contains(mock_coiid(9), vec![doc_id_2, doc_id_4]);
+        check_contains(mock_coi_id(0), vec![doc_id_0]);
+        check_contains(mock_coi_id(4), vec![doc_id_1, doc_id_3]);
+        check_contains(mock_coi_id(9), vec![doc_id_2, doc_id_4]);
     }
 
     #[test]
@@ -380,14 +380,14 @@ mod tests {
         let doc_id_4 = DocumentId::from_u128(4);
 
         let mut group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.4),
-            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.8),
-            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.2),
-            with_ctx(doc_id_3.clone(), mock_coiid(0), 0.9),
-            with_ctx(doc_id_4.clone(), mock_coiid(0), 0.6),
+            with_ctx(doc_id_0.clone(), mock_coi_id(0), 0.4),
+            with_ctx(doc_id_1.clone(), mock_coi_id(0), 0.8),
+            with_ctx(doc_id_2.clone(), mock_coi_id(0), 0.2),
+            with_ctx(doc_id_3.clone(), mock_coi_id(0), 0.9),
+            with_ctx(doc_id_4.clone(), mock_coi_id(0), 0.6),
         ]);
 
-        let docs = group.remove(&mock_coiid(0)).expect("document from coi id");
+        let docs = group.remove(&mock_coi_id(0)).expect("document from coi id");
         let docs_id: Vec<DocumentId> = docs
             .into_sorted_vec()
             .into_iter()
@@ -409,12 +409,12 @@ mod tests {
         let doc_id_2 = DocumentId::from_u128(2);
 
         let mut group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
-            with_ctx(doc_id_1.clone(), mock_coiid(0), f32::NAN),
-            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.8),
+            with_ctx(doc_id_0.clone(), mock_coi_id(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coi_id(0), f32::NAN),
+            with_ctx(doc_id_2.clone(), mock_coi_id(0), 0.8),
         ]);
 
-        let docs = group.remove(&mock_coiid(0)).expect("document from coi id");
+        let docs = group.remove(&mock_coi_id(0)).expect("document from coi id");
         let docs_id: Vec<DocumentId> = docs
             .into_sorted_vec()
             .into_iter()
@@ -435,8 +435,8 @@ mod tests {
     #[test]
     fn test_update_coi_no_docs() {
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0)),
-            mock_coiid(1) => coi!(mock_coiid(1)),
+            mock_coi_id(0) => coi!(mock_coi_id(0)),
+            mock_coi_id(1) => coi!(mock_coi_id(1)),
         };
 
         let new_cois = update_cois(cois.clone(), &[]).expect("cois");
@@ -447,7 +447,7 @@ mod tests {
     fn test_update_coi_no_coi() {
         let error = update_cois(
             HashMap::new(),
-            &[with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.)],
+            &[with_ctx(DocumentId::from_u128(0), mock_coi_id(0), 0.)],
         )
         .expect_err("no coi");
         assert!(matches!(error, MabError::DocumentCoiDoesNotExist));
@@ -456,14 +456,14 @@ mod tests {
     #[test]
     fn test_update_coi_invalid_context_value() {
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.91),
         };
 
         let error = update_cois(
             cois.clone(),
             &[
-                with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.35),
-                with_ctx(DocumentId::from_u128(1), mock_coiid(0), -1.),
+                with_ctx(DocumentId::from_u128(0), mock_coi_id(0), 0.35),
+                with_ctx(DocumentId::from_u128(1), mock_coi_id(0), -1.),
             ],
         )
         .expect_err("invalid context value");
@@ -472,8 +472,8 @@ mod tests {
         let error = update_cois(
             cois,
             &[
-                with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.35),
-                with_ctx(DocumentId::from_u128(1), mock_coiid(0), 1.01),
+                with_ctx(DocumentId::from_u128(0), mock_coi_id(0), 0.35),
+                with_ctx(DocumentId::from_u128(1), mock_coi_id(0), 1.01),
             ],
         )
         .expect_err("invalid context value");
@@ -483,17 +483,17 @@ mod tests {
     #[test]
     fn test_update_coi_ok() {
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
-            mock_coiid(1) => coi!(mock_coiid(1), 0.27)
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.91),
+            mock_coi_id(1) => coi!(mock_coi_id(1), 0.27)
         };
 
         let cois = update_cois(
             cois,
             &vec![
-                with_ctx(DocumentId::from_u128(0), mock_coiid(1), 1.),
-                with_ctx(DocumentId::from_u128(1), mock_coiid(0), 0.35),
-                with_ctx(DocumentId::from_u128(2), mock_coiid(1), 0.2),
-                with_ctx(DocumentId::from_u128(3), mock_coiid(0), 0.6),
+                with_ctx(DocumentId::from_u128(0), mock_coi_id(1), 1.),
+                with_ctx(DocumentId::from_u128(1), mock_coi_id(0), 0.35),
+                with_ctx(DocumentId::from_u128(2), mock_coi_id(1), 0.2),
+                with_ctx(DocumentId::from_u128(3), mock_coi_id(0), 0.6),
             ],
         )
         .expect("cois");
@@ -501,11 +501,11 @@ mod tests {
         // alpha is updated with `alpha += context_value`
         // beta is updated with `beta += (1. - context_value)`
 
-        let coi = cois.get(&mock_coiid(0)).expect("coi");
+        let coi = cois.get(&mock_coi_id(0)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.86);
         assert_approx_eq!(f32, coi.beta, 1.96);
 
-        let coi = cois.get(&mock_coiid(1)).expect("coi");
+        let coi = cois.get(&mock_coi_id(1)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.47);
         assert_approx_eq!(f32, coi.beta, 1.07);
     }
@@ -513,8 +513,8 @@ mod tests {
     #[test]
     fn test_pull_arms_coi_empty() {
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.),
-            with_ctx(DocumentId::from_u128(1), mock_coiid(1), 0.),
+            with_ctx(DocumentId::from_u128(0), mock_coi_id(0), 0.),
+            with_ctx(DocumentId::from_u128(1), mock_coi_id(1), 0.),
         ]);
 
         let beta_sampler = MockBetaSample::new();
@@ -527,11 +527,11 @@ mod tests {
     #[test]
     fn test_pull_arms_no_coi() {
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.91),
         };
 
         let documents_by_coi =
-            group_by_coi(vec![with_ctx(DocumentId::from_u128(1), mock_coiid(1), 0.)]);
+            group_by_coi(vec![with_ctx(DocumentId::from_u128(1), mock_coi_id(1), 0.)]);
 
         let beta_sampler = MockBetaSample::new();
 
@@ -549,7 +549,7 @@ mod tests {
         assert!(matches!(error, MabError::NoDocumentsToPull));
 
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.91),
         };
 
         let error =
@@ -560,13 +560,13 @@ mod tests {
     #[test]
     fn test_pull_arms_sampler_error() {
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
-            mock_coiid(1) => coi!(mock_coiid(1), 0.1),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.91),
+            mock_coi_id(1) => coi!(mock_coi_id(1), 0.1),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(DocumentId::from_u128(1), mock_coiid(0), 0.),
-            with_ctx(DocumentId::from_u128(2), mock_coiid(1), 0.),
+            with_ctx(DocumentId::from_u128(1), mock_coi_id(0), 0.),
+            with_ctx(DocumentId::from_u128(2), mock_coi_id(1), 0.),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -602,13 +602,13 @@ mod tests {
     #[test]
     fn test_pull_arms_malformed_documents_by_coi() {
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.91),
         };
 
         let mut documents_by_coi = DocumentsByCoi::new();
         // If `group_by_coi` and `pull_arms` are behaving correctly we will never have
         // a coi with an empty heap.
-        documents_by_coi.insert(mock_coiid(0), BinaryHeap::new());
+        documents_by_coi.insert(mock_coi_id(0), BinaryHeap::new());
 
         let mut beta_sampler = MockBetaSample::new();
         beta_sampler.expect_sample().returning(|_, _| Ok(0.2));
@@ -627,18 +627,18 @@ mod tests {
         let doc_id_5 = DocumentId::from_u128(5);
 
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.1),
-            mock_coiid(4) => coi!(mock_coiid(4), 0.5),
-            mock_coiid(7) => coi!(mock_coiid(7), 0.8),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.1),
+            mock_coi_id(4) => coi!(mock_coi_id(4), 0.5),
+            mock_coi_id(7) => coi!(mock_coi_id(7), 0.8),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
-            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.5),
-            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.7),
-            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
-            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
-            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.2),
+            with_ctx(doc_id_0.clone(), mock_coi_id(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coi_id(0), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coi_id(0), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coi_id(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coi_id(4), 0.7),
+            with_ctx(doc_id_5.clone(), mock_coi_id(7), 0.2),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -676,18 +676,18 @@ mod tests {
         let coi4 = 4.;
         let coi7 = 7.;
         let cois = hashmap! {
-            mock_coiid(1) => coi!(mock_coiid(1), coi1),
-            mock_coiid(4) => coi!(mock_coiid(4), coi4),
-            mock_coiid(7) => coi!(mock_coiid(7), coi7),
+            mock_coi_id(1) => coi!(mock_coi_id(1), coi1),
+            mock_coi_id(4) => coi!(mock_coi_id(4), coi4),
+            mock_coi_id(7) => coi!(mock_coi_id(7), coi7),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(1), 0.2),
-            with_ctx(doc_id_1.clone(), mock_coiid(1), 0.5),
-            with_ctx(doc_id_2.clone(), mock_coiid(1), 0.7),
-            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
-            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
-            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.2),
+            with_ctx(doc_id_0.clone(), mock_coi_id(1), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coi_id(1), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coi_id(1), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coi_id(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coi_id(4), 0.7),
+            with_ctx(doc_id_5.clone(), mock_coi_id(7), 0.2),
         ]);
 
         let mut coi_counter = 0;
@@ -760,17 +760,17 @@ mod tests {
 
         let cois = hashmap! {
             // high probability of low values
-            mock_coiid(0) => coi!(mock_coiid(0), 2., 8.),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 2., 8.),
             // high probability of high values
-            mock_coiid(4) => coi!(mock_coiid(4), 8., 2.),
+            mock_coi_id(4) => coi!(mock_coi_id(4), 8., 2.),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
-            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.5),
-            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.7),
-            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
-            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
+            with_ctx(doc_id_0.clone(), mock_coi_id(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coi_id(0), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coi_id(0), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coi_id(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coi_id(4), 0.7),
         ]);
 
         let beta_sampler = BetaSampler;
@@ -819,18 +819,18 @@ mod tests {
         let doc_id_5 = DocumentId::from_u128(5);
 
         let cois = hashmap! {
-            mock_coiid(0) => coi!(mock_coiid(0), 0.1),
-            mock_coiid(4) => coi!(mock_coiid(4), 0.5),
-            mock_coiid(7) => coi!(mock_coiid(7), 0.8),
+            mock_coi_id(0) => coi!(mock_coi_id(0), 0.1),
+            mock_coi_id(4) => coi!(mock_coi_id(4), 0.5),
+            mock_coi_id(7) => coi!(mock_coi_id(7), 0.8),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
-            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.5),
-            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.7),
-            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
-            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
-            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.2),
+            with_ctx(doc_id_0.clone(), mock_coi_id(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coi_id(0), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coi_id(0), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coi_id(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coi_id(4), 0.7),
+            with_ctx(doc_id_5.clone(), mock_coi_id(7), 0.2),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -866,7 +866,7 @@ mod tests {
     #[test]
     fn test_mab_ranking_iter_propagate_errors() {
         let documents_by_coi =
-            group_by_coi(vec![with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.)]);
+            group_by_coi(vec![with_ctx(DocumentId::from_u128(0), mock_coi_id(0), 0.)]);
 
         let beta_sampler = MockBetaSample::new();
 
@@ -875,7 +875,7 @@ mod tests {
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
 
         let cois = hashmap! {
-            mock_coiid(9) => coi!(mock_coiid(9), 0.1),
+            mock_coi_id(9) => coi!(mock_coi_id(9), 0.1),
         };
         let mab_rerank = MabRankingIter::new(&beta_sampler, &cois, documents_by_coi.clone());
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
@@ -888,7 +888,7 @@ mod tests {
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
 
         let mut documents_by_coi = DocumentsByCoi::new();
-        documents_by_coi.insert(mock_coiid(0), BinaryHeap::new());
+        documents_by_coi.insert(mock_coi_id(0), BinaryHeap::new());
         let mab_rerank = MabRankingIter::new(&beta_sampler, &cois, documents_by_coi);
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
     }
@@ -904,19 +904,19 @@ mod tests {
 
         let mut user_interests = UserInterests::new();
         user_interests.positive = vec![
-            coi!(mock_coiid(0), 1.),
-            coi!(mock_coiid(4), 10.),
-            coi!(mock_coiid(7), 100.),
+            coi!(mock_coi_id(0), 1.),
+            coi!(mock_coi_id(4), 10.),
+            coi!(mock_coi_id(7), 100.),
         ];
 
         // we use a small context_value to avoid changing alpha and beta too much
         let documents = vec![
-            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.01),
-            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.02),
-            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.03),
-            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.01),
-            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.02),
-            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.01),
+            with_ctx(doc_id_0.clone(), mock_coi_id(0), 0.01),
+            with_ctx(doc_id_1.clone(), mock_coi_id(0), 0.02),
+            with_ctx(doc_id_2.clone(), mock_coi_id(0), 0.03),
+            with_ctx(doc_id_3.clone(), mock_coi_id(4), 0.01),
+            with_ctx(doc_id_4.clone(), mock_coi_id(4), 0.02),
+            with_ctx(doc_id_5.clone(), mock_coi_id(7), 0.01),
         ];
 
         let mut beta_sampler = MockBetaSample::new();
@@ -948,15 +948,15 @@ mod tests {
             .map(|coi| (coi.id, coi))
             .collect::<HashMap<_, _>>();
 
-        let coi = cois.get(&mock_coiid(0)).expect("coi");
+        let coi = cois.get(&mock_coi_id(0)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.06);
         assert_approx_eq!(f32, coi.beta, 3.94);
 
-        let coi = cois.get(&mock_coiid(4)).expect("coi");
+        let coi = cois.get(&mock_coi_id(4)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 10.03);
         assert_approx_eq!(f32, coi.beta, 11.97);
 
-        let coi = cois.get(&mock_coiid(7)).expect("coi");
+        let coi = cois.get(&mock_coi_id(7)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 100.01);
         assert_approx_eq!(f32, coi.beta, 100.99);
     }

--- a/xayn-ai/src/mab.rs
+++ b/xayn-ai/src/mab.rs
@@ -285,7 +285,7 @@ mod tests {
                 SMBertComponent,
             },
         },
-        utils::mock_uuid,
+        utils::mock_coiid,
     };
     use ndarray::arr1;
 
@@ -344,11 +344,11 @@ mod tests {
         let doc_id_4 = DocumentId::from_u128(4);
 
         let group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.),
-            with_ctx(doc_id_1.clone(), mock_uuid(4).into(), 0.),
-            with_ctx(doc_id_2.clone(), mock_uuid(9).into(), 0.),
-            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.),
-            with_ctx(doc_id_4.clone(), mock_uuid(9).into(), 0.),
+            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.),
+            with_ctx(doc_id_1.clone(), mock_coiid(4), 0.),
+            with_ctx(doc_id_2.clone(), mock_coiid(9), 0.),
+            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.),
+            with_ctx(doc_id_4.clone(), mock_coiid(9), 0.),
         ]);
 
         let check_contains = |coi_id: CoiId, docs_id_ok: Vec<DocumentId>| {
@@ -366,9 +366,9 @@ mod tests {
             }
         };
 
-        check_contains(mock_uuid(0).into(), vec![doc_id_0]);
-        check_contains(mock_uuid(4).into(), vec![doc_id_1, doc_id_3]);
-        check_contains(mock_uuid(9).into(), vec![doc_id_2, doc_id_4]);
+        check_contains(mock_coiid(0), vec![doc_id_0]);
+        check_contains(mock_coiid(4), vec![doc_id_1, doc_id_3]);
+        check_contains(mock_coiid(9), vec![doc_id_2, doc_id_4]);
     }
 
     #[test]
@@ -380,16 +380,14 @@ mod tests {
         let doc_id_4 = DocumentId::from_u128(4);
 
         let mut group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.4),
-            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.8),
-            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.2),
-            with_ctx(doc_id_3.clone(), mock_uuid(0).into(), 0.9),
-            with_ctx(doc_id_4.clone(), mock_uuid(0).into(), 0.6),
+            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.4),
+            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.8),
+            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.2),
+            with_ctx(doc_id_3.clone(), mock_coiid(0), 0.9),
+            with_ctx(doc_id_4.clone(), mock_coiid(0), 0.6),
         ]);
 
-        let docs = group
-            .remove(&CoiId(mock_uuid(0)))
-            .expect("document from coi id");
+        let docs = group.remove(&mock_coiid(0)).expect("document from coi id");
         let docs_id: Vec<DocumentId> = docs
             .into_sorted_vec()
             .into_iter()
@@ -411,14 +409,12 @@ mod tests {
         let doc_id_2 = DocumentId::from_u128(2);
 
         let mut group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
-            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), f32::NAN),
-            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.8),
+            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coiid(0), f32::NAN),
+            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.8),
         ]);
 
-        let docs = group
-            .remove(&CoiId(mock_uuid(0)))
-            .expect("document from coi id");
+        let docs = group.remove(&mock_coiid(0)).expect("document from coi id");
         let docs_id: Vec<DocumentId> = docs
             .into_sorted_vec()
             .into_iter()
@@ -439,8 +435,8 @@ mod tests {
     #[test]
     fn test_update_coi_no_docs() {
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into()),
-            mock_uuid(1).into() => coi!(mock_uuid(1).into()),
+            mock_coiid(0) => coi!(mock_coiid(0)),
+            mock_coiid(1) => coi!(mock_coiid(1)),
         };
 
         let new_cois = update_cois(cois.clone(), &[]).expect("cois");
@@ -451,7 +447,7 @@ mod tests {
     fn test_update_coi_no_coi() {
         let error = update_cois(
             HashMap::new(),
-            &[with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.)],
+            &[with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.)],
         )
         .expect_err("no coi");
         assert!(matches!(error, MabError::DocumentCoiDoesNotExist));
@@ -460,14 +456,14 @@ mod tests {
     #[test]
     fn test_update_coi_invalid_context_value() {
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
+            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
         };
 
         let error = update_cois(
             cois.clone(),
             &[
-                with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.35),
-                with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), -1.),
+                with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.35),
+                with_ctx(DocumentId::from_u128(1), mock_coiid(0), -1.),
             ],
         )
         .expect_err("invalid context value");
@@ -476,8 +472,8 @@ mod tests {
         let error = update_cois(
             cois,
             &[
-                with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.35),
-                with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), 1.01),
+                with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.35),
+                with_ctx(DocumentId::from_u128(1), mock_coiid(0), 1.01),
             ],
         )
         .expect_err("invalid context value");
@@ -487,17 +483,17 @@ mod tests {
     #[test]
     fn test_update_coi_ok() {
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
-            mock_uuid(1).into() => coi!(mock_uuid(1).into(), 0.27)
+            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
+            mock_coiid(1) => coi!(mock_coiid(1), 0.27)
         };
 
         let cois = update_cois(
             cois,
             &vec![
-                with_ctx(DocumentId::from_u128(0), mock_uuid(1).into(), 1.),
-                with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), 0.35),
-                with_ctx(DocumentId::from_u128(2), mock_uuid(1).into(), 0.2),
-                with_ctx(DocumentId::from_u128(3), mock_uuid(0).into(), 0.6),
+                with_ctx(DocumentId::from_u128(0), mock_coiid(1), 1.),
+                with_ctx(DocumentId::from_u128(1), mock_coiid(0), 0.35),
+                with_ctx(DocumentId::from_u128(2), mock_coiid(1), 0.2),
+                with_ctx(DocumentId::from_u128(3), mock_coiid(0), 0.6),
             ],
         )
         .expect("cois");
@@ -505,11 +501,11 @@ mod tests {
         // alpha is updated with `alpha += context_value`
         // beta is updated with `beta += (1. - context_value)`
 
-        let coi = cois.get(&CoiId(mock_uuid(0))).expect("coi");
+        let coi = cois.get(&mock_coiid(0)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.86);
         assert_approx_eq!(f32, coi.beta, 1.96);
 
-        let coi = cois.get(&CoiId(mock_uuid(1))).expect("coi");
+        let coi = cois.get(&mock_coiid(1)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.47);
         assert_approx_eq!(f32, coi.beta, 1.07);
     }
@@ -517,8 +513,8 @@ mod tests {
     #[test]
     fn test_pull_arms_coi_empty() {
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.),
-            with_ctx(DocumentId::from_u128(1), mock_uuid(1).into(), 0.),
+            with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.),
+            with_ctx(DocumentId::from_u128(1), mock_coiid(1), 0.),
         ]);
 
         let beta_sampler = MockBetaSample::new();
@@ -531,14 +527,11 @@ mod tests {
     #[test]
     fn test_pull_arms_no_coi() {
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
+            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
         };
 
-        let documents_by_coi = group_by_coi(vec![with_ctx(
-            DocumentId::from_u128(1),
-            mock_uuid(1).into(),
-            0.,
-        )]);
+        let documents_by_coi =
+            group_by_coi(vec![with_ctx(DocumentId::from_u128(1), mock_coiid(1), 0.)]);
 
         let beta_sampler = MockBetaSample::new();
 
@@ -556,7 +549,7 @@ mod tests {
         assert!(matches!(error, MabError::NoDocumentsToPull));
 
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
+            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
         };
 
         let error =
@@ -567,13 +560,13 @@ mod tests {
     #[test]
     fn test_pull_arms_sampler_error() {
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
-            mock_uuid(1).into() => coi!(mock_uuid(1).into(), 0.1),
+            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
+            mock_coiid(1) => coi!(mock_coiid(1), 0.1),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), 0.),
-            with_ctx(DocumentId::from_u128(2), mock_uuid(1).into(), 0.),
+            with_ctx(DocumentId::from_u128(1), mock_coiid(0), 0.),
+            with_ctx(DocumentId::from_u128(2), mock_coiid(1), 0.),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -609,13 +602,13 @@ mod tests {
     #[test]
     fn test_pull_arms_malformed_documents_by_coi() {
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
+            mock_coiid(0) => coi!(mock_coiid(0), 0.91),
         };
 
         let mut documents_by_coi = DocumentsByCoi::new();
         // If `group_by_coi` and `pull_arms` are behaving correctly we will never have
         // a coi with an empty heap.
-        documents_by_coi.insert(mock_uuid(0).into(), BinaryHeap::new());
+        documents_by_coi.insert(mock_coiid(0), BinaryHeap::new());
 
         let mut beta_sampler = MockBetaSample::new();
         beta_sampler.expect_sample().returning(|_, _| Ok(0.2));
@@ -634,18 +627,18 @@ mod tests {
         let doc_id_5 = DocumentId::from_u128(5);
 
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.1),
-            mock_uuid(4).into() => coi!(mock_uuid(4).into(), 0.5),
-            mock_uuid(7).into() => coi!(mock_uuid(7).into(), 0.8),
+            mock_coiid(0) => coi!(mock_coiid(0), 0.1),
+            mock_coiid(4) => coi!(mock_coiid(4), 0.5),
+            mock_coiid(7) => coi!(mock_coiid(7), 0.8),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
-            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.5),
-            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.7),
-            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
-            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
-            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.2),
+            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
+            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.2),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -683,18 +676,18 @@ mod tests {
         let coi4 = 4.;
         let coi7 = 7.;
         let cois = hashmap! {
-            mock_uuid(1).into() => coi!(mock_uuid(1).into(), coi1),
-            mock_uuid(4).into() => coi!(mock_uuid(4).into(), coi4),
-            mock_uuid(7).into() => coi!(mock_uuid(7).into(), coi7),
+            mock_coiid(1) => coi!(mock_coiid(1), coi1),
+            mock_coiid(4) => coi!(mock_coiid(4), coi4),
+            mock_coiid(7) => coi!(mock_coiid(7), coi7),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(1).into(), 0.2),
-            with_ctx(doc_id_1.clone(), mock_uuid(1).into(), 0.5),
-            with_ctx(doc_id_2.clone(), mock_uuid(1).into(), 0.7),
-            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
-            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
-            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.2),
+            with_ctx(doc_id_0.clone(), mock_coiid(1), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coiid(1), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coiid(1), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
+            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.2),
         ]);
 
         let mut coi_counter = 0;
@@ -767,17 +760,17 @@ mod tests {
 
         let cois = hashmap! {
             // high probability of low values
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 2., 8.),
+            mock_coiid(0) => coi!(mock_coiid(0), 2., 8.),
             // high probability of high values
-            mock_uuid(4).into() => coi!(mock_uuid(4).into(), 8., 2.),
+            mock_coiid(4) => coi!(mock_coiid(4), 8., 2.),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
-            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.5),
-            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.7),
-            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
-            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
+            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
         ]);
 
         let beta_sampler = BetaSampler;
@@ -826,18 +819,18 @@ mod tests {
         let doc_id_5 = DocumentId::from_u128(5);
 
         let cois = hashmap! {
-            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.1),
-            mock_uuid(4).into() => coi!(mock_uuid(4).into(), 0.5),
-            mock_uuid(7).into() => coi!(mock_uuid(7).into(), 0.8),
+            mock_coiid(0) => coi!(mock_coiid(0), 0.1),
+            mock_coiid(4) => coi!(mock_coiid(4), 0.5),
+            mock_coiid(7) => coi!(mock_coiid(7), 0.8),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
-            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.5),
-            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.7),
-            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
-            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
-            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.2),
+            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.2),
+            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.5),
+            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.7),
+            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.4),
+            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.7),
+            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.2),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -872,11 +865,8 @@ mod tests {
 
     #[test]
     fn test_mab_ranking_iter_propagate_errors() {
-        let documents_by_coi = group_by_coi(vec![with_ctx(
-            DocumentId::from_u128(0),
-            mock_uuid(0).into(),
-            0.,
-        )]);
+        let documents_by_coi =
+            group_by_coi(vec![with_ctx(DocumentId::from_u128(0), mock_coiid(0), 0.)]);
 
         let beta_sampler = MockBetaSample::new();
 
@@ -885,7 +875,7 @@ mod tests {
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
 
         let cois = hashmap! {
-            mock_uuid(9).into() => coi!(mock_uuid(9).into(), 0.1),
+            mock_coiid(9) => coi!(mock_coiid(9), 0.1),
         };
         let mab_rerank = MabRankingIter::new(&beta_sampler, &cois, documents_by_coi.clone());
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
@@ -898,7 +888,7 @@ mod tests {
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
 
         let mut documents_by_coi = DocumentsByCoi::new();
-        documents_by_coi.insert(mock_uuid(0).into(), BinaryHeap::new());
+        documents_by_coi.insert(mock_coiid(0), BinaryHeap::new());
         let mab_rerank = MabRankingIter::new(&beta_sampler, &cois, documents_by_coi);
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
     }
@@ -914,19 +904,19 @@ mod tests {
 
         let mut user_interests = UserInterests::new();
         user_interests.positive = vec![
-            coi!(mock_uuid(0).into(), 1.),
-            coi!(mock_uuid(4).into(), 10.),
-            coi!(mock_uuid(7).into(), 100.),
+            coi!(mock_coiid(0), 1.),
+            coi!(mock_coiid(4), 10.),
+            coi!(mock_coiid(7), 100.),
         ];
 
         // we use a small context_value to avoid changing alpha and beta too much
         let documents = vec![
-            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.01),
-            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.02),
-            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.03),
-            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.01),
-            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.02),
-            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.01),
+            with_ctx(doc_id_0.clone(), mock_coiid(0), 0.01),
+            with_ctx(doc_id_1.clone(), mock_coiid(0), 0.02),
+            with_ctx(doc_id_2.clone(), mock_coiid(0), 0.03),
+            with_ctx(doc_id_3.clone(), mock_coiid(4), 0.01),
+            with_ctx(doc_id_4.clone(), mock_coiid(4), 0.02),
+            with_ctx(doc_id_5.clone(), mock_coiid(7), 0.01),
         ];
 
         let mut beta_sampler = MockBetaSample::new();
@@ -958,15 +948,15 @@ mod tests {
             .map(|coi| (coi.id, coi))
             .collect::<HashMap<_, _>>();
 
-        let coi = cois.get(&CoiId(mock_uuid(0))).expect("coi");
+        let coi = cois.get(&mock_coiid(0)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.06);
         assert_approx_eq!(f32, coi.beta, 3.94);
 
-        let coi = cois.get(&CoiId(mock_uuid(4))).expect("coi");
+        let coi = cois.get(&mock_coiid(4)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 10.03);
         assert_approx_eq!(f32, coi.beta, 11.97);
 
-        let coi = cois.get(&CoiId(mock_uuid(7))).expect("coi");
+        let coi = cois.get(&mock_coiid(7)).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 100.01);
         assert_approx_eq!(f32, coi.beta, 100.99);
     }

--- a/xayn-ai/src/mab.rs
+++ b/xayn-ai/src/mab.rs
@@ -273,16 +273,19 @@ where
 mod tests {
     use super::*;
 
-    use crate::data::{
-        document::DocumentId,
-        document_data::{
-            CoiComponent,
-            ContextComponent,
-            DocumentBaseComponent,
-            LtrComponent,
-            QAMBertComponent,
-            SMBertComponent,
+    use crate::{
+        data::{
+            document::DocumentId,
+            document_data::{
+                CoiComponent,
+                ContextComponent,
+                DocumentBaseComponent,
+                LtrComponent,
+                QAMBertComponent,
+                SMBertComponent,
+            },
         },
+        utils::mock_uuid,
     };
     use ndarray::arr1;
 
@@ -341,11 +344,11 @@ mod tests {
         let doc_id_4 = DocumentId::from_u128(4);
 
         let group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), CoiId(0), 0.),
-            with_ctx(doc_id_1.clone(), CoiId(4), 0.),
-            with_ctx(doc_id_2.clone(), CoiId(9), 0.),
-            with_ctx(doc_id_3.clone(), CoiId(4), 0.),
-            with_ctx(doc_id_4.clone(), CoiId(9), 0.),
+            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.),
+            with_ctx(doc_id_1.clone(), mock_uuid(4).into(), 0.),
+            with_ctx(doc_id_2.clone(), mock_uuid(9).into(), 0.),
+            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.),
+            with_ctx(doc_id_4.clone(), mock_uuid(9).into(), 0.),
         ]);
 
         let check_contains = |coi_id: CoiId, docs_id_ok: Vec<DocumentId>| {
@@ -363,9 +366,9 @@ mod tests {
             }
         };
 
-        check_contains(CoiId(0), vec![doc_id_0]);
-        check_contains(CoiId(4), vec![doc_id_1, doc_id_3]);
-        check_contains(CoiId(9), vec![doc_id_2, doc_id_4]);
+        check_contains(mock_uuid(0).into(), vec![doc_id_0]);
+        check_contains(mock_uuid(4).into(), vec![doc_id_1, doc_id_3]);
+        check_contains(mock_uuid(9).into(), vec![doc_id_2, doc_id_4]);
     }
 
     #[test]
@@ -377,14 +380,16 @@ mod tests {
         let doc_id_4 = DocumentId::from_u128(4);
 
         let mut group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), CoiId(0), 0.4),
-            with_ctx(doc_id_1.clone(), CoiId(0), 0.8),
-            with_ctx(doc_id_2.clone(), CoiId(0), 0.2),
-            with_ctx(doc_id_3.clone(), CoiId(0), 0.9),
-            with_ctx(doc_id_4.clone(), CoiId(0), 0.6),
+            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.4),
+            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.8),
+            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.2),
+            with_ctx(doc_id_3.clone(), mock_uuid(0).into(), 0.9),
+            with_ctx(doc_id_4.clone(), mock_uuid(0).into(), 0.6),
         ]);
 
-        let docs = group.remove(&CoiId(0)).expect("document from coi id");
+        let docs = group
+            .remove(&CoiId(mock_uuid(0)))
+            .expect("document from coi id");
         let docs_id: Vec<DocumentId> = docs
             .into_sorted_vec()
             .into_iter()
@@ -406,12 +411,14 @@ mod tests {
         let doc_id_2 = DocumentId::from_u128(2);
 
         let mut group = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), CoiId(0), 0.2),
-            with_ctx(doc_id_1.clone(), CoiId(0), f32::NAN),
-            with_ctx(doc_id_2.clone(), CoiId(0), 0.8),
+            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
+            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), f32::NAN),
+            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.8),
         ]);
 
-        let docs = group.remove(&CoiId(0)).expect("document from coi id");
+        let docs = group
+            .remove(&CoiId(mock_uuid(0)))
+            .expect("document from coi id");
         let docs_id: Vec<DocumentId> = docs
             .into_sorted_vec()
             .into_iter()
@@ -432,8 +439,8 @@ mod tests {
     #[test]
     fn test_update_coi_no_docs() {
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0)),
-            CoiId(1) => coi!(CoiId(1))
+            mock_uuid(0).into() => coi!(mock_uuid(0).into()),
+            mock_uuid(1).into() => coi!(mock_uuid(1).into()),
         };
 
         let new_cois = update_cois(cois.clone(), &[]).expect("cois");
@@ -444,7 +451,7 @@ mod tests {
     fn test_update_coi_no_coi() {
         let error = update_cois(
             HashMap::new(),
-            &[with_ctx(DocumentId::from_u128(0), CoiId(0), 0.)],
+            &[with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.)],
         )
         .expect_err("no coi");
         assert!(matches!(error, MabError::DocumentCoiDoesNotExist));
@@ -453,14 +460,14 @@ mod tests {
     #[test]
     fn test_update_coi_invalid_context_value() {
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.91),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
         };
 
         let error = update_cois(
             cois.clone(),
             &[
-                with_ctx(DocumentId::from_u128(0), CoiId(0), 0.35),
-                with_ctx(DocumentId::from_u128(1), CoiId(0), -1.),
+                with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.35),
+                with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), -1.),
             ],
         )
         .expect_err("invalid context value");
@@ -469,8 +476,8 @@ mod tests {
         let error = update_cois(
             cois,
             &[
-                with_ctx(DocumentId::from_u128(0), CoiId(0), 0.35),
-                with_ctx(DocumentId::from_u128(1), CoiId(0), 1.01),
+                with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.35),
+                with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), 1.01),
             ],
         )
         .expect_err("invalid context value");
@@ -480,17 +487,17 @@ mod tests {
     #[test]
     fn test_update_coi_ok() {
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.91),
-            CoiId(1) => coi!(CoiId(1), 0.27)
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
+            mock_uuid(1).into() => coi!(mock_uuid(1).into(), 0.27)
         };
 
         let cois = update_cois(
             cois,
             &vec![
-                with_ctx(DocumentId::from_u128(0), CoiId(1), 1.),
-                with_ctx(DocumentId::from_u128(1), CoiId(0), 0.35),
-                with_ctx(DocumentId::from_u128(2), CoiId(1), 0.2),
-                with_ctx(DocumentId::from_u128(3), CoiId(0), 0.6),
+                with_ctx(DocumentId::from_u128(0), mock_uuid(1).into(), 1.),
+                with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), 0.35),
+                with_ctx(DocumentId::from_u128(2), mock_uuid(1).into(), 0.2),
+                with_ctx(DocumentId::from_u128(3), mock_uuid(0).into(), 0.6),
             ],
         )
         .expect("cois");
@@ -498,11 +505,11 @@ mod tests {
         // alpha is updated with `alpha += context_value`
         // beta is updated with `beta += (1. - context_value)`
 
-        let coi = cois.get(&CoiId(0)).expect("coi");
+        let coi = cois.get(&CoiId(mock_uuid(0))).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.86);
         assert_approx_eq!(f32, coi.beta, 1.96);
 
-        let coi = cois.get(&CoiId(1)).expect("coi");
+        let coi = cois.get(&CoiId(mock_uuid(1))).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.47);
         assert_approx_eq!(f32, coi.beta, 1.07);
     }
@@ -510,8 +517,8 @@ mod tests {
     #[test]
     fn test_pull_arms_coi_empty() {
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(DocumentId::from_u128(0), CoiId(0), 0.),
-            with_ctx(DocumentId::from_u128(1), CoiId(1), 0.),
+            with_ctx(DocumentId::from_u128(0), mock_uuid(0).into(), 0.),
+            with_ctx(DocumentId::from_u128(1), mock_uuid(1).into(), 0.),
         ]);
 
         let beta_sampler = MockBetaSample::new();
@@ -524,10 +531,14 @@ mod tests {
     #[test]
     fn test_pull_arms_no_coi() {
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.91),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
         };
 
-        let documents_by_coi = group_by_coi(vec![with_ctx(DocumentId::from_u128(1), CoiId(1), 0.)]);
+        let documents_by_coi = group_by_coi(vec![with_ctx(
+            DocumentId::from_u128(1),
+            mock_uuid(1).into(),
+            0.,
+        )]);
 
         let beta_sampler = MockBetaSample::new();
 
@@ -545,7 +556,7 @@ mod tests {
         assert!(matches!(error, MabError::NoDocumentsToPull));
 
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.91),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
         };
 
         let error =
@@ -556,13 +567,13 @@ mod tests {
     #[test]
     fn test_pull_arms_sampler_error() {
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.91),
-            CoiId(1) => coi!(CoiId(1), 0.1),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
+            mock_uuid(1).into() => coi!(mock_uuid(1).into(), 0.1),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(DocumentId::from_u128(1), CoiId(0), 0.),
-            with_ctx(DocumentId::from_u128(2), CoiId(1), 0.),
+            with_ctx(DocumentId::from_u128(1), mock_uuid(0).into(), 0.),
+            with_ctx(DocumentId::from_u128(2), mock_uuid(1).into(), 0.),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -598,13 +609,13 @@ mod tests {
     #[test]
     fn test_pull_arms_malformed_documents_by_coi() {
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.91),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.91),
         };
 
         let mut documents_by_coi = DocumentsByCoi::new();
         // If `group_by_coi` and `pull_arms` are behaving correctly we will never have
         // a coi with an empty heap.
-        documents_by_coi.insert(CoiId(0), BinaryHeap::new());
+        documents_by_coi.insert(mock_uuid(0).into(), BinaryHeap::new());
 
         let mut beta_sampler = MockBetaSample::new();
         beta_sampler.expect_sample().returning(|_, _| Ok(0.2));
@@ -623,18 +634,18 @@ mod tests {
         let doc_id_5 = DocumentId::from_u128(5);
 
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.1),
-            CoiId(4) => coi!(CoiId(4), 0.5),
-            CoiId(7) => coi!(CoiId(7), 0.8),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.1),
+            mock_uuid(4).into() => coi!(mock_uuid(4).into(), 0.5),
+            mock_uuid(7).into() => coi!(mock_uuid(7).into(), 0.8),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), CoiId(0), 0.2),
-            with_ctx(doc_id_1.clone(), CoiId(0), 0.5),
-            with_ctx(doc_id_2.clone(), CoiId(0), 0.7),
-            with_ctx(doc_id_3.clone(), CoiId(4), 0.4),
-            with_ctx(doc_id_4.clone(), CoiId(4), 0.7),
-            with_ctx(doc_id_5.clone(), CoiId(7), 0.2),
+            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
+            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.5),
+            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.7),
+            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
+            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
+            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.2),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -672,18 +683,18 @@ mod tests {
         let coi4 = 4.;
         let coi7 = 7.;
         let cois = hashmap! {
-            CoiId(1) => coi!(CoiId(1), coi1),
-            CoiId(4) => coi!(CoiId(4), coi4),
-            CoiId(7) => coi!(CoiId(7), coi7),
+            mock_uuid(1).into() => coi!(mock_uuid(1).into(), coi1),
+            mock_uuid(4).into() => coi!(mock_uuid(4).into(), coi4),
+            mock_uuid(7).into() => coi!(mock_uuid(7).into(), coi7),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), CoiId(1), 0.2),
-            with_ctx(doc_id_1.clone(), CoiId(1), 0.5),
-            with_ctx(doc_id_2.clone(), CoiId(1), 0.7),
-            with_ctx(doc_id_3.clone(), CoiId(4), 0.4),
-            with_ctx(doc_id_4.clone(), CoiId(4), 0.7),
-            with_ctx(doc_id_5.clone(), CoiId(7), 0.2),
+            with_ctx(doc_id_0.clone(), mock_uuid(1).into(), 0.2),
+            with_ctx(doc_id_1.clone(), mock_uuid(1).into(), 0.5),
+            with_ctx(doc_id_2.clone(), mock_uuid(1).into(), 0.7),
+            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
+            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
+            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.2),
         ]);
 
         let mut coi_counter = 0;
@@ -756,17 +767,17 @@ mod tests {
 
         let cois = hashmap! {
             // high probability of low values
-            CoiId(0) => coi!(CoiId(0), 2., 8.),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 2., 8.),
             // high probability of high values
-            CoiId(4) => coi!(CoiId(4), 8., 2.),
+            mock_uuid(4).into() => coi!(mock_uuid(4).into(), 8., 2.),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), CoiId(0), 0.2),
-            with_ctx(doc_id_1.clone(), CoiId(0), 0.5),
-            with_ctx(doc_id_2.clone(), CoiId(0), 0.7),
-            with_ctx(doc_id_3.clone(), CoiId(4), 0.4),
-            with_ctx(doc_id_4.clone(), CoiId(4), 0.7),
+            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
+            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.5),
+            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.7),
+            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
+            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
         ]);
 
         let beta_sampler = BetaSampler;
@@ -815,18 +826,18 @@ mod tests {
         let doc_id_5 = DocumentId::from_u128(5);
 
         let cois = hashmap! {
-            CoiId(0) => coi!(CoiId(0), 0.1),
-            CoiId(4) => coi!(CoiId(4), 0.5),
-            CoiId(7) => coi!(CoiId(7), 0.8),
+            mock_uuid(0).into() => coi!(mock_uuid(0).into(), 0.1),
+            mock_uuid(4).into() => coi!(mock_uuid(4).into(), 0.5),
+            mock_uuid(7).into() => coi!(mock_uuid(7).into(), 0.8),
         };
 
         let documents_by_coi = group_by_coi(vec![
-            with_ctx(doc_id_0.clone(), CoiId(0), 0.2),
-            with_ctx(doc_id_1.clone(), CoiId(0), 0.5),
-            with_ctx(doc_id_2.clone(), CoiId(0), 0.7),
-            with_ctx(doc_id_3.clone(), CoiId(4), 0.4),
-            with_ctx(doc_id_4.clone(), CoiId(4), 0.7),
-            with_ctx(doc_id_5.clone(), CoiId(7), 0.2),
+            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.2),
+            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.5),
+            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.7),
+            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.4),
+            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.7),
+            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.2),
         ]);
 
         let mut beta_sampler = MockBetaSample::new();
@@ -861,7 +872,11 @@ mod tests {
 
     #[test]
     fn test_mab_ranking_iter_propagate_errors() {
-        let documents_by_coi = group_by_coi(vec![with_ctx(DocumentId::from_u128(0), CoiId(0), 0.)]);
+        let documents_by_coi = group_by_coi(vec![with_ctx(
+            DocumentId::from_u128(0),
+            mock_uuid(0).into(),
+            0.,
+        )]);
 
         let beta_sampler = MockBetaSample::new();
 
@@ -870,7 +885,7 @@ mod tests {
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
 
         let cois = hashmap! {
-            CoiId(9) => coi!(CoiId(9), 0.1),
+            mock_uuid(9).into() => coi!(mock_uuid(9).into(), 0.1),
         };
         let mab_rerank = MabRankingIter::new(&beta_sampler, &cois, documents_by_coi.clone());
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
@@ -883,7 +898,7 @@ mod tests {
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
 
         let mut documents_by_coi = DocumentsByCoi::new();
-        documents_by_coi.insert(CoiId(0), BinaryHeap::new());
+        documents_by_coi.insert(mock_uuid(0).into(), BinaryHeap::new());
         let mab_rerank = MabRankingIter::new(&beta_sampler, &cois, documents_by_coi);
         assert!(mab_rerank.collect::<Result<Vec<_>, _>>().is_err());
     }
@@ -899,19 +914,19 @@ mod tests {
 
         let mut user_interests = UserInterests::new();
         user_interests.positive = vec![
-            coi!(CoiId(0), 1.),
-            coi!(CoiId(4), 10.),
-            coi!(CoiId(7), 100.),
+            coi!(mock_uuid(0).into(), 1.),
+            coi!(mock_uuid(4).into(), 10.),
+            coi!(mock_uuid(7).into(), 100.),
         ];
 
         // we use a small context_value to avoid changing alpha and beta too much
         let documents = vec![
-            with_ctx(doc_id_0.clone(), CoiId(0), 0.01),
-            with_ctx(doc_id_1.clone(), CoiId(0), 0.02),
-            with_ctx(doc_id_2.clone(), CoiId(0), 0.03),
-            with_ctx(doc_id_3.clone(), CoiId(4), 0.01),
-            with_ctx(doc_id_4.clone(), CoiId(4), 0.02),
-            with_ctx(doc_id_5.clone(), CoiId(7), 0.01),
+            with_ctx(doc_id_0.clone(), mock_uuid(0).into(), 0.01),
+            with_ctx(doc_id_1.clone(), mock_uuid(0).into(), 0.02),
+            with_ctx(doc_id_2.clone(), mock_uuid(0).into(), 0.03),
+            with_ctx(doc_id_3.clone(), mock_uuid(4).into(), 0.01),
+            with_ctx(doc_id_4.clone(), mock_uuid(4).into(), 0.02),
+            with_ctx(doc_id_5.clone(), mock_uuid(7).into(), 0.01),
         ];
 
         let mut beta_sampler = MockBetaSample::new();
@@ -943,15 +958,15 @@ mod tests {
             .map(|coi| (coi.id, coi))
             .collect::<HashMap<_, _>>();
 
-        let coi = cois.get(&CoiId(0)).expect("coi");
+        let coi = cois.get(&CoiId(mock_uuid(0))).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 1.06);
         assert_approx_eq!(f32, coi.beta, 3.94);
 
-        let coi = cois.get(&CoiId(4)).expect("coi");
+        let coi = cois.get(&CoiId(mock_uuid(4))).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 10.03);
         assert_approx_eq!(f32, coi.beta, 11.97);
 
-        let coi = cois.get(&CoiId(7)).expect("coi");
+        let coi = cois.get(&CoiId(mock_uuid(7))).expect("coi");
         assert_approx_eq!(f32, coi.alpha, 100.01);
         assert_approx_eq!(f32, coi.beta, 100.99);
     }

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -63,7 +63,7 @@ impl UserInterests {
 
 /// Appends `remotes` to `locals`.
 ///
-/// Remote CoIs with ids clashing with any of the local CoIs are removed in the process.
+/// Remote CoIs with ids clashing with any of the local CoIs are removed.
 fn append_cois<C: CoiPoint>(locals: &mut Vec<C>, remotes: &mut Vec<C>) {
     remotes.retain(|rem| !locals.iter().any(|loc| loc.id() == rem.id()));
     locals.append(remotes);

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -79,13 +79,13 @@ where
     let max_local_id = locals.iter().map(|coi| coi.id().0).max().unwrap_or(0);
     remotes
         .iter_mut()
-        .for_each(|coi| coi.set_id(max_local_id + coi.id().0));
+        .for_each(|coi| coi.set_id((max_local_id + coi.id().0).into()));
 
     locals.append(remotes);
 }
 
 fn reassign_coi_ids(cois: &mut Vec<impl CoiPoint>) {
     for (id, coi) in izip!(1..cois.len() + 1, cois) {
-        coi.set_id(id)
+        coi.set_id(id.into())
     }
 }

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -4,7 +4,6 @@ use crate::{
     error::Error,
 };
 use anyhow::bail;
-use itertools::izip;
 use serde::{Deserialize, Serialize};
 
 const CURRENT_SCHEMA_VERSION: u8 = 0;
@@ -51,41 +50,21 @@ impl SyncData {
 
         reduce_cois(&mut self.user_interests.positive);
         reduce_cois(&mut self.user_interests.negative);
-
-        self.user_interests.reassign_ids();
     }
 }
 
 impl UserInterests {
     /// Moves all user interests of `other` into `Self`.
     pub(crate) fn append(&mut self, mut other: Self) {
-        // TODO drop dupes in other
         append_cois(&mut self.positive, &mut other.positive);
         append_cois(&mut self.negative, &mut other.negative);
     }
-
-    /// Re-assigns CoI ids for normalization.
-    pub(crate) fn reassign_ids(&mut self) {
-        reassign_coi_ids(&mut self.positive);
-        reassign_coi_ids(&mut self.negative);
-    }
 }
 
-fn append_cois<C>(locals: &mut Vec<C>, remotes: &mut Vec<C>)
-where
-    C: CoiPoint,
-{
-    // shift remote ids to avoid clashes with local ids
-    let max_local_id = locals.iter().map(|coi| coi.id().0).max().unwrap_or(0);
-    remotes
-        .iter_mut()
-        .for_each(|coi| coi.set_id((max_local_id + coi.id().0).into()));
-
+/// Appends `remotes` to `locals`.
+///
+/// Remote CoIs with ids clashing with any of the local CoIs are removed in the process.
+fn append_cois<C: CoiPoint>(locals: &mut Vec<C>, remotes: &mut Vec<C>) {
+    remotes.retain(|rem| !locals.iter().any(|loc| loc.id() == rem.id()));
     locals.append(remotes);
-}
-
-fn reassign_coi_ids(cois: &mut Vec<impl CoiPoint>) {
-    for (id, coi) in izip!(1..cois.len() + 1, cois) {
-        coi.set_id(id.into())
-    }
 }

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     embedding::utils::Embedding,
     reranker::systems::{CoiSystemData, SMBertSystem},
-    utils::mock_coiid,
+    utils::mock_coi_id,
     Document,
     DocumentHistory,
     DocumentId,
@@ -76,7 +76,7 @@ fn cois_from_words<CP: CoiPoint>(titles: &[&str], smbert: impl SMBertSystem) -> 
         .unwrap()
         .into_iter()
         .enumerate()
-        .map(|(id, doc)| CP::new(mock_coiid(id), doc.smbert.embedding))
+        .map(|(id, doc)| CP::new(mock_coi_id(id), doc.smbert.embedding))
         .collect()
 }
 
@@ -116,7 +116,7 @@ pub(crate) fn data_with_mab(
             smbert: SMBertComponent { embedding },
             qambert: QAMBertComponent { similarity: 0.5 },
             coi: CoiComponent {
-                id: mock_coiid(1),
+                id: mock_coi_id(1),
                 pos_distance: 0.1,
                 neg_distance: 0.1,
             },

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -18,13 +18,13 @@ use crate::{
             QAMBertComponent,
             SMBertComponent,
         },
-        CoiId,
         CoiPoint,
         NegativeCoi,
         PositiveCoi,
     },
     embedding::utils::Embedding,
     reranker::systems::{CoiSystemData, SMBertSystem},
+    utils::mock_uuid,
     Document,
     DocumentHistory,
     DocumentId,
@@ -76,7 +76,7 @@ fn cois_from_words<CP: CoiPoint>(titles: &[&str], smbert: impl SMBertSystem) -> 
         .unwrap()
         .into_iter()
         .enumerate()
-        .map(|(id, doc)| CP::new(id, doc.smbert.embedding))
+        .map(|(id, doc)| CP::new(mock_uuid(id).into(), doc.smbert.embedding))
         .collect()
 }
 
@@ -116,7 +116,7 @@ pub(crate) fn data_with_mab(
             smbert: SMBertComponent { embedding },
             qambert: QAMBertComponent { similarity: 0.5 },
             coi: CoiComponent {
-                id: CoiId(1),
+                id: mock_uuid(1).into(),
                 pos_distance: 0.1,
                 neg_distance: 0.1,
             },

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     embedding::utils::Embedding,
     reranker::systems::{CoiSystemData, SMBertSystem},
-    utils::mock_uuid,
+    utils::mock_coiid,
     Document,
     DocumentHistory,
     DocumentId,
@@ -76,7 +76,7 @@ fn cois_from_words<CP: CoiPoint>(titles: &[&str], smbert: impl SMBertSystem) -> 
         .unwrap()
         .into_iter()
         .enumerate()
-        .map(|(id, doc)| CP::new(mock_uuid(id).into(), doc.smbert.embedding))
+        .map(|(id, doc)| CP::new(mock_coiid(id), doc.smbert.embedding))
         .collect()
 }
 
@@ -116,7 +116,7 @@ pub(crate) fn data_with_mab(
             smbert: SMBertComponent { embedding },
             qambert: QAMBertComponent { similarity: 0.5 },
             coi: CoiComponent {
-                id: mock_uuid(1).into(),
+                id: mock_coiid(1),
                 pos_distance: 0.1,
                 neg_distance: 0.1,
             },

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -80,7 +80,7 @@ pub(crate) fn mock_uuid(sub_id: usize) -> uuid::Uuid {
 
 /// Creates a CoI id from a mock UUID.
 #[cfg(test)]
-pub(crate) fn mock_coiid(sub_id: usize) -> crate::CoiId {
+pub(crate) fn mock_coi_id(sub_id: usize) -> crate::CoiId {
     mock_uuid(sub_id).into()
 }
 

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -78,6 +78,12 @@ pub(crate) fn mock_uuid(sub_id: usize) -> uuid::Uuid {
     uuid::Uuid::from_u128(BASE_UUID | (sub_id as u128))
 }
 
+/// Creates a CoI id from a mock UUID.
+#[cfg(test)]
+pub(crate) fn mock_coiid(sub_id: usize) -> crate::CoiId {
+    mock_uuid(sub_id).into()
+}
+
 /// Compares two "things" with approximate equality.
 ///
 /// # Examples


### PR DESCRIPTION
**Summary**

a follow up to #143 for synchronization to support global consistency of CoI ids. 

- refactors `CoiId(usize)` to `CoiId(Uuid)`, and various functions (e.g. methods of `CoiPoint`) to hide the underlying type.
- a new id is now assigned to a CoI whenever it is updated locally.
- duplicate CoIs (indicated by clashing ids) are removed during synchronization.