### PR TITLE
TY-1931 ListNet training with soundgarden: Split PR, part 2. Add samples preparation CLI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,9 +429,20 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bincode",
+ "csv",
+ "displaydoc",
+ "env_logger",
+ "float-cmp 0.9.0",
+ "itertools",
+ "log",
+ "ndarray",
+ "rand",
  "serde",
  "serde_json",
  "structopt",
+ "thiserror",
+ "uuid",
  "xayn-ai",
 ]
 
@@ -520,6 +531,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -649,6 +673,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
@@ -1752,6 +1782,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/dev-tool/Cargo.toml
+++ b/dev-tool/Cargo.toml
@@ -12,4 +12,17 @@ structopt = "0.3.22"
 xayn-ai = { path="../xayn-ai" }
 serde = { version="1.0.127", features=["derive"]}
 serde_json = "1.0.66"
+bincode = "1.3.3"
 base64 = "0.13.0"
+rand = "0.8.3"
+ndarray = "0.15.3"
+log = "0.4.14"
+env_logger =  "0.9.0"
+thiserror = "1.0.26"
+displaydoc = "0.2.3"
+csv = "1.1.6"
+uuid = "0.8.2"
+itertools = "0.10.0"
+
+[dev-dependencies]
+float-cmp = "0.9.0"

--- a/dev-tool/src/list_net.rs
+++ b/dev-tool/src/list_net.rs
@@ -1,0 +1,22 @@
+#![cfg(not(tarpaulin))]
+use anyhow::Error;
+use structopt::StructOpt;
+
+use self::convert::ConvertCmd;
+mod convert;
+mod data_source;
+
+/// Commands related to training ListNet (train, convert, inspect).
+#[derive(StructOpt, Debug)]
+pub enum ListNetCmd {
+    Convert(ConvertCmd),
+}
+
+impl ListNetCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        use ListNetCmd::*;
+        match self {
+            Convert(cmd) => cmd.run(),
+        }
+    }
+}

--- a/dev-tool/src/list_net/convert.rs
+++ b/dev-tool/src/list_net/convert.rs
@@ -496,6 +496,7 @@ mod tests {
             doc_with_action(&history[7], UserAction::Click),
             doc_with_action(&history[8], UserAction::Miss),
             doc_with_action(&history[9], UserAction::Miss),
+            /* -- next seq of query results (unique by `(session_id, query_count)`) -- */
             doc_with_action(&history[10], UserAction::Miss),
         ];
 

--- a/dev-tool/src/list_net/convert.rs
+++ b/dev-tool/src/list_net/convert.rs
@@ -1,0 +1,515 @@
+#![cfg(not(tarpaulin))]
+
+use std::{
+    convert::TryInto,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Error;
+use itertools::Itertools;
+use log::debug;
+use serde::Deserialize;
+use structopt::StructOpt;
+use uuid::Uuid;
+
+use xayn_ai::{
+    list_net_training_data_from_history,
+    DayOfWeek,
+    DocumentHistory,
+    DocumentId,
+    QueryId,
+    Relevance,
+    SessionId,
+    UserAction,
+    UserFeedback,
+};
+
+use super::data_source::InMemorySamples;
+use crate::exit_code::NO_ERROR;
+
+/// Converts different file formats.
+///
+/// This is mainly used to prepare a samples file
+/// based on a directory containing soundgarden user
+/// data-frame csv files.
+#[derive(Debug, StructOpt)]
+pub struct ConvertCmd {
+    /// Directory in which soundgarden saved user data-frames (one csv file per user).
+    #[structopt(short = "d", long)]
+    from_soundgarden: PathBuf,
+    /// File in which the samples should be stored, e.g. `data.samples`.
+    #[structopt(short = "o", long)]
+    to_samples: PathBuf,
+}
+
+impl ConvertCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        let ConvertCmd {
+            from_soundgarden,
+            to_samples,
+        } = self;
+
+        let mut storage = InMemorySamples::default();
+
+        for entry in fs::read_dir(&from_soundgarden)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension() != Some(OsStr::new("csv")) {
+                continue;
+            }
+
+            debug!("Loading history for {:?}.", path.file_name().unwrap());
+            let history = load_history(path)?;
+            debug!("Processing history");
+            for (inputs, target_prob_dist) in list_net_training_data_from_history(&history)? {
+                storage.add_sample(inputs.view(), target_prob_dist.view())?;
+            }
+        }
+
+        debug!("Write output file.");
+        storage.serialize_into_file(to_samples)?;
+
+        Ok(NO_ERROR)
+    }
+}
+
+//FIXME[follow up PR]: Change ltr feature extraction tests to share code with
+//                     this implementation and then to use the normal soundgarden
+//                     user data-frames instead of specially pre-processed csv
+//                     files.
+//
+//FIXME maybe verify the structural integrity of the file, currently it's expected
+// to have the records partitioned by query as well as sorted both in each query
+// (first ranked record to last ranked record) and in between queries (oldest
+// query to newest query).
+//
+/// Loads a history from a soundgarden user data-frame csv file.
+///
+/// The [`UserAction`] values will be inferred from the data in the
+/// same way soundgarden does so.
+fn load_history(path: impl AsRef<Path>) -> Result<Vec<DocumentHistory>, Error> {
+    let mut reader = csv::Reader::from_path(path)?;
+
+    let mut history = Vec::new();
+    for (counter, record) in reader.deserialize().enumerate() {
+        let record: SoundgardenUserDfRecord = record?;
+        history.push(
+            record.into_document_history_with_bad_user_action(
+                counter
+                    .try_into()
+                    .expect("User with more then 2^32-1 records."),
+            ),
+        );
+    }
+
+    fix_user_actions_in_history(&mut history);
+
+    Ok(history)
+}
+
+/// Struct to load a soundgarden user data-frame csv file record into.
+#[derive(Deserialize)]
+struct SoundgardenUserDfRecord {
+    /// Session Id, is an incremental unsigned integer in soundgarden.
+    session_id: u64,
+    /// Query Id, same for all queries using the same parameters.
+    query_id: u64,
+    /// User Id, arbitrary unsigned integer.
+    ///
+    /// We treat all data as if it's from the same user, so we
+    /// don't really need it but we use it to infer an appropriate
+    /// deterministic document id.
+    user_id: u64,
+    /// Number of days since the start of the soundgarden history.
+    ///
+    /// Starting with `Tue == 1`.
+    ///
+    /// As such `Mon` is `0`, `Wed` is `2` etc.
+    ///
+    /// The number is not limited to `0..=6`, e.g. all of `1`,`8`,`15` are `Tue`
+    day: usize,
+    /// The words of the query as *comma* separated string.
+    ///
+    /// This are not actual words but string encoded word ids.
+    /// E.g. `"2142,53423"` but treating `2142` as a word is not
+    /// a problem for our use-case.
+    query_words: String,
+    /// The url of the document.
+    ///
+    /// Theoretically this is also an "arbitrary" unsigned integer id, but
+    /// practically it's simpler to just treat it as a string.
+    url: String,
+    /// The domain of the document.
+    ///
+    /// Theoretically this is also an "arbitrary" unsigned integer id, but
+    /// practically it's simpler to just treat it as a string.
+    domain: String,
+    /// The relevance of the document.
+    relevance: Relevance,
+    /// The position of the document, *starting with `1`*.
+    position: usize,
+    /// The index of the query in the session it belongs to.
+    query_counter: usize,
+}
+
+impl SoundgardenUserDfRecord {
+    /// Creates a [`DocumentHistory`] from this record.
+    ///
+    /// The `user_action` field *will* be incorrect and
+    /// needs to be fixed separately. This is the case
+    /// as the other documents need to be known to
+    /// infer the [`UserAction`] correctly.
+    fn into_document_history_with_bad_user_action(
+        self,
+        per_user_result_counter: u32,
+    ) -> DocumentHistory {
+        let Self {
+            session_id,
+            query_id,
+            user_id,
+            day,
+            query_words,
+            url,
+            domain,
+            relevance,
+            position,
+            query_counter,
+        } = self;
+
+        DocumentHistory {
+            // By combining the `user_id` with a monotonic increasing per-user counter
+            // we can create deterministically an appropriate document id.
+            id: DocumentId(id2uuid(user_id, Some(per_user_result_counter))),
+            relevance,
+            user_feedback: UserFeedback::NotGiven,
+            session: SessionId(id2uuid(session_id, None)),
+            query_count: query_counter,
+            query_id: QueryId(id2uuid(query_id, None)),
+            query_words: query_words.replace(",", " "),
+            day: day_from_day_offset(day),
+            url,
+            domain,
+            rank: position.checked_sub(1).unwrap(),
+            user_action: UserAction::Miss,
+        }
+    }
+}
+
+/// Updates the history with user actions inferred from the context.
+///
+/// This uses the same approach as in soundgarden.
+fn fix_user_actions_in_history(histories: &mut [DocumentHistory]) {
+    // Soundgarden User Df are already grouped by query and sorted, ordered from past to present.
+    // (There is a FIXME for this above.)
+    histories
+        .iter_mut()
+        .rev()
+        .group_by(|d| d.query_id)
+        .into_iter()
+        .for_each(|(_, query)| fix_user_actions_in_query_reverse_order(query))
+}
+
+/// Function Split out from [`fix_user_actions_in_history`] **do not reuse elsewhere**.
+///
+/// The iterator must iterate over queries from last to first.
+fn fix_user_actions_in_query_reverse_order<'a>(
+    query: impl IntoIterator<Item = &'a mut DocumentHistory>,
+) {
+    let mut has_clicked_docs_after_it = false;
+    for doc in query.into_iter() {
+        doc.user_action = match doc.relevance {
+            Relevance::High | Relevance::Medium => {
+                has_clicked_docs_after_it = true;
+                UserAction::Click
+            }
+            Relevance::Low => {
+                if has_clicked_docs_after_it {
+                    UserAction::Skip
+                } else {
+                    UserAction::Miss
+                }
+            }
+        }
+    }
+}
+
+/// Crate a [`DayOfWeek`] instance from an offset.
+fn day_from_day_offset(day: usize) -> DayOfWeek {
+    use DayOfWeek::*;
+    static DAYS: &[DayOfWeek] = &[Mon, Tue, Wed, Thu, Fri, Sat, Sun];
+    DAYS[day % 7]
+}
+
+/// Creates an UUID by combining `YYYYYYYY-eb92-4d36-XXXX-XXXXXXXXXXXX` with given `sub_id`(s).
+///
+/// - `X..` is replaced with the `sub_id`.
+///
+/// - `Y..` is replaced with the `sub_id2` if given. If
+///       not given `0xd006a685` is used instead.
+fn id2uuid(sub_id: u64, sub_id2: Option<u32>) -> Uuid {
+    const BASE_UUID: u128 = 0x00000000_eb92_4d36_0000_000000000000;
+    const DEFAULT_SUB_ID_2: u32 = 0xd006a685;
+    let sub_id2 = sub_id2.unwrap_or(DEFAULT_SUB_ID_2);
+    let sub_id2 = (sub_id2 as u128) << 96;
+    uuid::Uuid::from_u128(sub_id2 | BASE_UUID | (sub_id as u128))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_id2uuid() {
+        assert_eq!(
+            id2uuid(0, Some(0)),
+            Uuid::from_u128(0x00000000_eb92_4d36_0000_000000000000)
+        );
+        assert_eq!(
+            id2uuid(0, None),
+            Uuid::from_u128(0xd006a685_eb92_4d36_0000_000000000000)
+        );
+        assert_eq!(
+            id2uuid(u64::MAX, Some(u32::MAX)),
+            Uuid::from_u128(0xffffffff_eb92_4d36_ffff_ffffffffffff)
+        )
+    }
+
+    #[test]
+    fn test_day_from_offset() {
+        assert_eq!(day_from_day_offset(0), DayOfWeek::Mon);
+        assert_eq!(day_from_day_offset(1), DayOfWeek::Tue);
+        assert_eq!(day_from_day_offset(2), DayOfWeek::Wed);
+        assert_eq!(day_from_day_offset(3), DayOfWeek::Thu);
+        assert_eq!(day_from_day_offset(4), DayOfWeek::Fri);
+        assert_eq!(day_from_day_offset(5), DayOfWeek::Sat);
+        assert_eq!(day_from_day_offset(6), DayOfWeek::Sun);
+        assert_eq!(day_from_day_offset(7), DayOfWeek::Mon);
+        assert_eq!(day_from_day_offset(8), DayOfWeek::Tue);
+    }
+
+    #[test]
+    fn test_soundgarden_record_to_document_history() {
+        let record = SoundgardenUserDfRecord {
+            session_id: 10,
+            query_id: 23,
+            user_id: 142313,
+            day: 17,
+            query_words: "123,432".to_owned(),
+            url: "32".to_owned(),
+            domain: "23".to_owned(),
+            relevance: Relevance::Medium,
+            position: 4,
+            query_counter: 12,
+        };
+        let expected = DocumentHistory {
+            id: DocumentId(id2uuid(142313, Some(u32::MAX))),
+            relevance: Relevance::Medium,
+            user_feedback: UserFeedback::NotGiven,
+            session: SessionId(id2uuid(10, None)),
+            query_count: 12,
+            query_id: QueryId(id2uuid(23, None)),
+            query_words: "123 432".to_owned(),
+            day: DayOfWeek::Thu,
+            url: "32".to_owned(),
+            domain: "23".to_owned(),
+            rank: 3,
+            user_action: UserAction::Miss,
+        };
+
+        let history = record.into_document_history_with_bad_user_action(u32::MAX);
+
+        assert_eq!(history, expected);
+    }
+
+    #[test]
+    fn test_fix_user_action_in_history() {
+        let mut history = vec![
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(0))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar/a".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(1))),
+                relevance: Relevance::Medium,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar/b".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 1,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(2))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo/t".to_owned(),
+                rank: 2,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(3))),
+                relevance: Relevance::High,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar-foo/fu".to_owned(),
+                rank: 3,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(4))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "bar/bar".to_owned(),
+                domain: "bar".to_owned(),
+                rank: 4,
+                user_action: UserAction::Miss,
+            },
+            /* ---- */
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(5))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 1,
+                query_id: QueryId(id2uuid(52, None)),
+                query_words: "bar bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(6))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 1,
+                query_id: QueryId(id2uuid(52, None)),
+                query_words: "bar bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foobar".to_owned(),
+                domain: "barfoo".to_owned(),
+                rank: 1,
+                user_action: UserAction::Miss,
+            },
+            /* ---- */
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(7))),
+                relevance: Relevance::High,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 2,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(8))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 2,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 1,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(9))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 2,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 2,
+                user_action: UserAction::Miss,
+            },
+            /* ---- */
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(10))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 3,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+        ];
+        let fixed_history = &[
+            doc_with_action(&history[0], UserAction::Skip),
+            doc_with_action(&history[1], UserAction::Click),
+            doc_with_action(&history[2], UserAction::Skip),
+            doc_with_action(&history[3], UserAction::Click),
+            doc_with_action(&history[4], UserAction::Miss),
+            /* ---- */
+            doc_with_action(&history[5], UserAction::Miss),
+            doc_with_action(&history[6], UserAction::Miss),
+            /* ---- */
+            doc_with_action(&history[7], UserAction::Click),
+            doc_with_action(&history[8], UserAction::Miss),
+            doc_with_action(&history[9], UserAction::Miss),
+            doc_with_action(&history[10], UserAction::Miss),
+        ];
+
+        assert_eq!(history.len(), fixed_history.len());
+
+        fix_user_actions_in_history(&mut history);
+
+        assert_eq!(history, fixed_history);
+
+        fn doc_with_action(doc: &DocumentHistory, action: UserAction) -> DocumentHistory {
+            let mut doc = doc.clone();
+            doc.user_action = action;
+            doc
+        }
+    }
+}

--- a/dev-tool/src/list_net/convert.rs
+++ b/dev-tool/src/list_net/convert.rs
@@ -54,8 +54,7 @@ impl ConvertCmd {
         let mut storage = InMemorySamples::default();
 
         for entry in fs::read_dir(&from_soundgarden)? {
-            let entry = entry?;
-            let path = entry.path();
+            let path = entry?.path();
             if path.extension() != Some(OsStr::new("csv")) {
                 continue;
             }
@@ -211,7 +210,7 @@ fn fix_user_actions_in_history(histories: &mut [DocumentHistory]) {
         .for_each(|(_, query)| fix_user_actions_in_query_reverse_order(query))
 }
 
-/// Function Split out from [`fix_user_actions_in_history`] **do not reuse elsewhere**.
+/// Function split out from [`fix_user_actions_in_history`] **do not reuse elsewhere**.
 ///
 /// The iterator must iterate over queries from last to first.
 fn fix_user_actions_in_query_reverse_order<'a>(
@@ -396,7 +395,7 @@ mod tests {
                 rank: 4,
                 user_action: UserAction::Miss,
             },
-            /* ---- */
+            /* -- next seq of query results (unique by `(session_id, query_count)`) -- */
             DocumentHistory {
                 id: DocumentId(id2uuid(12, Some(5))),
                 relevance: Relevance::Low,
@@ -425,7 +424,7 @@ mod tests {
                 rank: 1,
                 user_action: UserAction::Miss,
             },
-            /* ---- */
+            /* -- next seq of query results (unique by `(session_id, query_count)`) -- */
             DocumentHistory {
                 id: DocumentId(id2uuid(12, Some(7))),
                 relevance: Relevance::High,
@@ -468,7 +467,7 @@ mod tests {
                 rank: 2,
                 user_action: UserAction::Miss,
             },
-            /* ---- */
+            /* -- next seq of query results (unique by `(session_id, query_count)`) -- */
             DocumentHistory {
                 id: DocumentId(id2uuid(12, Some(10))),
                 relevance: Relevance::Low,
@@ -490,10 +489,10 @@ mod tests {
             doc_with_action(&history[2], UserAction::Skip),
             doc_with_action(&history[3], UserAction::Click),
             doc_with_action(&history[4], UserAction::Miss),
-            /* ---- */
+            /* -- next seq of query results (unique by `(session_id, query_count)`) -- */
             doc_with_action(&history[5], UserAction::Miss),
             doc_with_action(&history[6], UserAction::Miss),
-            /* ---- */
+            /* -- next seq of query results (unique by `(session_id, query_count)`) -- */
             doc_with_action(&history[7], UserAction::Click),
             doc_with_action(&history[8], UserAction::Miss),
             doc_with_action(&history[9], UserAction::Miss),

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -1,0 +1,567 @@
+#![cfg(not(tarpaulin))]
+
+//FIXME[follow up PR]: Move modified parts of this module into the `ltr::list_net` module to re-use them for in-app training.
+use std::{
+    error::Error as StdError,
+    fs::File,
+    io::{BufReader, BufWriter, Read, Write},
+    ops::RangeTo,
+    path::Path,
+    u64,
+};
+
+use anyhow::{bail, Error};
+use bincode::Options;
+use displaydoc::Display;
+use log::debug;
+use ndarray::{ArrayBase, ArrayView, ArrayView1, ArrayView2, Data, Dimension};
+use rand::{prelude::SliceRandom, Rng};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use xayn_ai::list_net::{self, ListNet, Sample};
+
+/// A [`xayn_ai::list_net::DataSource`] implementation.
+pub(crate) struct DataSource<S>
+where
+    S: Storage,
+{
+    /// The storage containing all samples.
+    storage: S,
+    /// The batch size (if already provided).
+    batch_size: Option<usize>,
+    /// A container with all ids of all training samples, returning them in randomized order.
+    training_data_order: DataLookupOrder,
+    /// A container with all ids of all evaluation samples, returning them in randomized order.
+    evaluation_data_order: DataLookupOrder,
+}
+
+impl<S> DataSource<S>
+where
+    S: Storage,
+{
+    /// Creates a new `DataSource` from given storage and evaluation split.
+    ///
+    /// # Errors
+    ///
+    /// - If `evaluation_split` is less then 0 or not a normal float.
+    /// - If there are no samples.
+    /// - If there are no training samples with the given `evaluation_split`.
+    /// - If there are no evaluation samples with the given `evaluation_split`,
+    ///   but the split is not `0`.
+    /// - If calling `storage.data_ids()` failed.
+    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
+    pub(crate) fn new(
+        storage: S,
+        evaluation_split: f32,
+    ) -> Result<Self, DataSourceError<S::Error>> {
+        if evaluation_split < 0. || !evaluation_split.is_normal() {
+            return Err(DataSourceError::BadEvaluationSplit(evaluation_split));
+        }
+        let nr_all_samples = storage.data_ids().map_err(DataSourceError::Storage)?.end;
+        if nr_all_samples == 0 {
+            return Err(DataSourceError::EmptyDatabase);
+        }
+        let nr_evaluation_samples = (nr_all_samples as f32 * evaluation_split).round() as usize;
+        if nr_evaluation_samples >= nr_all_samples {
+            return Err(DataSourceError::ToLargeEvaluationSplit(evaluation_split));
+        }
+        if nr_evaluation_samples == 0 && evaluation_split > 0. {
+            return Err(DataSourceError::NoEvaluationSamples(evaluation_split));
+        }
+        let nr_training_samples = nr_all_samples - nr_evaluation_samples;
+        let evaluation_ids = (nr_training_samples..nr_all_samples).collect();
+        let training_ids = (0..nr_training_samples).collect();
+
+        Ok(Self {
+            storage,
+            batch_size: None,
+            training_data_order: DataLookupOrder::new(training_ids),
+            evaluation_data_order: DataLookupOrder::new(evaluation_ids),
+        })
+    }
+}
+
+#[derive(Error, Debug, Display)]
+pub enum DataSourceError<SE>
+where
+    SE: StdError + 'static,
+{
+    /// Unusable evaluation split: Assertion `split >= 0 && split.is_normal()` failed (split = {0}).
+    BadEvaluationSplit(f32),
+    /// Unusable evaluation split: With evaluation split {0} no samples are left for training.
+    ToLargeEvaluationSplit(f32),
+    /// Unusable evaluation split: Assertion `nr_evaluation_samples > 0 || split == 0` failed (split = {0}).
+    NoEvaluationSamples(f32),
+    /// A batch size of 0 is not usable for training.
+    BatchSize0,
+    /// The batch size is larger then the number of samples.
+    ToLargeBatchSize(usize),
+    /// Not reset/initialized.
+    ResetWasNotCalledBeforeTraining,
+    /// Empty database can not be used for training.
+    EmptyDatabase,
+    /// Fetching sample from storage failed: {0}.
+    Storage(SE),
+}
+
+impl<S> list_net::DataSource for DataSource<S>
+where
+    S: Storage,
+{
+    type Error = DataSourceError<S::Error>;
+
+    fn reset(&mut self, batch_size: usize) -> Result<usize, Self::Error> {
+        if batch_size == 0 {
+            return Err(DataSourceError::BatchSize0);
+        }
+        let mut rng = rand::thread_rng();
+        self.batch_size = Some(batch_size);
+        self.training_data_order.reset(&mut rng);
+        self.evaluation_data_order.reset(&mut rng);
+
+        let nr_batches = self.training_data_order.number_of_batches(batch_size);
+        if nr_batches == 0 {
+            return Err(DataSourceError::ToLargeBatchSize(nr_batches));
+        }
+        Ok(nr_batches)
+    }
+
+    fn next_training_batch(&mut self) -> Result<Vec<Sample>, Self::Error> {
+        let batch_size = self
+            .batch_size
+            .ok_or(DataSourceError::ResetWasNotCalledBeforeTraining)?;
+
+        let ids = self.training_data_order.next_batch(batch_size);
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.storage
+            .load_batch(&ids)
+            .map_err(DataSourceError::Storage)
+    }
+
+    fn next_evaluation_sample(&mut self) -> Result<Option<Sample>, Self::Error> {
+        if let Some(id) = self.evaluation_data_order.next() {
+            match self.storage.load_sample(id) {
+                Ok(sample) => Ok(Some(sample)),
+                Err(error) => Err(DataSourceError::Storage(error)),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub(crate) trait Storage {
+    type Error: StdError + 'static;
+
+    /// Return the all sample ids.
+    ///
+    /// For now this is a range. I.e. `0..nr_of_samples`. We might need
+    /// to change this in the future, but for now this is simpler.
+    fn data_ids(&self) -> Result<RangeTo<usize>, Self::Error>;
+
+    /// Loads a sample and returns a reference to it.
+    ///
+    /// This method is `&mut self` as it might change the internal state
+    /// (due to loading/caching) and we also want to make sure that there
+    /// are no more lend out samples, when `load_sample` or `load_batch` are
+    /// called again.
+    fn load_sample(&mut self, id: DataId) -> Result<Sample, Self::Error>;
+
+    /// Loads a batch of samples and returns a vector of references to them.
+    ///
+    /// See [`Storage.load_batch()`] about why this is `&mut self`.
+    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<Sample<'a>>, Self::Error>;
+}
+
+/// For now samples id's are always incremental integers form `0..nr_samples`.
+///
+/// Given that this is just used to handle shuffling and similar it's unlikely to
+/// ever change, we do explicitly not care about any consistency of the id to
+/// sample mapping between trainings.
+type DataId = usize;
+
+/// Helper to randomize sample order.
+struct DataLookupOrder {
+    /// Ids of all samples in this lookup order.
+    data_ids: Vec<DataId>,
+    /// The offset splitting already used samples from not yet used samples.
+    data_ids_offset: usize,
+}
+
+impl DataLookupOrder {
+    fn new(data_ids: Vec<DataId>) -> Self {
+        Self {
+            data_ids,
+            data_ids_offset: 0,
+        }
+    }
+
+    /// Returns the number of batches which will be produced with given batch size.
+    fn number_of_batches(&self, batch_size: usize) -> usize {
+        self.data_ids.len() / batch_size
+    }
+
+    /// Resets this container.
+    ///
+    /// This will mark all samples as unused and
+    /// shuffles the order of samples.
+    fn reset(&mut self, rng: &mut impl Rng) {
+        self.data_ids.shuffle(rng);
+        self.data_ids_offset = 0;
+    }
+
+    /// Returns the next unused sample id.
+    fn next(&mut self) -> Option<DataId> {
+        if self.data_ids_offset < self.data_ids.len() {
+            let idx = self.data_ids_offset;
+            self.data_ids_offset += 1;
+
+            Some(self.data_ids[idx])
+        } else {
+            None
+        }
+    }
+
+    /// Returns the next `batch_size` many sample ids.
+    fn next_batch(&mut self, batch_size: usize) -> Vec<DataId> {
+        let end_idx = self.data_ids_offset + batch_size;
+        if end_idx <= self.data_ids.len() {
+            let start_idx = self.data_ids_offset;
+            self.data_ids_offset = end_idx;
+
+            self.data_ids[start_idx..end_idx].to_owned()
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// A "in-memory" sample storage.
+///
+/// It also can be portably stored to disk using bincode serialization.
+///
+/// The storage is reasonably compact as ~5.3GiB of soundgarden user
+/// data-frames will produce a less then 975MiB serialized `.samples` file.
+// While there are many ways to improve on this (e.g. memory-mapped I/O), they are not relevant for our
+// use-case for now.
+#[derive(Serialize, Deserialize, Default)]
+pub(crate) struct InMemorySamples {
+    /// Vector of concatenated `inputs` and `target_prob_dist`, this slightly improves memory size and
+    /// cache locality, we can derive the number of document from the vectors length as the vectors length
+    /// is `nr_document * INPUT_NR_FEATURES + nr_document*1`, i.e. `nr_documents * 51`.
+    data: Vec<Vec<f32>>,
+}
+
+#[derive(Error, Debug, Display)]
+pub enum StorageError {
+    /// The database was parsed successfully but contains broken invariants at index {at_index}.
+    BrokenInvariants { at_index: usize },
+}
+
+impl InMemorySamples {
+    /// Serializes this instance into a file, preferably use the `.samples` file ending.
+    //FIXME[follow-up PR] version the file format, it's used to persist data and it's not
+    //                    unlikely to slightly change in the future.
+    pub(crate) fn serialize_into_file(&self, file: impl AsRef<Path>) -> Result<(), Error> {
+        self.serialize_into(BufWriter::new(File::create(file)?))
+    }
+
+    /// Serializes this instance into given writer.
+    fn serialize_into(&self, writer: impl Write) -> Result<(), Error> {
+        bincode::DefaultOptions::new()
+            .serialize_into(writer, self)
+            .map_err(Into::into)
+    }
+
+    /// Deserialize a instance from given file.
+    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
+    pub(crate) fn deserialize_from_file(file: impl AsRef<Path>) -> Result<Self, Error> {
+        Self::deserialize_from(BufReader::new(File::open(file)?))
+    }
+
+    /// Deserialize a instance from given reader, preferably pass in a buffered reader.
+    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
+    fn deserialize_from(reader: impl Read) -> Result<Self, Error> {
+        let self_: Self = bincode::DefaultOptions::new().deserialize_from(reader)?;
+        debug!("Loaded {} samples.", self_.data.len());
+        Ok(self_)
+    }
+
+    fn load_sample_helper(&self, id: DataId) -> Result<Sample, StorageError> {
+        let raw = &self.data[id];
+
+        // len == nr_document * nr_features + nr_documents * 1
+        let nr_documents = raw.len() / (ListNet::INPUT_NR_FEATURES + 1);
+        let start_of_target_prob_dist = nr_documents * ListNet::INPUT_NR_FEATURES;
+        debug_assert_eq!(start_of_target_prob_dist + nr_documents, raw.len());
+
+        let inputs = ArrayView::from_shape(
+            (nr_documents, ListNet::INPUT_NR_FEATURES),
+            &raw[..start_of_target_prob_dist],
+        )
+        .map_err(|_| StorageError::BrokenInvariants { at_index: id })?;
+        let target_prob_dist =
+            ArrayView::from_shape((nr_documents,), &raw[start_of_target_prob_dist..])
+                .map_err(|_| StorageError::BrokenInvariants { at_index: id })?;
+
+        Ok(Sample {
+            inputs,
+            target_prob_dist,
+        })
+    }
+
+    /// Add a new sample.
+    ///
+    /// # Panics
+    ///
+    /// - If the number of documents in `inputs` doesn't match the number of probabilities in
+    /// `target_prob_dist`.
+    /// - If the number of features per document is not equal to `[ListNet::INPUT_NR_FEATURES]`.
+    pub(crate) fn add_sample(
+        &mut self,
+        inputs: ArrayView2<f32>,
+        target_prob_dist: ArrayView1<f32>,
+    ) -> Result<(), Error> {
+        if inputs.shape() != [target_prob_dist.len(), ListNet::INPUT_NR_FEATURES] {
+            bail!("Sample with bad array shapes. Expected shapes [{nr_docs}, {nr_feats}] & [{nr_docs}] but got shapes {inputs_shape:?} & {prob_dist_shape:?}",
+                nr_docs=inputs.shape()[0],
+                nr_feats=ListNet::INPUT_NR_FEATURES,
+                inputs_shape=inputs.shape(),
+                prob_dist_shape=target_prob_dist.shape(),
+            );
+        }
+        let mut data = Vec::with_capacity(inputs.len() + target_prob_dist.len());
+        extend_vec_with_ndarray(&mut data, inputs);
+        extend_vec_with_ndarray(&mut data, target_prob_dist);
+        self.data.push(data);
+        Ok(())
+    }
+}
+
+/// Extend a vec with the elements of given array in logical order.
+fn extend_vec_with_ndarray<T: Clone>(
+    data: &mut Vec<T>,
+    array: ArrayBase<impl Data<Elem = T>, impl Dimension>,
+) {
+    if let Some(slice) = array.as_slice() {
+        data.extend_from_slice(slice);
+    } else {
+        data.extend(array.iter().cloned());
+    }
+}
+
+impl Storage for InMemorySamples {
+    type Error = StorageError;
+
+    fn data_ids(&self) -> Result<RangeTo<usize>, Self::Error> {
+        Ok(..self.data.len())
+    }
+
+    fn load_sample(&mut self, id: DataId) -> Result<Sample, Self::Error> {
+        self.load_sample_helper(id)
+    }
+
+    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<Sample<'a>>, Self::Error> {
+        let mut samples = Vec::new();
+        for id in ids {
+            samples.push(self.load_sample_helper(*id)?)
+        }
+        Ok(samples)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ndarray::Array;
+    use rand::thread_rng;
+    use xayn_ai::assert_approx_eq;
+
+    use super::*;
+
+    fn dummy_storage() -> InMemorySamples {
+        let mut storage = InMemorySamples::default();
+
+        let inputs = Array::zeros((10, 50));
+        let target_prob_dist = Array::ones((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap();
+
+        let inputs = Array::ones((10, 50));
+        let target_prob_dist = Array::zeros((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap();
+
+        let inputs = Array::from_elem((10, 50), 4.);
+        let target_prob_dist = Array::ones((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap();
+
+        storage
+    }
+
+    #[test]
+    fn test_adding_bad_matrices_fails() {
+        let mut storage = InMemorySamples::default();
+        let inputs = Array::zeros((10, 48));
+        let target_prob_dist = Array::ones((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap_err();
+
+        let inputs = Array::zeros((10, 50));
+        let target_prob_dist = Array::ones((12,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap_err();
+
+        assert!(storage.data.is_empty());
+    }
+
+    #[test]
+    fn test_runtime_representation_of_in_memory_storage() {
+        let storage = dummy_storage();
+
+        assert_eq!(storage.data.len(), 3);
+
+        for f in &storage.data[0][..500] {
+            assert_approx_eq!(f32, f, 0.0, ulps = 0);
+        }
+        for f in &storage.data[0][500..] {
+            assert_approx_eq!(f32, f, 1.0, ulps = 0);
+        }
+        assert_eq!(storage.data[0].len(), 510);
+
+        for f in &storage.data[1][..500] {
+            assert_approx_eq!(f32, f, 1.0, ulps = 0);
+        }
+        for f in &storage.data[1][500..] {
+            assert_approx_eq!(f32, f, 0.0, ulps = 0);
+        }
+        assert_eq!(storage.data[1].len(), 510);
+
+        for f in &storage.data[2][..500] {
+            assert_approx_eq!(f32, f, 4.0, ulps = 0);
+        }
+        for f in &storage.data[2][500..] {
+            assert_approx_eq!(f32, f, 1.0, ulps = 0);
+        }
+        assert_eq!(storage.data[2].len(), 510);
+    }
+
+    #[test]
+    fn test_get_samples_from_in_memory_storage() {
+        let mut storage = dummy_storage();
+
+        {
+            let sample = storage.load_sample(0).unwrap();
+            assert_eq!(sample.inputs.shape(), &[10, 50]);
+            for f in sample.inputs.iter() {
+                assert_approx_eq!(f32, f, 0.0, ulps = 0);
+            }
+            assert_eq!(sample.target_prob_dist.shape(), &[10]);
+            for f in sample.target_prob_dist.iter() {
+                assert_approx_eq!(f32, f, 1.0, ulps = 0);
+            }
+        }
+        {
+            let sample = storage.load_sample(1).unwrap();
+            assert_eq!(sample.inputs.shape(), &[10, 50]);
+            for f in sample.inputs.iter() {
+                assert_approx_eq!(f32, f, 1.0, ulps = 0);
+            }
+            assert_eq!(sample.target_prob_dist.shape(), &[10]);
+            for f in sample.target_prob_dist.iter() {
+                assert_approx_eq!(f32, f, 0.0, ulps = 0);
+            }
+        }
+        {
+            let sample = storage.load_sample(2).unwrap();
+            assert_eq!(sample.inputs.shape(), &[10, 50]);
+            for f in sample.inputs.iter() {
+                assert_approx_eq!(f32, f, 4.0, ulps = 0);
+            }
+            assert_eq!(sample.target_prob_dist.shape(), &[10]);
+            for f in sample.target_prob_dist.iter() {
+                assert_approx_eq!(f32, f, 1.0, ulps = 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_batch_from_in_memory_storage() {
+        let mut storage = dummy_storage();
+
+        assert_eq!(storage.load_batch(&[]).unwrap().len(), 0);
+
+        {
+            let samples = storage.load_batch(&[1, 1, 0, 1]).unwrap();
+            assert_eq!(samples.len(), 4);
+
+            assert_approx_eq!(f32, &samples[0].inputs, &samples[1].inputs, ulps = 0);
+            assert_approx_eq!(
+                f32,
+                &samples[0].target_prob_dist,
+                &samples[1].target_prob_dist,
+                ulps = 0
+            );
+            assert_approx_eq!(f32, &samples[0].inputs, &samples[3].inputs, ulps = 0);
+            assert_approx_eq!(
+                f32,
+                &samples[0].target_prob_dist,
+                &samples[3].target_prob_dist,
+                ulps = 0
+            );
+
+            assert_approx_eq!(f32, samples[0].inputs[[0, 0]], 1.0, ulps = 0);
+            assert_approx_eq!(f32, samples[2].inputs[[0, 0]], 0.0, ulps = 0);
+        }
+    }
+
+    #[test]
+    fn test_serialization_of_in_memory_storage_works() {
+        let storage = dummy_storage();
+
+        let mut buffer = Vec::new();
+        storage.serialize_into(&mut buffer).unwrap();
+        let storage2 = InMemorySamples::deserialize_from(&*buffer).unwrap();
+
+        assert_approx_eq!(f32, storage.data, storage2.data);
+    }
+
+    #[test]
+    fn test_data_lookup_order_changes_on_reset() {
+        let mut rng = thread_rng();
+        let mut dlo = DataLookupOrder::new(vec![0, 1, 2, 3, 4]);
+
+        dlo.reset(&mut rng);
+        let all = dlo.next_batch(5);
+        dlo.reset(&mut rng);
+        let all2 = dlo.next_batch(5);
+        assert_ne!(all, all2);
+    }
+
+    #[test]
+    fn test_data_lookup_order_does_not_return_partial_batches() {
+        let mut dlo = DataLookupOrder::new(vec![0, 1, 2, 3, 4]);
+        assert_eq!(dlo.next_batch(2), [0, 1]);
+        assert_eq!(dlo.next_batch(2), [2, 3]);
+        assert!(dlo.next_batch(2).is_empty());
+        assert!(dlo.next_batch(2).is_empty());
+    }
+
+    #[test]
+    fn test_data_lookup_order_returns_samples_in_order() {
+        let mut dlo = DataLookupOrder::new(vec![0, 1, 4]);
+        assert_eq!(dlo.next(), Some(0));
+        assert_eq!(dlo.next(), Some(1));
+        assert_eq!(dlo.next(), Some(4));
+        assert_eq!(dlo.next(), None);
+        assert_eq!(dlo.next(), None);
+    }
+}

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -176,14 +176,14 @@ pub(crate) trait Storage {
     fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<Sample<'a>>, Self::Error>;
 }
 
-/// For now samples ids are always incremental integers form `0..nr_samples`.
+/// For now samples ids are always incremental integers from `0` to `nr_samples`.
 ///
 /// - This is only used to handle shuffling and retrieving the samples from the
 ///   storage.
 /// - This is unlikely to ever change.
 /// - We do not care about the consistency of the id-to-sample mapping between
 ///   trainings.
-///     - Through we do care about a deterministic evaluation split, as such
+///     - Though we do care about a deterministic evaluation split, as such
 ///       we currently need some degree of determinism in practice. But that is
 ///       an implementation detail of the splitting unrelated to the rest of
 ///       the code.
@@ -289,7 +289,7 @@ impl InMemorySamples {
         Self::deserialize_from(BufReader::new(File::open(file)?))
     }
 
-    /// Deserialize an instance from the given reader, using a buffered reader is preferred.
+    /// Deserialize an instance from the given (preferably buffered) reader.
     #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
     fn deserialize_from(reader: impl Read) -> Result<Self, Error> {
         let self_: Self = bincode::DefaultOptions::new().deserialize_from(reader)?;
@@ -351,7 +351,7 @@ impl InMemorySamples {
 /// Extend a vec with the elements of the given array.
 ///
 /// Elements are added in logical order independent of storage order,
-/// i.e. elements are added as if `data` was continuos and in standard
+/// i.e. elements are added as if `data` was continuous and in standard
 /// storage order (terms are used the way they are defined by ndarray).
 fn extend_vec_with_ndarray<T: Clone>(
     data: &mut Vec<T>,

--- a/dev-tool/src/main.rs
+++ b/dev-tool/src/main.rs
@@ -1,36 +1,50 @@
 #![cfg(not(tarpaulin))]
+#![cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::process::exit;
 
 use anyhow::Error;
+use log::error;
 use structopt::StructOpt;
 
-use crate::exit_code::FATAL_ERROR;
+use crate::exit_code::{FATAL_ERROR, NO_ERROR};
 
 mod call_data;
 mod exit_code;
+mod list_net;
 
 /// Tooling for the developers of XaynAi.
 #[derive(StructOpt, Debug)]
 enum CommandArgs {
     RunCallData(call_data::CallDataCmd),
+    ListNet(list_net::ListNetCmd),
 }
 
 impl CommandArgs {
     fn run(self) -> Result<i32, Error> {
+        use CommandArgs::*;
+
         match self {
-            CommandArgs::RunCallData(cmd) => cmd.run(),
+            RunCallData(cmd) => cmd.run(),
+            ListNet(cmd) => cmd.run(),
         }
     }
 }
 
 fn main() {
+    env_logger::init();
+
     let exit_code = match CommandArgs::from_args().run() {
         Ok(exit_code) => exit_code,
         Err(error) => {
-            eprintln!("{:?}", error);
+            error!("FATAL: {}\n{:?}", error, error);
             FATAL_ERROR
         }
     };
 
+    if exit_code == NO_ERROR {
+        eprintln!("DONE");
+    } else {
+        eprintln!("EXIT WITH ERRORS");
+    }
     exit(exit_code);
 }


### PR DESCRIPTION
This adds the `dev-tool list-net convert` sub-command which can be used to convert a folder with soundgarden user data frame csv files to a `<name>.samples` file (which is a bincode serialized version of `InMemorySamples`).

For the 500_000 samples with are ~5.4GiB unpacked on disk this will produce a 875MiB file. Which if compiled in release mode will load in ~1s (or ~50s if not in release mode).

The `<name>.samples` files are used for training using soundgarden data, both with the classical training which is added in part 3 and the XaynNet emulation training which will be added in a followup PR.

PS:
Also don't forget that each split out PR will contain all changes of the previous PR until that is merged and this PR is rebased so this PR doesn't have ~2200 changes but ~1800.