### PR TITLE
TY-1897 expose sync methods to ffi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- AI data is synchronizable between devices via the new functions `syncdata_bytes` and `synchronize`.
 - Outsourcing of ai assets. The assets are no longer part of the library. See [#94](https://github.com/xaynetwork/xayn_ai/pull/94) for more information about the API changes.
 - `XaynAi.rerank` takes as parameter `RerankMode` that allows to specify if we are reranking news or results from a search.
 - Assets for releases on the `staging` branch are uploaded to a S3 bucket (`https://xayn_ai_staging_assets.s3-de-central.profitbricks.com`).

--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -69,7 +69,7 @@ class XaynAi {
   Uint8List syncdataBytes() => throw UnsupportedError('Unsupported platform.');
 
   /// Synchronizes the internal data of the reranker with another.
-  void synchronize([Uint8List? serialized]) =>
+  void synchronize(Uint8List serialized) =>
       throw UnsupportedError('Unsupported platform');
 
   /// Frees the memory.

--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -65,6 +65,13 @@ class XaynAi {
   /// Retrieves the analytics which were collected in the penultimate reranking.
   Analytics? analytics() => throw UnsupportedError('Unsupported platform.');
 
+  /// Serializes the synchronizable data of the reranker.
+  Uint8List syncdataBytes() => throw UnsupportedError('Unsupported platform.');
+
+  /// Synchronizes the internal data of the reranker with another.
+  void synchronize([Uint8List? serialized]) =>
+      throw UnsupportedError('Unsupported platform');
+
   /// Frees the memory.
   void free() => throw UnsupportedError('Unsupported platform.');
 }

--- a/bindings/dart/lib/src/common/result/error.dart
+++ b/bindings/dart/lib/src/common/result/error.dart
@@ -93,6 +93,18 @@ enum Code {
 
   /// Deserialization of document collection error.
   documentsDeserialization,
+
+  /// Deserialization of rerank mode error.
+  rerankModeDeserialization,
+
+  /// Serialization of sync data error.
+  syncDataSerialization,
+
+  /// Synchronization error.
+  synchronization,
+
+  /// Sync data bytes null pointer error.
+  syncDataBytesPointer,
 }
 
 extension CodeToInt on Code {
@@ -159,6 +171,14 @@ extension CodeToInt on Code {
         return CCode.HistoriesDeserialization;
       case Code.documentsDeserialization:
         return CCode.DocumentsDeserialization;
+      case Code.rerankModeDeserialization:
+        return CCode.RerankModeDeserialization;
+      case Code.syncDataSerialization:
+        return CCode.SyncDataSerialization;
+      case Code.synchronization:
+        return CCode.Synchronization;
+      case Code.syncDataBytesPointer:
+        return CCode.SyncDataBytesPointer;
       default:
         throw UnsupportedError('Undefined enum variant.');
     }
@@ -229,6 +249,14 @@ extension IntToCode on int {
         return Code.historiesDeserialization;
       case CCode.DocumentsDeserialization:
         return Code.documentsDeserialization;
+      case CCode.RerankModeDeserialization:
+        return Code.rerankModeDeserialization;
+      case CCode.SyncDataSerialization:
+        return Code.syncDataSerialization;
+      case CCode.Synchronization:
+        return Code.synchronization;
+      case CCode.SyncDataBytesPointer:
+        return Code.syncDataBytesPointer;
       default:
         throw UnsupportedError('Undefined enum variant.');
     }

--- a/bindings/dart/lib/src/mobile/reranker/ai.dart
+++ b/bindings/dart/lib/src/mobile/reranker/ai.dart
@@ -163,6 +163,41 @@ class XaynAi implements common.XaynAi {
     }
   }
 
+  /// Serializes the synchronizable data of the reranker.
+  @override
+  Uint8List syncdataBytes() {
+    final error = XaynAiError();
+
+    final bytes = Bytes(ffi.xaynai_syncdata_bytes(_ai, error.ptr));
+    try {
+      if (error.isError()) {
+        throw error.toException();
+      }
+      return bytes.toList();
+    } finally {
+      error.free();
+      bytes.free();
+    }
+  }
+
+  /// Synchronizes the internal data of the reranker with another.
+  @override
+  void synchronize([Uint8List? serialized]) {
+    Bytes? bytes;
+    final error = XaynAiError();
+
+    try {
+      bytes = Bytes.fromList(serialized ?? Uint8List(0));
+      ffi.xaynai_synchronize(_ai, bytes.ptr, error.ptr);
+      if (error.isError()) {
+        throw error.toException();
+      }
+    } finally {
+      bytes?.free();
+      error.free();
+    }
+  }
+
   /// Frees the memory.
   @override
   void free() {

--- a/bindings/dart/lib/src/mobile/reranker/ai.dart
+++ b/bindings/dart/lib/src/mobile/reranker/ai.dart
@@ -182,12 +182,12 @@ class XaynAi implements common.XaynAi {
 
   /// Synchronizes the internal data of the reranker with another.
   @override
-  void synchronize([Uint8List? serialized]) {
+  void synchronize(Uint8List serialized) {
     Bytes? bytes;
     final error = XaynAiError();
 
     try {
-      bytes = Bytes.fromList(serialized ?? Uint8List(0));
+      bytes = Bytes.fromList(serialized);
       ffi.xaynai_synchronize(_ai, bytes.ptr, error.ptr);
       if (error.isError()) {
         throw error.toException();

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -55,7 +55,7 @@ class _XaynAi {
 
   external Uint8List syncdataBytes();
 
-  external void synchronize([Uint8List? serialized]);
+  external void synchronize(Uint8List serialized);
 
   external void free();
 }
@@ -209,7 +209,7 @@ class XaynAi implements common.XaynAi {
   /// valid state can be restored with a previously serialized reranker database obtained from
   /// [`serialize()`].
   @override
-  void synchronize([Uint8List? serialized]) {
+  void synchronize(Uint8List serialized) {
     if (_ai == null) {
       throw StateError('XaynAi was already freed');
     }

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -53,6 +53,10 @@ class _XaynAi {
 
   external JsAnalytics? analytics();
 
+  external Uint8List syncdataBytes();
+
+  external void synchronize([Uint8List? serialized]);
+
   external void free();
 }
 
@@ -172,6 +176,48 @@ class XaynAi implements common.XaynAi {
 
     try {
       return _ai!.analytics()?.toAnalytics();
+    } on RuntimeError catch (error) {
+      _ai = null;
+      throw error.toException();
+    }
+  }
+
+  /// Serializes the synchronizable data of the reranker.
+  ///
+  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// valid state can be restored with a previously serialized reranker database obtained from
+  /// [`serialize()`].
+  @override
+  Uint8List syncdataBytes() {
+    if (_ai == null) {
+      throw StateError('XaynAi was already freed');
+    }
+
+    try {
+      return _ai!.syncdataBytes();
+    } on XaynAiError catch (error) {
+      throw error.toException();
+    } on RuntimeError catch (error) {
+      _ai = null;
+      throw error.toException();
+    }
+  }
+
+  /// Synchronizes the internal data of the reranker with another.
+  ///
+  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// valid state can be restored with a previously serialized reranker database obtained from
+  /// [`serialize()`].
+  @override
+  void synchronize([Uint8List? serialized]) {
+    if (_ai == null) {
+      throw StateError('XaynAi was already freed');
+    }
+
+    try {
+      _ai!.synchronize(serialized);
+    } on XaynAiError catch (error) {
+      throw error.toException();
     } on RuntimeError catch (error) {
       _ai = null;
       throw error.toException();

--- a/bindings/dart/test/mobile/reranker/ai_test.dart
+++ b/bindings/dart/test/mobile/reranker/ai_test.dart
@@ -118,5 +118,36 @@ void main() {
         throwsXaynAiException(Code.rerankerDeserialization),
       );
     });
+
+    test('serialize syncdata', () async {
+      final ai = await XaynAi.create(mkSetupData(
+          smbertVocab, smbertModel, qambertVocab, qambertModel, ltrModel));
+
+      expect(ai.syncdataBytes(), isNot(isEmpty));
+
+      ai.free();
+    });
+
+    test('synchronize empty', () async {
+      final ai = await XaynAi.create(mkSetupData(
+          smbertVocab, smbertModel, qambertVocab, qambertModel, ltrModel));
+      expect(
+        () => ai.synchronize(Uint8List(0)),
+        throwsXaynAiException(Code.synchronization),
+      );
+
+      ai.free();
+    });
+
+    test('synchronize invalid', () async {
+      final ai = await XaynAi.create(mkSetupData(
+          smbertVocab, smbertModel, qambertVocab, qambertModel, ltrModel));
+      expect(
+        () => ai.synchronize(Uint8List.fromList([255])),
+        throwsXaynAiException(Code.synchronization),
+      );
+
+      ai.free();
+    });
   });
 }

--- a/xayn-ai-ffi-c/src/reranker/ai.rs
+++ b/xayn-ai-ffi-c/src/reranker/ai.rs
@@ -490,6 +490,7 @@ mod tests {
     }
 
     impl TestSyncdata {
+        #[allow(clippy::unnecessary_wraps)]
         fn as_ptr(&self) -> Option<&CBytes> {
             Some(&self.0)
         }

--- a/xayn-ai-ffi-c/src/reranker/ai.rs
+++ b/xayn-ai-ffi-c/src/reranker/ai.rs
@@ -334,16 +334,6 @@ pub unsafe extern "C" fn xaynai_analytics(
     call_with_result(analytics, error)
 }
 
-/// Frees the memory of the Xayn AI.
-///
-/// # Safety
-/// The behavior is undefined if:
-/// - A non-null `xaynai` doesn't point to memory allocated by [`xaynai_new()`].
-/// - A non-null `xaynai` is freed more than once.
-/// - A non-null `xaynai` is accessed after being freed.
-#[no_mangle]
-pub unsafe extern "C" fn xaynai_drop(_xaynai: Option<Box<CXaynAi>>) {}
-
 /// Serializes the synchronizable data of the reranker.
 ///
 /// # Errors
@@ -396,6 +386,16 @@ pub unsafe extern "C" fn xaynai_synchronize(
 
     call_with_result(synchronize, error);
 }
+
+/// Frees the memory of the Xayn AI.
+///
+/// # Safety
+/// The behavior is undefined if:
+/// - A non-null `xaynai` doesn't point to memory allocated by [`xaynai_new()`].
+/// - A non-null `xaynai` is freed more than once.
+/// - A non-null `xaynai` is accessed after being freed.
+#[no_mangle]
+pub unsafe extern "C" fn xaynai_drop(_xaynai: Option<Box<CXaynAi>>) {}
 
 #[cfg(test)]
 mod tests {

--- a/xayn-ai-ffi-wasm/src/ai.rs
+++ b/xayn-ai-ffi-wasm/src/ai.rs
@@ -131,6 +131,38 @@ impl WXaynAi {
     pub fn analytics(&self) -> JsValue {
         JsValue::from_serde(&self.0.analytics()).expect("Failed to serialize the analytics")
     }
+
+    /// Serializes the synchronizable data of the reranker.
+    ///
+    /// # Errors
+    ///
+    /// - The serialization of the synchronizable data fails.
+    pub fn syncdata_bytes(&self) -> Result<Uint8Array, JsValue> {
+        self.0
+            .syncdata_bytes()
+            .map(|bytes| bytes.as_slice().into())
+            .map_err(|cause| {
+                CCode::SyncDataSerialization
+                    .with_context(format!("Failed to serialize sync data: {}", cause))
+            })
+            .into_js_result()
+    }
+
+    /// Synchronizes the internal data of the reranker with another.
+    ///
+    /// # Errors
+    ///
+    /// - The serialized data `bytes` is invalid.
+    /// - The synchronization failed.
+    pub fn synchronize(&mut self, bytes: &[u8]) -> Result<(), JsValue> {
+        self.0
+            .synchronize(bytes)
+            .map_err(|cause| {
+                CCode::Synchronization
+                    .with_context(format!("Failed to synchronize data: {}", cause))
+            })
+            .into_js_result()
+    }
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]
@@ -373,6 +405,21 @@ mod tests {
         .unwrap();
         let analytics = xaynai.analytics();
         assert!(analytics.is_null());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_syncdata_bytes() {
+        let xaynai = WXaynAi::new(
+            SMBERT_VOCAB,
+            SMBERT_MODEL,
+            QAMBERT_VOCAB,
+            QAMBERT_MODEL,
+            LTR_MODEL,
+            None,
+        )
+        .unwrap();
+        let syncdata = xaynai.syncdata_bytes();
+        assert!(syncdata.is_ok())
     }
 
     #[wasm_bindgen_test]

--- a/xayn-ai-ffi-wasm/src/ai.rs
+++ b/xayn-ai-ffi-wasm/src/ai.rs
@@ -419,7 +419,63 @@ mod tests {
         )
         .unwrap();
         let syncdata = xaynai.syncdata_bytes();
-        assert!(syncdata.is_ok())
+        assert!(syncdata.is_ok());
+        assert!(!syncdata.unwrap().to_vec().is_empty());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_synchronize() {
+        let mut xaynai = WXaynAi::new(
+            SMBERT_VOCAB,
+            SMBERT_MODEL,
+            QAMBERT_VOCAB,
+            QAMBERT_MODEL,
+            LTR_MODEL,
+            None,
+        )
+        .unwrap();
+        let syncdata = &[0; 17];
+        assert!(xaynai.synchronize(syncdata).is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_bytes_empty_synchronize() {
+        let mut xaynai = WXaynAi::new(
+            SMBERT_VOCAB,
+            SMBERT_MODEL,
+            QAMBERT_VOCAB,
+            QAMBERT_MODEL,
+            LTR_MODEL,
+            None,
+        )
+        .unwrap();
+        let synchronized = xaynai.synchronize(&[]);
+        assert!(synchronized.is_err());
+        let error = synchronized.unwrap_err().into_serde::<Error>().unwrap();
+        assert_eq!(error.code(), CCode::Synchronization);
+        assert!(error
+            .message()
+            .contains("Failed to synchronize data: Empty serialized data."));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_bytes_invalid_synchronize() {
+        let mut xaynai = WXaynAi::new(
+            SMBERT_VOCAB,
+            SMBERT_MODEL,
+            QAMBERT_VOCAB,
+            QAMBERT_MODEL,
+            LTR_MODEL,
+            None,
+        )
+        .unwrap();
+        let synchronized = xaynai.synchronize(&[u8::MAX]);
+        assert!(synchronized.is_err());
+        let error = synchronized.unwrap_err().into_serde::<Error>().unwrap();
+        assert_eq!(error.code(), CCode::Synchronization);
+        assert!(error
+            .message()
+            .contains("Failed to synchronize data: Unsupported serialized data."));
     }
 
     #[wasm_bindgen_test]
@@ -695,7 +751,7 @@ mod tests {
             QAMBERT_VOCAB,
             QAMBERT_MODEL,
             LTR_MODEL,
-            Some(Box::new([2, 3, 4])),
+            Some(Box::new([u8::MAX])),
         )
         .unwrap_err()
         .into_serde::<Error>()

--- a/xayn-ai-ffi/src/error.rs
+++ b/xayn-ai-ffi/src/error.rs
@@ -80,6 +80,8 @@ pub enum CCode {
     SyncDataSerialization,
     /// Synchronization error.
     Synchronization,
+    /// Sync data bytes null pointer error.
+    SyncDataBytesPointer,
 }
 
 impl CCode {

--- a/xayn-ai-ffi/src/error.rs
+++ b/xayn-ai-ffi/src/error.rs
@@ -76,6 +76,10 @@ pub enum CCode {
     DocumentsDeserialization,
     /// Deserialization of rerank mode error.
     RerankModeDeserialization,
+    /// Serialization of sync data error.
+    SyncDataSerialization,
+    /// Synchronization error.
+    Synchronization,
 }
 
 impl CCode {

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -227,13 +227,12 @@ where
         self.common_systems.database().serialize(&self.data)
     }
 
-    #[allow(dead_code)] // TEMP
     /// Create a byte representation of the synchronizable data.
-    pub(crate) fn sync_bytes(&self) -> Result<Vec<u8>, Error> {
+    pub(crate) fn syncdata_bytes(&self) -> Result<Vec<u8>, Error> {
         self.data.sync_data.serialize()
     }
 
-    #[allow(dead_code)] // TEMP
+    /// Synchronizes internal data with the `SyncData` given in serialized form.
     pub(crate) fn synchronize(&mut self, bytes: &[u8]) -> Result<(), Error> {
         let remote_data = SyncData::deserialize(bytes)?;
         self.data.sync_data.synchronize(remote_data);

--- a/xayn-ai/src/reranker/public.rs
+++ b/xayn-ai/src/reranker/public.rs
@@ -98,6 +98,14 @@ impl Reranker {
     pub fn serialize(&self) -> Result<Vec<u8>, Error> {
         self.0.serialize()
     }
+
+    pub fn syncdata_bytes(&self) -> Result<Vec<u8>, Error> {
+        self.0.syncdata_bytes()
+    }
+
+    pub fn synchronize(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        self.0.synchronize(bytes)
+    }
 }
 
 pub struct Builder<SV, SM, QAV, QAM, DM> {

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -18,6 +18,10 @@ pub(crate) struct SyncData {
 impl SyncData {
     /// Deserializes a `SyncData` from `bytes`.
     pub(crate) fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
+        if bytes.is_empty() {
+            bail!("Empty serialized data.");
+        }
+
         // version encoded in first byte
         let version = bytes[0];
         if version != CURRENT_SCHEMA_VERSION {


### PR DESCRIPTION
**Summary**

previous related: #143, #152.
- exposes the functions `syncdata_bytes`, `synchronize` to ffi layers and dart binding.
- corresponding tests.
- handles panic when empty passed to `synchronize` (see `sync.rs`).
- updates changelog.