### PR TITLE
TY-1978 update metadata

### DIFF
--- a/bindings/dart/example/lib/data_provider/mobile.dart
+++ b/bindings/dart/example/lib/data_provider/mobile.dart
@@ -21,8 +21,8 @@ Future<SetupData> getInputData() async {
 
   final paths = <AssetType, String>{};
   for (var asset in getAssets().entries) {
-    final path = await _getData(
-        baseDiskPath.path, asset.value.suffix, asset.value.checksumAsHex);
+    final path = await _getData(baseDiskPath.path, asset.value.urlSuffix,
+        asset.value.checksum.checksumAsHex);
     paths.putIfAbsent(asset.key, () => path);
   }
 

--- a/bindings/dart/example/lib/data_provider/web.dart
+++ b/bindings/dart/example/lib/data_provider/web.dart
@@ -14,8 +14,8 @@ Future<SetupData> getInputData() async {
   final fetched = <AssetType, Uint8List>{};
 
   for (var asset in getAssets().entries) {
-    final path = joinPaths([_baseAssetUrl, asset.value.suffix]);
-    final data = await _fetchAsset(path, asset.value.checksumSri);
+    final path = joinPaths([_baseAssetUrl, asset.value.urlSuffix]);
+    final data = await _fetchAsset(path, asset.value.checksum.checksumSri);
     fetched.putIfAbsent(asset.key, () => data);
   }
 

--- a/bindings/dart/lib/src/common/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/common/reranker/data_provider.dart
@@ -3,16 +3,55 @@ import 'package:hex/hex.dart' show HEX;
 
 part 'assets.dart';
 
+/// An asset consists of an URL suffix, a [`Checksum`] and optionally
+/// a list of [`Fragment`]s.
+///
+/// The base URL (defined by the caller) concatenated with the URL suffix
+/// creates the URL to fetch an asset.
+///
+/// The checksum is the hash of an asset and can be used to verify its
+/// integrity after it has been fetched.
+///
+/// In order to keep larger assets in the http cache of a browser,
+/// an asset might be split into multiple fragments.
+///
+/// Implementation details for fetching assets:
+///
+/// If the list of fragments is empty, the caller may use the URL suffix of the
+/// asset to fetch it.
+///
+/// If the list of fragments is not empty, the caller must fetch each
+/// [`Fragment`] in the fragments list and concatenate them in the same order
+/// as they are defined in the fragments list in order to reassemble the asset.
+/// Using the URL suffix of the [`Asset`] is not allowed. The checksum of the
+/// [`Asset`] can be used to to verify its integrity after it has been
+/// reassembled.
 class Asset {
-  final String suffix;
+  final String urlSuffix;
+  final Checksum checksum;
+  final List<Fragment> fragments;
+
+  Asset(this.urlSuffix, this.checksum, this.fragments);
+}
+
+/// A fragment of an asset.
+class Fragment {
+  final String urlSuffix;
+  final Checksum checksum;
+
+  Fragment(this.urlSuffix, this.checksum);
+}
+
+/// The checksum an asset/fragment.
+class Checksum {
   final String _checksum;
 
-  Asset(this.suffix, this._checksum);
+  Checksum(this._checksum);
 
-  /// Returns the sha256 hash (hex-encoded) of the asset.
+  /// Returns the sha256 hash (hex-encoded) of the asset/fragment.
   String get checksumAsHex => _checksum;
 
-  /// Returns the SRI hash of the asset.
+  /// Returns the SRI hash of the asset/fragment.
   /// https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#tools_for_generating_sri_hashes
   String get checksumSri => 'sha256-' + base64.encode(HEX.decode(_checksum));
 }
@@ -22,7 +61,7 @@ Map<AssetType, Asset> getAssets() {
   throw UnsupportedError('Unsupported platform.');
 }
 
-/// Data that can be used to initialize [`XaynAi`].
+/// Data that is required to initialize [`XaynAi`].
 class SetupData {
   SetupData(Map<AssetType, dynamic> assets);
 }

--- a/bindings/dart/lib/src/common/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/common/reranker/data_provider.dart
@@ -17,7 +17,7 @@ part 'assets.dart';
 ///
 /// Implementation details for fetching assets:
 ///
-/// If the list of fragments is empty, the caller may use the URL suffix of the
+/// If the list of fragments is empty, the caller must use the URL suffix of the
 /// asset to fetch it.
 ///
 /// If the list of fragments is not empty, the caller must fetch each

--- a/bindings/dart/lib/src/mobile/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/mobile/reranker/data_provider.dart
@@ -8,7 +8,7 @@ Map<common.AssetType, common.Asset> getAssets() {
       .where((asset) => wasmAssets.contains(asset.key) == false));
 }
 
-/// Data that can be used to initialize [`XaynAi`].
+/// Data that is required to initialize [`XaynAi`].
 class SetupData implements common.SetupData {
   late String smbertVocab;
   late String smbertModel;

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -8,7 +8,7 @@ Map<common.AssetType, common.Asset> getAssets() {
   return common.baseAssets;
 }
 
-/// Data that can be used to initialize [`XaynAi`].
+/// Data that is required to initialize [`XaynAi`].
 class SetupData implements common.SetupData {
   late Uint8List smbertVocab;
   late Uint8List smbertModel;

--- a/data/asset_templates/assets.dart.tmpl
+++ b/data/asset_templates/assets.dart.tmpl
@@ -8,7 +8,7 @@ part of 'data_provider.dart';
 /// To calculate the checksum run 'shasum -a 256 vocab.txt'.
 final baseAssets = <AssetType, Asset>{
   {{- range (ds "assets").assets }}
-  AssetType.{{.name}}: Asset('{{.suffix}}', '{{.checksum}}'),
+  AssetType.{{.name}}: Asset('{{.suffix}}', Checksum('{{.checksum}}'), [Fragment('{{.suffix}}', Checksum('{{.checksum}}'))]),
   {{- end}}
 };
 


### PR DESCRIPTION
**Ticket**

- [TY-1978]

**Summary**

- renamed `suffix` to `urlSuffix`
- moved the checksum method into a new `Checksum` class
- added a `fragments` field to the `Asset` class
  - each `Fragment` consists of a `checksum` and a `urlSuffix`
- updated the example

[TY-1978]: https://xainag.atlassian.net/browse/TY-1978