### PR TITLE
TY-1991 parallelization benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ dependencies = [
  "indicatif",
  "ndarray",
  "onnxruntime",
+ "rayon",
  "rubert-tokenizer",
  "serde",
  "thiserror",

--- a/rubert/Cargo.toml
+++ b/rubert/Cargo.toml
@@ -22,9 +22,10 @@ criterion = { version = "0.3.5", features = ["html_reports"], optional = true }
 csv = { version = "1.1.6", optional = true }
 indicatif = { version = "0.16.2", optional = true }
 onnxruntime = { version = "0.0.13", optional = true }
+rayon = { version = "1.5.1", optional = true }
 
 [features]
-bench = ["criterion", "onnxruntime"]
+bench = ["criterion", "onnxruntime", "rayon"]
 validate = ["csv", "indicatif", "onnxruntime"]
 
 [[example]]
@@ -44,6 +45,12 @@ required-features = ["bench"]
 
 [[bench]]
 name = "matmul"
+harness = false
+bench = false
+required-features = ["bench"]
+
+[[bench]]
+name = "parallel"
 harness = false
 bench = false
 required-features = ["bench"]

--- a/rubert/benches/parallel.rs
+++ b/rubert/benches/parallel.rs
@@ -1,0 +1,274 @@
+//! Run as `cargo bench --bench parallel --features bench`.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rayon::{
+    iter::{IntoParallelRefIterator, ParallelIterator},
+    join,
+};
+
+use rubert::{
+    kinds::{QAMBert, SMBert},
+    AveragePooler,
+    Builder,
+};
+
+const BATCH_SIZE: usize = 16;
+const TOKEN_SIZE: usize = 64;
+
+/// Creates a number of dummy sequences as input for the MBert pipelines.
+fn sequences(n: usize) -> Vec<String> {
+    (0..n)
+        .map(|i| format!("This is sequence number {}.", i))
+        .collect()
+}
+
+/// Builds a MBert pipeline of the given kind with the corresponding vocabulary and model files.
+macro_rules! mbert {
+    ($kind:ty, $vocab:expr, $model:expr $(,)?) => {
+        Builder::<_, _, $kind, _>::from_files($vocab, $model)
+            .unwrap()
+            .with_accents(false)
+            .with_lowercase(true)
+            .with_token_size(TOKEN_SIZE)
+            .unwrap()
+            .with_pooling(AveragePooler)
+            .build()
+            .unwrap()
+    };
+}
+
+/// Benches the SMBert pipeline sequentially.
+fn bench_smbert_sequential(manager: &mut Criterion) {
+    let smbert = mbert!(
+        SMBert,
+        "../data/smbert_v0000/vocab.txt",
+        "../data/smbert_v0000/smbert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("SMBert Sequential", |bencher| {
+        bencher.iter(|| {
+            let _ = sequences
+                .iter() // runs each sequence sequentially
+                .map(|sequence| smbert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+        });
+    });
+}
+
+/// Benches the SMBert pipeline parallelly.
+fn bench_smbert_parallel(manager: &mut Criterion) {
+    let smbert = mbert!(
+        SMBert,
+        "../data/smbert_v0000/vocab.txt",
+        "../data/smbert_v0000/smbert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("SMBert Parallel", |bencher| {
+        bencher.iter(|| {
+            let _ = sequences
+                .par_iter() // runs each sequence parallelly
+                .map(|sequence| smbert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+        })
+    });
+}
+
+/// Benches the QAMBert pipeline sequentially.
+fn bench_qambert_sequential(manager: &mut Criterion) {
+    let qambert = mbert!(
+        QAMBert,
+        "../data/qambert_v0001/vocab.txt",
+        "../data/qambert_v0001/qambert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("QAMBert Sequential", |bencher| {
+        bencher.iter(|| {
+            let _ = sequences
+                .iter() // runs each sequence sequentially
+                .map(|sequence| qambert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+        });
+    });
+}
+
+/// Benches the QAMBert pipeline parallelly.
+fn bench_qambert_parallel(manager: &mut Criterion) {
+    let qambert = mbert!(
+        QAMBert,
+        "../data/qambert_v0001/vocab.txt",
+        "../data/qambert_v0001/qambert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("QAMBert Parallel", |bencher| {
+        bencher.iter(|| {
+            let _ = sequences
+                .par_iter() // runs each sequence parallelly
+                .map(|sequence| qambert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+        })
+    });
+}
+
+/// Benches both MBert pipelines fully sequentially.
+fn bench_mberts_sequential(manager: &mut Criterion) {
+    let smbert = mbert!(
+        SMBert,
+        "../data/smbert_v0000/vocab.txt",
+        "../data/smbert_v0000/smbert.onnx",
+    );
+    let qambert = mbert!(
+        QAMBert,
+        "../data/qambert_v0001/vocab.txt",
+        "../data/qambert_v0001/qambert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("SMBert & QAMBert Sequential", |bencher| {
+        bencher.iter(|| {
+            // runs the SMBert & QAMBert pipelines sequentially
+            let _ = sequences
+                .iter() // runs each sequence sequentially within the SMBert pipeline
+                .map(|sequence| smbert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+            let _ = sequences
+                .iter() // runs each sequence sequentially within the QAMBert pipeline
+                .map(|sequence| qambert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+        });
+    });
+}
+
+/// Benches both MBert pipelines parallelly, while within each pipeline it runs sequentially.
+fn bench_mberts_join(manager: &mut Criterion) {
+    let smbert = mbert!(
+        SMBert,
+        "../data/smbert_v0000/vocab.txt",
+        "../data/smbert_v0000/smbert.onnx",
+    );
+    let qambert = mbert!(
+        QAMBert,
+        "../data/qambert_v0001/vocab.txt",
+        "../data/qambert_v0001/qambert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("SMBert & QAMBert Join", |bencher| {
+        bencher.iter(|| {
+            // runs the SMBert & QAMBert pipelines parallelly
+            let _ = join(
+                || {
+                    sequences
+                        .iter() // runs each sequence sequentially within the SMBert pipeline
+                        .map(|sequence| smbert.run(black_box(sequence)).unwrap())
+                        .collect::<Vec<_>>()
+                },
+                || {
+                    sequences
+                        .iter() // runs each sequence sequentially within the QAMBert pipeline
+                        .map(|sequence| qambert.run(black_box(sequence)).unwrap())
+                        .collect::<Vec<_>>()
+                },
+            );
+        });
+    });
+}
+
+/// Benches both MBert pipelines sequentially, while within each pipeline it runs parallely.
+fn bench_mberts_parallel(manager: &mut Criterion) {
+    let smbert = mbert!(
+        SMBert,
+        "../data/smbert_v0000/vocab.txt",
+        "../data/smbert_v0000/smbert.onnx",
+    );
+    let qambert = mbert!(
+        QAMBert,
+        "../data/qambert_v0001/vocab.txt",
+        "../data/qambert_v0001/qambert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("SMBert & QAMBert Parallel", |bencher| {
+        bencher.iter(|| {
+            // runs the SMBert & QAMBert pipelines sequentially
+            let _ = sequences
+                .par_iter() // runs each sequence parallelly within the SMBert pipeline
+                .map(|sequence| smbert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+            let _ = sequences
+                .par_iter() // runs each sequence parallelly within the QAMBert pipeline
+                .map(|sequence| qambert.run(black_box(sequence)).unwrap())
+                .collect::<Vec<_>>();
+        });
+    });
+}
+
+/// Benches both Mbert pipelines fully parallelly.
+fn bench_mberts_join_parallel(manager: &mut Criterion) {
+    let smbert = mbert!(
+        SMBert,
+        "../data/smbert_v0000/vocab.txt",
+        "../data/smbert_v0000/smbert.onnx",
+    );
+    let qambert = mbert!(
+        QAMBert,
+        "../data/qambert_v0001/vocab.txt",
+        "../data/qambert_v0001/qambert.onnx",
+    );
+    let sequences = sequences(BATCH_SIZE);
+
+    manager.bench_function("SMBert & QAMBert Join Parallel", |bencher| {
+        bencher.iter(|| {
+            // runs the SMBert & QAMBert pipelines parallelly
+            let _ = join(
+                || {
+                    sequences
+                        .par_iter() // runs each sequence parallelly within the SMBert pipeline
+                        .map(|sequence| smbert.run(black_box(sequence)).unwrap())
+                        .collect::<Vec<_>>()
+                },
+                || {
+                    sequences
+                        .par_iter() // runs each sequence parallelly within the QAMBert pipeline
+                        .map(|sequence| qambert.run(black_box(sequence)).unwrap())
+                        .collect::<Vec<_>>()
+                },
+            );
+        });
+    });
+}
+
+criterion_group! {
+    name = bench_smbert;
+    config = Criterion::default();
+    targets =
+        bench_smbert_sequential,
+        bench_smbert_parallel,
+}
+
+criterion_group! {
+    name = bench_qambert;
+    config = Criterion::default();
+    targets =
+        bench_qambert_sequential,
+        bench_qambert_parallel,
+}
+
+criterion_group! {
+    name = bench_mberts;
+    config = Criterion::default();
+    targets =
+        bench_mberts_sequential,
+        bench_mberts_join,
+        bench_mberts_parallel,
+        bench_mberts_join_parallel,
+}
+
+criterion_main! {
+    bench_smbert,
+    bench_qambert,
+    bench_mberts,
+}


### PR DESCRIPTION
**References**

- [TY-1991]
- [rust book on parallelism](https://doc.rust-lang.org/book/ch16-00-concurrency.html)
- [rustonomicon on parallelism](https://doc.rust-lang.org/nomicon/concurrency.html)

**Use case constraints**

- MBert pipeline and sequence only taken by shared reference to produce an embedding
- MBert pipelines can run independently and take the same batch of sequences as input
- each MBert pipeline can run the sequences/samples of the batch independently

**Memory sharing vs message passing**

- parallelization of batch looping is straight forward (e.g. with `rayon`), parallelization of pipelines is also kind of easy due to shared references; passing messages would probably require a clone of the pipeline per channel (maybe `Arc`ing works as well?)
- little change needed, ios & android & wasm compile successfully with `rayon` (i haven't run them though, wasm may need additional setup via [wasm-bindgen-rayon](https://crates.io/crates/wasm-bindgen-rayon)), but some targets may need conditional compilation/fallbacks ([like safari for wasm](https://webassembly.org/roadmap/)); channels will probably work without issues on any platform but multithreading still has the same constraints as in the shared memory case

**Further parallelization opportunities**

- remove need for parallelization of the tokenization by running the tokenization only once (requires same tokenizer configuration and vocabulary which is currently the case but not enforced in the code and the data archives), but this may be done later as the tokenization only accounts for roughly 5-7% of the pipeline (less than 1% for the pooler, rest for the model)

**Potential speed improvements**

- checked on my mac with four cores, depending on processor load we can achieve almost a speedup up to the number of available cores in the fully parallized setting
- SMBert sequential -> parallel: 3.5-3.8x
- QAMBert sequential -> parallel: 3.3-3.7x
- SMBert & QAMBert sequential -> join: 1.7-1.9x
- SMBert & QAMBert sequential -> parallel: 3.2-3.5x
- SMBert & QAMBert sequential -> join parallel: 3.8-3.9x


[TY-1991]: https://xainag.atlassian.net/browse/TY-1991