### PR TITLE
TY-1931 ListNet training with soundgarden: Split PR, part 3. Add train CLI.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "displaydoc",
  "env_logger",
  "float-cmp 0.9.0",
+ "indicatif",
  "itertools",
  "log",
  "ndarray",

--- a/dev-tool/Cargo.toml
+++ b/dev-tool/Cargo.toml
@@ -23,6 +23,7 @@ displaydoc = "0.2.3"
 csv = "1.1.6"
 uuid = "0.8.2"
 itertools = "0.10.0"
+indicatif = "0.16.0"
 
 [dev-dependencies]
 float-cmp = "0.9.0"

--- a/dev-tool/Cargo.toml
+++ b/dev-tool/Cargo.toml
@@ -23,7 +23,7 @@ displaydoc = "0.2.3"
 csv = "1.1.6"
 uuid = "0.8.2"
 itertools = "0.10.0"
-indicatif = "0.16.0"
+indicatif = "0.16.2"
 
 [dev-dependencies]
 float-cmp = "0.9.0"

--- a/dev-tool/src/list_net.rs
+++ b/dev-tool/src/list_net.rs
@@ -2,14 +2,18 @@
 use anyhow::Error;
 use structopt::StructOpt;
 
-use self::convert::ConvertCmd;
+use self::{convert::ConvertCmd, train::TrainCmd};
+
+mod cli_callbacks;
 mod convert;
 mod data_source;
+mod train;
 
 /// Commands related to training ListNet (train, convert, inspect).
 #[derive(StructOpt, Debug)]
 pub enum ListNetCmd {
     Convert(ConvertCmd),
+    Train(TrainCmd),
 }
 
 impl ListNetCmd {
@@ -17,6 +21,7 @@ impl ListNetCmd {
         use ListNetCmd::*;
         match self {
             Convert(cmd) => cmd.run(),
+            Train(cmd) => cmd.run(),
         }
     }
 }

--- a/dev-tool/src/list_net/cli_callbacks.rs
+++ b/dev-tool/src/list_net/cli_callbacks.rs
@@ -1,0 +1,218 @@
+#![cfg(not(tarpaulin))]
+
+use std::{convert::TryInto, path::PathBuf, time::Instant};
+
+use bincode::Error;
+use indicatif::{FormattedDuration, MultiProgress, ProgressBar, ProgressStyle};
+use log::{debug, info, trace};
+use xayn_ai::list_net::{ListNet, TrainingController};
+
+/// Builder to create a [`CliTrainingController`].
+pub(crate) struct CliTrainingControllerBuilder {
+    /// The output dir into which files are written.
+    pub(crate) out_dir: PathBuf,
+
+    /// If true dumps the initial parameters.
+    ///
+    /// This is can be useful if the initial parameters
+    /// have been freshly created using some random
+    /// initializer.
+    pub(crate) dump_initial_parameters: bool,
+
+    /// If included dumps the current ListNet parameters every `n` epochs.
+    ///
+    /// The ListNet will be written to the output folder in the form of
+    /// `list_net_{epoch}.binparams`.
+    pub(crate) dump_every: Option<usize>,
+}
+
+impl CliTrainingControllerBuilder {
+    /// Builds the `CliTrainingController`.
+    pub(crate) fn build(self) -> CliTrainingController {
+        CliTrainingController {
+            setting: self,
+            current_epoch: 0,
+            current_batch: 0,
+            start_time: None,
+            epoch_progress_bar: None,
+            train_progress_bar: None,
+        }
+    }
+}
+
+/// Training controller for usage in a CLI setup.
+pub(crate) struct CliTrainingController {
+    /// The settings to use when controlling the training.
+    setting: CliTrainingControllerBuilder,
+    /// The current active (or just ended) epoch.
+    current_epoch: usize,
+    /// The current active (or just ended) batch.
+    current_batch: usize,
+    /// The time at which the training did start.
+    start_time: Option<Instant>,
+    /// A (CLI) progress bar used to track the progress of the current epoch.
+    epoch_progress_bar: Option<ProgressBar>,
+    /// A (CLI) progress bar used to track the progress of the current training.
+    train_progress_bar: Option<ProgressBar>,
+}
+
+impl CliTrainingController {
+    /// Safe the current ListNet parameters to the output dir using the given suffix.
+    ///
+    /// The file path will be:
+    ///
+    /// `<out_dir>/list_net_<suffix>.binparams`
+    fn save_parameters(&self, list_net: ListNet, suffix: &str) -> Result<(), Error> {
+        let file_path = self
+            .setting
+            .out_dir
+            .join(format!("list_net_{:0>4}.binparams", suffix));
+        list_net.serialize_into_file(file_path).map_err(Into::into)
+    }
+}
+
+impl TrainingController for CliTrainingController {
+    type Error = Error;
+
+    type Outcome = ();
+
+    fn begin_of_batch(&mut self) -> Result<(), Self::Error> {
+        trace!("Start of batch #{}", self.current_batch);
+        Ok(())
+    }
+
+    fn end_of_batch(&mut self, losses: Vec<f32>) -> Result<(), Self::Error> {
+        let loss = mean_loss(&losses);
+        trace!("End of batch #{}, mean loss = {}", self.current_batch, loss);
+        if let Some(bar) = &self.epoch_progress_bar {
+            bar.inc(1);
+        }
+        self.current_batch += 1;
+        Ok(())
+    }
+
+    fn begin_of_epoch(
+        &mut self,
+        nr_batches: usize,
+        _list_net: &ListNet,
+    ) -> Result<(), Self::Error> {
+        debug!(
+            "Begin of epoch #{:0>4} (#batch {})",
+            self.current_epoch, nr_batches
+        );
+        self.current_batch = 0;
+        if let Some(bar) = &self.epoch_progress_bar {
+            bar.set_position(0);
+            bar.set_length(nr_batches.try_into().unwrap());
+        }
+        Ok(())
+    }
+
+    fn end_of_epoch(
+        &mut self,
+        list_net: &ListNet,
+        mean_kl_divergence_evaluation: Option<f32>,
+    ) -> Result<(), Self::Error> {
+        debug!(
+            "End of epoch #{}, Mean eval. KL-Divergence {:?}",
+            self.current_epoch, mean_kl_divergence_evaluation
+        );
+
+        if let Some(dump_every) = self.setting.dump_every {
+            if (self.current_epoch + 1) % dump_every == 0 {
+                trace!("Dumping parameters.");
+                self.save_parameters(list_net.clone(), &format!("{}", self.current_epoch))?;
+            }
+        }
+
+        if let Some(bar) = &self.train_progress_bar {
+            bar.inc(1);
+        }
+
+        //FIXME This can always happen (after a longer training, mainly
+        //      if training with inadequate data or parameters). Still
+        //      we want to handle this better in the future.
+        if mean_kl_divergence_evaluation
+            .map(|v| v.is_nan())
+            .unwrap_or_default()
+        {
+            panic!("evaluation KL-Divergence cost is NaN");
+        }
+
+        self.current_epoch += 1;
+        Ok(())
+    }
+
+    fn begin_of_training(
+        &mut self,
+        nr_epochs: usize,
+        list_net: &ListNet,
+    ) -> Result<(), Self::Error> {
+        self.start_time = Some(Instant::now());
+        info!("Begin of training for {}", nr_epochs);
+        if self.setting.dump_initial_parameters {
+            trace!("Dumping initial parameters.");
+            self.save_parameters(list_net.clone(), "initial")?;
+        }
+
+        let multibar = MultiProgress::new();
+        let train_bar = ProgressBar::new(nr_epochs.try_into().unwrap());
+        train_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("Epochs:  [{bar:50.green}] {percent:>3}% ({pos:>5}/{len:>5})")
+                .progress_chars("=> "),
+        );
+        multibar.add(train_bar.clone());
+        let epoch_bar = ProgressBar::new(1);
+        epoch_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("Batches: [{bar:50.green}] {percent:>3}% ({pos:>5}/{len:>5})")
+                .progress_chars("=> "),
+        );
+        multibar.add(epoch_bar.clone());
+        // Needed or else bars won't print to the screen.
+        std::thread::spawn(move || multibar.join());
+        train_bar.tick();
+        epoch_bar.tick();
+
+        self.train_progress_bar = Some(train_bar);
+        self.epoch_progress_bar = Some(epoch_bar);
+        Ok(())
+    }
+
+    fn end_of_training(&mut self) -> Result<(), Self::Error> {
+        let elapsed = self.start_time.map(|t| t.elapsed()).unwrap_or_default();
+        info!("End of training. Duration: {}", FormattedDuration(elapsed));
+        Ok(())
+    }
+
+    fn training_result(self, list_net: ListNet) -> Result<Self::Outcome, Self::Error> {
+        if let Some(bar) = &self.epoch_progress_bar {
+            bar.finish_at_current_pos();
+        }
+        if let Some(bar) = &self.train_progress_bar {
+            bar.finish_at_current_pos();
+        }
+        info!("Save final ListNet parameters.");
+        self.save_parameters(list_net, "final")?;
+        Ok(())
+    }
+}
+
+/// Calculates the mean loss.
+fn mean_loss(losses: &[f32]) -> f32 {
+    let count = losses.len() as f32;
+    losses.iter().fold(0f32, |acc, v| acc + v / count)
+}
+
+#[cfg(test)]
+mod tests {
+    use xayn_ai::assert_approx_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_mean_loss() {
+        assert_approx_eq!(f32, mean_loss(&[0.5, 0.75, 0.25, 0.5]), 0.5);
+    }
+}

--- a/dev-tool/src/list_net/cli_callbacks.rs
+++ b/dev-tool/src/list_net/cli_callbacks.rs
@@ -91,11 +91,7 @@ impl TrainingController for CliTrainingController {
         Ok(())
     }
 
-    fn begin_of_epoch(
-        &mut self,
-        nr_batches: usize,
-        _list_net: &ListNet,
-    ) -> Result<(), Self::Error> {
+    fn begin_of_epoch(&mut self, nr_batches: usize) -> Result<(), Self::Error> {
         debug!(
             "Begin of epoch #{:0>4} (#batch {})",
             self.current_epoch, nr_batches

--- a/dev-tool/src/list_net/cli_callbacks.rs
+++ b/dev-tool/src/list_net/cli_callbacks.rs
@@ -14,7 +14,7 @@ pub(crate) struct CliTrainingControllerBuilder {
 
     /// If true dumps the initial parameters.
     ///
-    /// This is can be useful if the initial parameters
+    /// This can be useful if the initial parameters
     /// have been freshly created using some random
     /// initializer.
     pub(crate) dump_initial_parameters: bool,

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -50,7 +50,6 @@ where
     /// - If there are no evaluation samples with the given `evaluation_split`,
     ///   but the split is not `0`.
     /// - If calling `storage.data_ids()` failed.
-    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
     pub(crate) fn new(
         storage: S,
         evaluation_split: f32,

--- a/dev-tool/src/list_net/train.rs
+++ b/dev-tool/src/list_net/train.rs
@@ -1,0 +1,101 @@
+#![cfg(not(tarpaulin))]
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Error};
+use structopt::StructOpt;
+use xayn_ai::list_net::{optimizer::MiniBatchSgd, ListNet, ListNetTrainer};
+
+use crate::exit_code::NO_ERROR;
+
+use super::{
+    cli_callbacks::CliTrainingControllerBuilder,
+    data_source::{DataSource, InMemorySamples},
+};
+
+/// Trains a ListNet.
+#[derive(StructOpt, Debug)]
+pub struct TrainCmd {
+    /// A file containing samples we can train and evaluate on.
+    #[structopt(long)]
+    samples: PathBuf,
+
+    /// The number of epochs to run.
+    #[structopt(long)]
+    epochs: usize,
+
+    /// The batch size to use.
+    #[structopt(long, default_value = "32")]
+    batch_size: usize,
+
+    /// The percent of samples to use for evaluation.
+    ///
+    /// The evaluation samples will be taken
+    /// from the back of the data source. This
+    /// means the same split used with the same
+    /// samples file will yield the exact same
+    /// training and evaluation samples every
+    /// time.
+    #[structopt(long, default_value = "0.2")]
+    evaluation_split: f32,
+
+    /// The learning rate to use.
+    #[structopt(long, default_value = "0.1")]
+    learning_rate: f32,
+
+    /// Uses given parameters instead of initializing them randomly.
+    #[structopt(long)]
+    use_initial_parameters: Option<PathBuf>,
+
+    /// Directory to store outputs in.
+    #[structopt(short, long, default_value = "./")]
+    out_dir: PathBuf,
+
+    /// After how many epochs a intermediate result should be dumped (if at all).
+    #[structopt(long)]
+    dump_every: Option<usize>,
+
+    /// Dumps the initial parameters before any training was done.
+    #[structopt(long)]
+    dump_initial_parameters: bool,
+}
+
+impl TrainCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        let TrainCmd {
+            samples,
+            epochs,
+            batch_size,
+            evaluation_split,
+            learning_rate,
+            use_initial_parameters,
+            out_dir,
+            dump_every,
+            dump_initial_parameters,
+        } = self;
+
+        let storage = InMemorySamples::deserialize_from_file(samples)
+            .context("Loading training & evaluation samples failed.")?;
+        let data_source =
+            DataSource::new(storage, evaluation_split).context("Creating DataSource failed.")?;
+
+        let callbacks = CliTrainingControllerBuilder {
+            out_dir,
+            dump_initial_parameters,
+            dump_every,
+        }
+        .build();
+
+        let optimizer = MiniBatchSgd { learning_rate };
+
+        let list_net = if let Some(initial_params_file) = use_initial_parameters {
+            ListNet::deserialize_from_file(initial_params_file)?
+        } else {
+            ListNet::new_with_random_weights()
+        };
+
+        let trainer = ListNetTrainer::new(list_net, data_source, callbacks, optimizer);
+        trainer.train(epochs, batch_size)?;
+        Ok(NO_ERROR)
+    }
+}

--- a/dev-tool/src/list_net/train.rs
+++ b/dev-tool/src/list_net/train.rs
@@ -51,7 +51,7 @@ pub struct TrainCmd {
     #[structopt(short, long, default_value = "./")]
     out_dir: PathBuf,
 
-    /// After how many epochs a intermediate result should be dumped (if at all).
+    /// After how many epochs an intermediate result should be dumped (if at all).
     #[structopt(long)]
     dump_every: Option<usize>,
 

--- a/xayn-ai/src/ltr/list_net/mod.rs
+++ b/xayn-ai/src/ltr/list_net/mod.rs
@@ -590,7 +590,7 @@ where
                 .reset(batch_size)
                 .map_err(TrainingError::Data)?;
             self.callbacks
-                .begin_of_epoch(nr_batches, &self.list_net)
+                .begin_of_epoch(nr_batches)
                 .map_err(TrainingError::Control)?;
 
             while self.train_next_batch()? {}
@@ -737,7 +737,7 @@ pub trait TrainingController {
     fn end_of_batch(&mut self, losses: Vec<f32>) -> Result<(), Self::Error>;
 
     /// Called at the begin of each epoch.
-    fn begin_of_epoch(&mut self, nr_batches: usize, list_net: &ListNet) -> Result<(), Self::Error>;
+    fn begin_of_epoch(&mut self, nr_batches: usize) -> Result<(), Self::Error>;
 
     /// Called at the end of each epoch with the mean of running the evaluation with KL-Divergence.
     ///

--- a/xayn-ai/src/ltr/list_net/tests/training.rs
+++ b/xayn-ai/src/ltr/list_net/tests/training.rs
@@ -125,12 +125,8 @@ impl TrainingController for TestController {
         Ok(())
     }
 
-    fn begin_of_epoch(
-        &mut self,
-        _nr_batches: usize,
-        _list_net: &ListNet,
-    ) -> Result<(), Self::Error> {
-        eprintln!("begin of epoch");
+    fn begin_of_epoch(&mut self, nr_batches: usize) -> Result<(), Self::Error> {
+        eprintln!("begin of epoch ({} batches)", nr_batches);
         Ok(())
     }
 


### PR DESCRIPTION
Allows training of a ListNet using soundgarden data converted to a `.samples` file.

This doesn't yet include the emulation of `XaynNet`.

Some features like choosing a weight initializer, parallelized training or better support for huge batch sizes 
are done in a follow up PR.

Side note: 
A follow up PR parallelizes the training speeding it up by quite a bit, especially if run in release mode.