### PR TITLE
TY-1931 ListNet training with soundgarden: Split PR, part 4. Add inspect CLI utility.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "displaydoc",
  "env_logger",
  "float-cmp",
+ "indicatif",
  "itertools",
  "log",
  "ndarray",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,9 +429,20 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bincode",
+ "csv",
+ "displaydoc",
+ "env_logger",
+ "float-cmp",
+ "itertools",
+ "log",
+ "ndarray",
+ "rand",
  "serde",
  "serde_json",
  "structopt",
+ "thiserror",
+ "uuid",
  "xayn-ai",
 ]
 
@@ -452,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3274a6bc8a6a4521291b53b9dcb8345e963fe931c3fc462a7d3ead71d7ccd30d"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -520,6 +531,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -640,6 +664,12 @@ checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
@@ -1744,6 +1774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1764,18 +1803,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dev-tool/Cargo.toml
+++ b/dev-tool/Cargo.toml
@@ -23,6 +23,7 @@ displaydoc = "0.2.3"
 csv = "1.1.6"
 uuid = "0.8.2"
 itertools = "0.10.0"
+indicatif = "0.16.0"
 
 [dev-dependencies]
 float-cmp = "0.8.0"

--- a/dev-tool/Cargo.toml
+++ b/dev-tool/Cargo.toml
@@ -12,4 +12,17 @@ structopt = "0.3.21"
 xayn-ai = { path="../xayn-ai" }
 serde = { version="1.0.126", features=["derive"]}
 serde_json = "1.0.64"
+bincode = "1.3.3"
 base64 = "0.13.0"
+rand = "0.8.3"
+ndarray = "0.15.3"
+log = "0.4.14"
+env_logger =  "0.9.0"
+thiserror = "1.0.26"
+displaydoc = "0.2.3"
+csv = "1.1.6"
+uuid = "0.8.2"
+itertools = "0.10.0"
+
+[dev-dependencies]
+float-cmp = "0.8.0"

--- a/dev-tool/src/list_net.rs
+++ b/dev-tool/src/list_net.rs
@@ -2,14 +2,18 @@
 use anyhow::Error;
 use structopt::StructOpt;
 
-use self::convert::ConvertCmd;
+use self::{convert::ConvertCmd, train::TrainCmd};
+
+mod cli_callbacks;
 mod convert;
 mod data_source;
+mod train;
 
 /// Commands related to training ListNet (train, convert, inspect).
 #[derive(StructOpt, Debug)]
 pub enum ListNetCmd {
     Convert(ConvertCmd),
+    Train(TrainCmd),
 }
 
 impl ListNetCmd {
@@ -17,6 +21,7 @@ impl ListNetCmd {
         use ListNetCmd::*;
         match self {
             Convert(cmd) => cmd.run(),
+            Train(cmd) => cmd.run(),
         }
     }
 }

--- a/dev-tool/src/list_net.rs
+++ b/dev-tool/src/list_net.rs
@@ -2,11 +2,12 @@
 use anyhow::Error;
 use structopt::StructOpt;
 
-use self::{convert::ConvertCmd, train::TrainCmd};
+use self::{convert::ConvertCmd, inspect::InspectCmd, train::TrainCmd};
 
 mod cli_callbacks;
 mod convert;
 mod data_source;
+mod inspect;
 mod train;
 
 /// Commands related to training ListNet (train, convert, inspect).
@@ -14,6 +15,7 @@ mod train;
 pub enum ListNetCmd {
     Convert(ConvertCmd),
     Train(TrainCmd),
+    Inspect(InspectCmd),
 }
 
 impl ListNetCmd {
@@ -22,6 +24,7 @@ impl ListNetCmd {
         match self {
             Convert(cmd) => cmd.run(),
             Train(cmd) => cmd.run(),
+            Inspect(cmd) => cmd.run(),
         }
     }
 }

--- a/dev-tool/src/list_net.rs
+++ b/dev-tool/src/list_net.rs
@@ -1,0 +1,22 @@
+#![cfg(not(tarpaulin))]
+use anyhow::Error;
+use structopt::StructOpt;
+
+use self::convert::ConvertCmd;
+mod convert;
+mod data_source;
+
+/// Commands related to training ListNet (train, convert, inspect).
+#[derive(StructOpt, Debug)]
+pub enum ListNetCmd {
+    Convert(ConvertCmd),
+}
+
+impl ListNetCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        use ListNetCmd::*;
+        match self {
+            Convert(cmd) => cmd.run(),
+        }
+    }
+}

--- a/dev-tool/src/list_net/cli_callbacks.rs
+++ b/dev-tool/src/list_net/cli_callbacks.rs
@@ -1,0 +1,218 @@
+#![cfg(not(tarpaulin))]
+
+use std::{convert::TryInto, path::PathBuf, time::Instant};
+
+use bincode::Error;
+use indicatif::{FormattedDuration, MultiProgress, ProgressBar, ProgressStyle};
+use log::{debug, info, trace};
+use xayn_ai::list_net::{ListNet, TrainingController};
+
+/// Builder to create a [`CliTrainingController`].
+pub(crate) struct CliTrainingControllerBuilder {
+    /// The output dir into which files are written.
+    pub(crate) out_dir: PathBuf,
+
+    /// If true dumps the initial parameters.
+    ///
+    /// This is can be useful if the initial parameters
+    /// have been freshly created using some random
+    /// initializer.
+    pub(crate) dump_initial_parameters: bool,
+
+    /// If included dumps the current ListNet parameters every `n` epochs.
+    ///
+    /// The ListNet will be written to the output folder in the form of
+    /// `list_net_{epoch}.binparams`.
+    pub(crate) dump_every: Option<usize>,
+}
+
+impl CliTrainingControllerBuilder {
+    /// Builds the `CliTrainingController`.
+    pub(crate) fn build(self) -> CliTrainingController {
+        CliTrainingController {
+            setting: self,
+            current_epoch: 0,
+            current_batch: 0,
+            start_time: None,
+            epoch_progress_bar: None,
+            train_progress_bar: None,
+        }
+    }
+}
+
+/// Training controller for usage in a CLI setup.
+pub(crate) struct CliTrainingController {
+    /// The settings to use when controlling the training.
+    setting: CliTrainingControllerBuilder,
+    /// The current active (or just ended) epoch.
+    current_epoch: usize,
+    /// The current active (or just ended) batch.
+    current_batch: usize,
+    /// The time at which the training did start.
+    start_time: Option<Instant>,
+    /// A (CLI) progress bar used to track the progress of the current epoch.
+    epoch_progress_bar: Option<ProgressBar>,
+    /// A (CLI) progress bar used to track the progress of the current training.
+    train_progress_bar: Option<ProgressBar>,
+}
+
+impl CliTrainingController {
+    /// Safe the current ListNet parameters to the output dir using the given suffix.
+    ///
+    /// The file path will be:
+    ///
+    /// `<out_dir>/list_net_<suffix>.binparams`
+    fn save_parameters(&self, list_net: ListNet, suffix: &str) -> Result<(), Error> {
+        let file_path = self
+            .setting
+            .out_dir
+            .join(format!("list_net_{:0>4}.binparams", suffix));
+        list_net.serialize_into_file(file_path).map_err(Into::into)
+    }
+}
+
+impl TrainingController for CliTrainingController {
+    type Error = Error;
+
+    type Outcome = ();
+
+    fn begin_of_batch(&mut self) -> Result<(), Self::Error> {
+        trace!("Start of batch #{}", self.current_batch);
+        Ok(())
+    }
+
+    fn end_of_batch(&mut self, losses: Vec<f32>) -> Result<(), Self::Error> {
+        let loss = mean_loss(&losses);
+        trace!("End of batch #{}, mean loss = {}", self.current_batch, loss);
+        if let Some(bar) = &self.epoch_progress_bar {
+            bar.inc(1);
+        }
+        self.current_batch += 1;
+        Ok(())
+    }
+
+    fn begin_of_epoch(
+        &mut self,
+        nr_batches: usize,
+        _list_net: &ListNet,
+    ) -> Result<(), Self::Error> {
+        debug!(
+            "Begin of epoch #{:0>4} (#batch {})",
+            self.current_epoch, nr_batches
+        );
+        self.current_batch = 0;
+        if let Some(bar) = &self.epoch_progress_bar {
+            bar.set_position(0);
+            bar.set_length(nr_batches.try_into().unwrap());
+        }
+        Ok(())
+    }
+
+    fn end_of_epoch(
+        &mut self,
+        list_net: &ListNet,
+        mean_kl_divergence_evaluation: Option<f32>,
+    ) -> Result<(), Self::Error> {
+        debug!(
+            "End of epoch #{}, Mean eval. KL-Divergence {:?}",
+            self.current_epoch, mean_kl_divergence_evaluation
+        );
+
+        if let Some(dump_every) = self.setting.dump_every {
+            if (self.current_epoch + 1) % dump_every == 0 {
+                trace!("Dumping parameters.");
+                self.save_parameters(list_net.clone(), &format!("{}", self.current_epoch))?;
+            }
+        }
+
+        if let Some(bar) = &self.train_progress_bar {
+            bar.inc(1);
+        }
+
+        //FIXME This can always happen (after a longer training, mainly
+        //      if training with inadequate data or parameters). Still
+        //      we want to handle this better in the future.
+        if mean_kl_divergence_evaluation
+            .map(|v| v.is_nan())
+            .unwrap_or_default()
+        {
+            panic!("evaluation KL-Divergence cost is NaN");
+        }
+
+        self.current_epoch += 1;
+        Ok(())
+    }
+
+    fn begin_of_training(
+        &mut self,
+        nr_epochs: usize,
+        list_net: &ListNet,
+    ) -> Result<(), Self::Error> {
+        self.start_time = Some(Instant::now());
+        info!("Begin of training for {}", nr_epochs);
+        if self.setting.dump_initial_parameters {
+            trace!("Dumping initial parameters.");
+            self.save_parameters(list_net.clone(), "initial")?;
+        }
+
+        let multibar = MultiProgress::new();
+        let train_bar = ProgressBar::new(nr_epochs.try_into().unwrap());
+        train_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("Epochs:  [{bar:50.green}] {percent:>3}% ({pos:>5}/{len:>5})")
+                .progress_chars("=> "),
+        );
+        multibar.add(train_bar.clone());
+        let epoch_bar = ProgressBar::new(1);
+        epoch_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("Batches: [{bar:50.green}] {percent:>3}% ({pos:>5}/{len:>5})")
+                .progress_chars("=> "),
+        );
+        multibar.add(epoch_bar.clone());
+        // Needed or else bars won't print to the screen.
+        std::thread::spawn(move || multibar.join());
+        train_bar.tick();
+        epoch_bar.tick();
+
+        self.train_progress_bar = Some(train_bar);
+        self.epoch_progress_bar = Some(epoch_bar);
+        Ok(())
+    }
+
+    fn end_of_training(&mut self) -> Result<(), Self::Error> {
+        let elapsed = self.start_time.map(|t| t.elapsed()).unwrap_or_default();
+        info!("End of training. Duration: {}", FormattedDuration(elapsed));
+        Ok(())
+    }
+
+    fn training_result(self, list_net: ListNet) -> Result<Self::Outcome, Self::Error> {
+        if let Some(bar) = &self.epoch_progress_bar {
+            bar.finish_at_current_pos();
+        }
+        if let Some(bar) = &self.train_progress_bar {
+            bar.finish_at_current_pos();
+        }
+        info!("Save final ListNet parameters.");
+        self.save_parameters(list_net, "final")?;
+        Ok(())
+    }
+}
+
+/// Calculates the mean loss.
+fn mean_loss(losses: &[f32]) -> f32 {
+    let count = losses.len() as f32;
+    losses.iter().fold(0f32, |acc, v| acc + v / count)
+}
+
+#[cfg(test)]
+mod tests {
+    use xayn_ai::assert_approx_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_mean_loss() {
+        assert_approx_eq!(f32, mean_loss(&[0.5, 0.75, 0.25, 0.5]), 0.5);
+    }
+}

--- a/dev-tool/src/list_net/convert.rs
+++ b/dev-tool/src/list_net/convert.rs
@@ -1,0 +1,515 @@
+#![cfg(not(tarpaulin))]
+
+use std::{
+    convert::TryInto,
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Error;
+use itertools::Itertools;
+use log::debug;
+use serde::Deserialize;
+use structopt::StructOpt;
+use uuid::Uuid;
+
+use xayn_ai::{
+    list_net_training_data_from_history,
+    DayOfWeek,
+    DocumentHistory,
+    DocumentId,
+    QueryId,
+    Relevance,
+    SessionId,
+    UserAction,
+    UserFeedback,
+};
+
+use super::data_source::InMemorySamples;
+use crate::exit_code::NO_ERROR;
+
+/// Converts different file formats.
+///
+/// This is mainly used to prepare a samples file
+/// based on a directory containing soundgarden user
+/// data-frame csv files.
+#[derive(Debug, StructOpt)]
+pub struct ConvertCmd {
+    /// Directory in which soundgarden saved user data-frames (one csv file per user).
+    #[structopt(short = "d", long)]
+    from_soundgarden: PathBuf,
+    /// File in which the samples should be stored, e.g. `data.samples`.
+    #[structopt(short = "o", long)]
+    to_samples: PathBuf,
+}
+
+impl ConvertCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        let ConvertCmd {
+            from_soundgarden,
+            to_samples,
+        } = self;
+
+        let mut storage = InMemorySamples::default();
+
+        for entry in fs::read_dir(&from_soundgarden)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension() != Some(OsStr::new("csv")) {
+                continue;
+            }
+
+            debug!("Loading history for {:?}.", path.file_name().unwrap());
+            let history = load_history(path)?;
+            debug!("Processing history");
+            for (inputs, target_prob_dist) in list_net_training_data_from_history(&history)? {
+                storage.add_sample(inputs.view(), target_prob_dist.view())?;
+            }
+        }
+
+        debug!("Write output file.");
+        storage.serialize_into_file(to_samples)?;
+
+        Ok(NO_ERROR)
+    }
+}
+
+//FIXME[follow up PR]: Change ltr feature extraction tests to share code with
+//                     this implementation and then to use the normal soundgarden
+//                     user data-frames instead of specially pre-processed csv
+//                     files.
+//
+//FIXME maybe verify the structural integrity of the file, currently it's expected
+// to have the records partitioned by query as well as sorted both in each query
+// (first ranked record to last ranked record) and in between queries (oldest
+// query to newest query).
+//
+/// Loads a history from a soundgarden user data-frame csv file.
+///
+/// The [`UserAction`] values will be inferred from the data in the
+/// same way soundgarden does so.
+fn load_history(path: impl AsRef<Path>) -> Result<Vec<DocumentHistory>, Error> {
+    let mut reader = csv::Reader::from_path(path)?;
+
+    let mut history = Vec::new();
+    for (counter, record) in reader.deserialize().enumerate() {
+        let record: SoundgardenUserDfRecord = record?;
+        history.push(
+            record.into_document_history_with_bad_user_action(
+                counter
+                    .try_into()
+                    .expect("User with more then 2^32-1 records."),
+            ),
+        );
+    }
+
+    fix_user_actions_in_history(&mut history);
+
+    Ok(history)
+}
+
+/// Struct to load a soundgarden user data-frame csv file record into.
+#[derive(Deserialize)]
+struct SoundgardenUserDfRecord {
+    /// Session Id, is an incremental unsigned integer in soundgarden.
+    session_id: u64,
+    /// Query Id, same for all queries using the same parameters.
+    query_id: u64,
+    /// User Id, arbitrary unsigned integer.
+    ///
+    /// We treat all data as if it's from the same user, so we
+    /// don't really need it but we use it to infer an appropriate
+    /// deterministic document id.
+    user_id: u64,
+    /// Number of days since the start of the soundgarden history.
+    ///
+    /// Starting with `Tue == 1`.
+    ///
+    /// As such `Mon` is `0`, `Wed` is `2` etc.
+    ///
+    /// The number is not limited to `0..=6`, e.g. all of `1`,`8`,`15` are `Tue`
+    day: usize,
+    /// The words of the query as *comma* separated string.
+    ///
+    /// This are not actual words but string encoded word ids.
+    /// E.g. `"2142,53423"` but treating `2142` as a word is not
+    /// a problem for our use-case.
+    query_words: String,
+    /// The url of the document.
+    ///
+    /// Theoretically this is also an "arbitrary" unsigned integer id, but
+    /// practically it's simpler to just treat it as a string.
+    url: String,
+    /// The domain of the document.
+    ///
+    /// Theoretically this is also an "arbitrary" unsigned integer id, but
+    /// practically it's simpler to just treat it as a string.
+    domain: String,
+    /// The relevance of the document.
+    relevance: Relevance,
+    /// The position of the document, *starting with `1`*.
+    position: usize,
+    /// The index of the query in the session it belongs to.
+    query_counter: usize,
+}
+
+impl SoundgardenUserDfRecord {
+    /// Creates a [`DocumentHistory`] from this record.
+    ///
+    /// The `user_action` field *will* be incorrect and
+    /// needs to be fixed separately. This is the case
+    /// as the other documents need to be known to
+    /// infer the [`UserAction`] correctly.
+    fn into_document_history_with_bad_user_action(
+        self,
+        per_user_result_counter: u32,
+    ) -> DocumentHistory {
+        let Self {
+            session_id,
+            query_id,
+            user_id,
+            day,
+            query_words,
+            url,
+            domain,
+            relevance,
+            position,
+            query_counter,
+        } = self;
+
+        DocumentHistory {
+            // By combining the `user_id` with a monotonic increasing per-user counter
+            // we can create deterministically an appropriate document id.
+            id: DocumentId(id2uuid(user_id, Some(per_user_result_counter))),
+            relevance,
+            user_feedback: UserFeedback::NotGiven,
+            session: SessionId(id2uuid(session_id, None)),
+            query_count: query_counter,
+            query_id: QueryId(id2uuid(query_id, None)),
+            query_words: query_words.replace(",", " "),
+            day: day_from_day_offset(day),
+            url,
+            domain,
+            rank: position.checked_sub(1).unwrap(),
+            user_action: UserAction::Miss,
+        }
+    }
+}
+
+/// Updates the history with user actions inferred from the context.
+///
+/// This uses the same approach as in soundgarden.
+fn fix_user_actions_in_history(histories: &mut [DocumentHistory]) {
+    // Soundgarden User Df are already grouped by query and sorted, ordered from past to present.
+    // (There is a FIXME for this above.)
+    histories
+        .iter_mut()
+        .rev()
+        .group_by(|d| d.query_id)
+        .into_iter()
+        .for_each(|(_, query)| fix_user_actions_in_query_reverse_order(query))
+}
+
+/// Function Split out from [`fix_user_actions_in_history`] **do not reuse elsewhere**.
+///
+/// The iterator must iterate over queries from last to first.
+fn fix_user_actions_in_query_reverse_order<'a>(
+    query: impl IntoIterator<Item = &'a mut DocumentHistory>,
+) {
+    let mut has_clicked_docs_after_it = false;
+    for doc in query.into_iter() {
+        doc.user_action = match doc.relevance {
+            Relevance::High | Relevance::Medium => {
+                has_clicked_docs_after_it = true;
+                UserAction::Click
+            }
+            Relevance::Low => {
+                if has_clicked_docs_after_it {
+                    UserAction::Skip
+                } else {
+                    UserAction::Miss
+                }
+            }
+        }
+    }
+}
+
+/// Crate a [`DayOfWeek`] instance from an offset.
+fn day_from_day_offset(day: usize) -> DayOfWeek {
+    use DayOfWeek::*;
+    static DAYS: &[DayOfWeek] = &[Mon, Tue, Wed, Thu, Fri, Sat, Sun];
+    DAYS[day % 7]
+}
+
+/// Creates an UUID by combining `YYYYYYYY-eb92-4d36-XXXX-XXXXXXXXXXXX` with given `sub_id`(s).
+///
+/// - `X..` is replaced with the `sub_id`.
+///
+/// - `Y..` is replaced with the `sub_id2` if given. If
+///       not given `0xd006a685` is used instead.
+fn id2uuid(sub_id: u64, sub_id2: Option<u32>) -> Uuid {
+    const BASE_UUID: u128 = 0x00000000_eb92_4d36_0000_000000000000;
+    const DEFAULT_SUB_ID_2: u32 = 0xd006a685;
+    let sub_id2 = sub_id2.unwrap_or(DEFAULT_SUB_ID_2);
+    let sub_id2 = (sub_id2 as u128) << 96;
+    uuid::Uuid::from_u128(sub_id2 | BASE_UUID | (sub_id as u128))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_id2uuid() {
+        assert_eq!(
+            id2uuid(0, Some(0)),
+            Uuid::from_u128(0x00000000_eb92_4d36_0000_000000000000)
+        );
+        assert_eq!(
+            id2uuid(0, None),
+            Uuid::from_u128(0xd006a685_eb92_4d36_0000_000000000000)
+        );
+        assert_eq!(
+            id2uuid(u64::MAX, Some(u32::MAX)),
+            Uuid::from_u128(0xffffffff_eb92_4d36_ffff_ffffffffffff)
+        )
+    }
+
+    #[test]
+    fn test_day_from_offset() {
+        assert_eq!(day_from_day_offset(0), DayOfWeek::Mon);
+        assert_eq!(day_from_day_offset(1), DayOfWeek::Tue);
+        assert_eq!(day_from_day_offset(2), DayOfWeek::Wed);
+        assert_eq!(day_from_day_offset(3), DayOfWeek::Thu);
+        assert_eq!(day_from_day_offset(4), DayOfWeek::Fri);
+        assert_eq!(day_from_day_offset(5), DayOfWeek::Sat);
+        assert_eq!(day_from_day_offset(6), DayOfWeek::Sun);
+        assert_eq!(day_from_day_offset(7), DayOfWeek::Mon);
+        assert_eq!(day_from_day_offset(8), DayOfWeek::Tue);
+    }
+
+    #[test]
+    fn test_soundgarden_record_to_document_history() {
+        let record = SoundgardenUserDfRecord {
+            session_id: 10,
+            query_id: 23,
+            user_id: 142313,
+            day: 17,
+            query_words: "123,432".to_owned(),
+            url: "32".to_owned(),
+            domain: "23".to_owned(),
+            relevance: Relevance::Medium,
+            position: 4,
+            query_counter: 12,
+        };
+        let expected = DocumentHistory {
+            id: DocumentId(id2uuid(142313, Some(u32::MAX))),
+            relevance: Relevance::Medium,
+            user_feedback: UserFeedback::NotGiven,
+            session: SessionId(id2uuid(10, None)),
+            query_count: 12,
+            query_id: QueryId(id2uuid(23, None)),
+            query_words: "123 432".to_owned(),
+            day: DayOfWeek::Thu,
+            url: "32".to_owned(),
+            domain: "23".to_owned(),
+            rank: 3,
+            user_action: UserAction::Miss,
+        };
+
+        let history = record.into_document_history_with_bad_user_action(u32::MAX);
+
+        assert_eq!(history, expected);
+    }
+
+    #[test]
+    fn test_fix_user_action_in_history() {
+        let mut history = vec![
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(0))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar/a".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(1))),
+                relevance: Relevance::Medium,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar/b".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 1,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(2))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo/t".to_owned(),
+                rank: 2,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(3))),
+                relevance: Relevance::High,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar-foo/fu".to_owned(),
+                rank: 3,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(4))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 0,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "bar/bar".to_owned(),
+                domain: "bar".to_owned(),
+                rank: 4,
+                user_action: UserAction::Miss,
+            },
+            /* ---- */
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(5))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 1,
+                query_id: QueryId(id2uuid(52, None)),
+                query_words: "bar bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(6))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 1,
+                query_id: QueryId(id2uuid(52, None)),
+                query_words: "bar bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foobar".to_owned(),
+                domain: "barfoo".to_owned(),
+                rank: 1,
+                user_action: UserAction::Miss,
+            },
+            /* ---- */
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(7))),
+                relevance: Relevance::High,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 2,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(8))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 2,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 1,
+                user_action: UserAction::Miss,
+            },
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(9))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 2,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 2,
+                user_action: UserAction::Miss,
+            },
+            /* ---- */
+            DocumentHistory {
+                id: DocumentId(id2uuid(12, Some(10))),
+                relevance: Relevance::Low,
+                user_feedback: UserFeedback::NotGiven,
+                session: SessionId(id2uuid(3441, None)),
+                query_count: 3,
+                query_id: QueryId(id2uuid(42, None)),
+                query_words: "foo bar".to_owned(),
+                day: DayOfWeek::Wed,
+                url: "foo/bar".to_owned(),
+                domain: "bar/foo".to_owned(),
+                rank: 0,
+                user_action: UserAction::Miss,
+            },
+        ];
+        let fixed_history = &[
+            doc_with_action(&history[0], UserAction::Skip),
+            doc_with_action(&history[1], UserAction::Click),
+            doc_with_action(&history[2], UserAction::Skip),
+            doc_with_action(&history[3], UserAction::Click),
+            doc_with_action(&history[4], UserAction::Miss),
+            /* ---- */
+            doc_with_action(&history[5], UserAction::Miss),
+            doc_with_action(&history[6], UserAction::Miss),
+            /* ---- */
+            doc_with_action(&history[7], UserAction::Click),
+            doc_with_action(&history[8], UserAction::Miss),
+            doc_with_action(&history[9], UserAction::Miss),
+            doc_with_action(&history[10], UserAction::Miss),
+        ];
+
+        assert_eq!(history.len(), fixed_history.len());
+
+        fix_user_actions_in_history(&mut history);
+
+        assert_eq!(history, fixed_history);
+
+        fn doc_with_action(doc: &DocumentHistory, action: UserAction) -> DocumentHistory {
+            let mut doc = doc.clone();
+            doc.user_action = action;
+            doc
+        }
+    }
+}

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -50,7 +50,6 @@ where
     /// - If there are no evaluation samples with the given `evaluation_split`,
     ///   but the split is not `0`.
     /// - If calling `storage.data_ids()` failed.
-    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
     pub(crate) fn new(
         storage: S,
         evaluation_split: f32,
@@ -277,13 +276,11 @@ impl InMemorySamples {
     }
 
     /// Deserialize a instance from given file.
-    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
     pub(crate) fn deserialize_from_file(file: impl AsRef<Path>) -> Result<Self, Error> {
         Self::deserialize_from(BufReader::new(File::open(file)?))
     }
 
     /// Deserialize a instance from given reader, preferably pass in a buffered reader.
-    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
     fn deserialize_from(reader: impl Read) -> Result<Self, Error> {
         let self_: Self = bincode::DefaultOptions::new().deserialize_from(reader)?;
         debug!("Loaded {} samples.", self_.data.len());

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -1,0 +1,567 @@
+#![cfg(not(tarpaulin))]
+
+//FIXME[follow up PR]: Move modified parts of this module into the `ltr::list_net` module to re-use them for in-app training.
+use std::{
+    error::Error as StdError,
+    fs::File,
+    io::{BufReader, BufWriter, Read, Write},
+    ops::RangeTo,
+    path::Path,
+    u64,
+};
+
+use anyhow::{bail, Error};
+use bincode::Options;
+use displaydoc::Display;
+use log::debug;
+use ndarray::{ArrayBase, ArrayView, ArrayView1, ArrayView2, Data, Dimension};
+use rand::{prelude::SliceRandom, Rng};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use xayn_ai::list_net::{self, ListNet, Sample};
+
+/// A [`xayn_ai::list_net::DataSource`] implementation.
+pub(crate) struct DataSource<S>
+where
+    S: Storage,
+{
+    /// The storage containing all samples.
+    storage: S,
+    /// The batch size (if already provided).
+    batch_size: Option<usize>,
+    /// A container with all ids of all training samples, returning them in randomized order.
+    training_data_order: DataLookupOrder,
+    /// A container with all ids of all evaluation samples, returning them in randomized order.
+    evaluation_data_order: DataLookupOrder,
+}
+
+impl<S> DataSource<S>
+where
+    S: Storage,
+{
+    /// Creates a new `DataSource` from given storage and evaluation split.
+    ///
+    /// # Errors
+    ///
+    /// - If `evaluation_split` is less then 0 or not a normal float.
+    /// - If there are no samples.
+    /// - If there are no training samples with the given `evaluation_split`.
+    /// - If there are no evaluation samples with the given `evaluation_split`,
+    ///   but the split is not `0`.
+    /// - If calling `storage.data_ids()` failed.
+    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
+    pub(crate) fn new(
+        storage: S,
+        evaluation_split: f32,
+    ) -> Result<Self, DataSourceError<S::Error>> {
+        if evaluation_split < 0. || !evaluation_split.is_normal() {
+            return Err(DataSourceError::BadEvaluationSplit(evaluation_split));
+        }
+        let nr_all_samples = storage.data_ids().map_err(DataSourceError::Storage)?.end;
+        if nr_all_samples == 0 {
+            return Err(DataSourceError::EmptyDatabase);
+        }
+        let nr_evaluation_samples = (nr_all_samples as f32 * evaluation_split).round() as usize;
+        if nr_evaluation_samples >= nr_all_samples {
+            return Err(DataSourceError::ToLargeEvaluationSplit(evaluation_split));
+        }
+        if nr_evaluation_samples == 0 && evaluation_split > 0. {
+            return Err(DataSourceError::NoEvaluationSamples(evaluation_split));
+        }
+        let nr_training_samples = nr_all_samples - nr_evaluation_samples;
+        let evaluation_ids = (nr_training_samples..nr_all_samples).collect();
+        let training_ids = (0..nr_training_samples).collect();
+
+        Ok(Self {
+            storage,
+            batch_size: None,
+            training_data_order: DataLookupOrder::new(training_ids),
+            evaluation_data_order: DataLookupOrder::new(evaluation_ids),
+        })
+    }
+}
+
+#[derive(Error, Debug, Display)]
+pub enum DataSourceError<SE>
+where
+    SE: StdError + 'static,
+{
+    /// Unusable evaluation split: Assertion `split >= 0 && split.is_normal()` failed (split = {0}).
+    BadEvaluationSplit(f32),
+    /// Unusable evaluation split: With evaluation split {0} no samples are left for training.
+    ToLargeEvaluationSplit(f32),
+    /// Unusable evaluation split: Assertion `nr_evaluation_samples > 0 || split == 0` failed (split = {0}).
+    NoEvaluationSamples(f32),
+    /// A batch size of 0 is not usable for training.
+    BatchSize0,
+    /// The batch size is larger then the number of samples.
+    ToLargeBatchSize(usize),
+    /// Not reset/initialized.
+    ResetWasNotCalledBeforeTraining,
+    /// Empty database can not be used for training.
+    EmptyDatabase,
+    /// Fetching sample from storage failed: {0}.
+    Storage(SE),
+}
+
+impl<S> list_net::DataSource for DataSource<S>
+where
+    S: Storage,
+{
+    type Error = DataSourceError<S::Error>;
+
+    fn reset(&mut self, batch_size: usize) -> Result<usize, Self::Error> {
+        if batch_size == 0 {
+            return Err(DataSourceError::BatchSize0);
+        }
+        let mut rng = rand::thread_rng();
+        self.batch_size = Some(batch_size);
+        self.training_data_order.reset(&mut rng);
+        self.evaluation_data_order.reset(&mut rng);
+
+        let nr_batches = self.training_data_order.number_of_batches(batch_size);
+        if nr_batches == 0 {
+            return Err(DataSourceError::ToLargeBatchSize(nr_batches));
+        }
+        Ok(nr_batches)
+    }
+
+    fn next_training_batch(&mut self) -> Result<Vec<Sample>, Self::Error> {
+        let batch_size = self
+            .batch_size
+            .ok_or(DataSourceError::ResetWasNotCalledBeforeTraining)?;
+
+        let ids = self.training_data_order.next_batch(batch_size);
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.storage
+            .load_batch(&ids)
+            .map_err(DataSourceError::Storage)
+    }
+
+    fn next_evaluation_sample(&mut self) -> Result<Option<Sample>, Self::Error> {
+        if let Some(id) = self.evaluation_data_order.next() {
+            match self.storage.load_sample(id) {
+                Ok(sample) => Ok(Some(sample)),
+                Err(error) => Err(DataSourceError::Storage(error)),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub(crate) trait Storage {
+    type Error: StdError + 'static;
+
+    /// Return the all sample ids.
+    ///
+    /// For now this is a range. I.e. `0..nr_of_samples`. We might need
+    /// to change this in the future, but for now this is simpler.
+    fn data_ids(&self) -> Result<RangeTo<usize>, Self::Error>;
+
+    /// Loads a sample and returns a reference to it.
+    ///
+    /// This method is `&mut self` as it might change the internal state
+    /// (due to loading/caching) and we also want to make sure that there
+    /// are no more lend out samples, when `load_sample` or `load_batch` are
+    /// called again.
+    fn load_sample(&mut self, id: DataId) -> Result<Sample, Self::Error>;
+
+    /// Loads a batch of samples and returns a vector of references to them.
+    ///
+    /// See [`Storage.load_batch()`] about why this is `&mut self`.
+    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<Sample<'a>>, Self::Error>;
+}
+
+/// For now samples id's are always incremental integers form `0..nr_samples`.
+///
+/// Given that this is just used to handle shuffling and similar it's unlikely to
+/// ever change, we do explicitly not care about any consistency of the id to
+/// sample mapping between trainings.
+type DataId = usize;
+
+/// Helper to randomize sample order.
+struct DataLookupOrder {
+    /// Ids of all samples in this lookup order.
+    data_ids: Vec<DataId>,
+    /// The offset splitting already used samples from not yet used samples.
+    data_ids_offset: usize,
+}
+
+impl DataLookupOrder {
+    fn new(data_ids: Vec<DataId>) -> Self {
+        Self {
+            data_ids,
+            data_ids_offset: 0,
+        }
+    }
+
+    /// Returns the number of batches which will be produced with given batch size.
+    fn number_of_batches(&self, batch_size: usize) -> usize {
+        self.data_ids.len() / batch_size
+    }
+
+    /// Resets this container.
+    ///
+    /// This will mark all samples as unused and
+    /// shuffles the order of samples.
+    fn reset(&mut self, rng: &mut impl Rng) {
+        self.data_ids.shuffle(rng);
+        self.data_ids_offset = 0;
+    }
+
+    /// Returns the next unused sample id.
+    fn next(&mut self) -> Option<DataId> {
+        if self.data_ids_offset < self.data_ids.len() {
+            let idx = self.data_ids_offset;
+            self.data_ids_offset += 1;
+
+            Some(self.data_ids[idx])
+        } else {
+            None
+        }
+    }
+
+    /// Returns the next `batch_size` many sample ids.
+    fn next_batch(&mut self, batch_size: usize) -> Vec<DataId> {
+        let end_idx = self.data_ids_offset + batch_size;
+        if end_idx <= self.data_ids.len() {
+            let start_idx = self.data_ids_offset;
+            self.data_ids_offset = end_idx;
+
+            self.data_ids[start_idx..end_idx].to_owned()
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+/// A "in-memory" sample storage.
+///
+/// It also can be portably stored to disk using bincode serialization.
+///
+/// The storage is reasonably compact as ~5.3GiB of soundgarden user
+/// data-frames will produce a less then 975MiB serialized `.samples` file.
+// While there are many ways to improve on this (e.g. memory-mapped I/O), they are not relevant for our
+// use-case for now.
+#[derive(Serialize, Deserialize, Default)]
+pub(crate) struct InMemorySamples {
+    /// Vector of concatenated `inputs` and `target_prob_dist`, this slightly improves memory size and
+    /// cache locality, we can derive the number of document from the vectors length as the vectors length
+    /// is `nr_document * INPUT_NR_FEATURES + nr_document*1`, i.e. `nr_documents * 51`.
+    data: Vec<Vec<f32>>,
+}
+
+#[derive(Error, Debug, Display)]
+pub enum StorageError {
+    /// The database was parsed successfully but contains broken invariants at index {at_index}.
+    BrokenInvariants { at_index: usize },
+}
+
+impl InMemorySamples {
+    /// Serializes this instance into a file, preferably use the `.samples` file ending.
+    //FIXME[follow-up PR] version the file format, it's used to persist data and it's not
+    //                    unlikely to slightly change in the future.
+    pub(crate) fn serialize_into_file(&self, file: impl AsRef<Path>) -> Result<(), Error> {
+        self.serialize_into(BufWriter::new(File::create(file)?))
+    }
+
+    /// Serializes this instance into given writer.
+    fn serialize_into(&self, writer: impl Write) -> Result<(), Error> {
+        bincode::DefaultOptions::new()
+            .serialize_into(writer, self)
+            .map_err(Into::into)
+    }
+
+    /// Deserialize a instance from given file.
+    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
+    pub(crate) fn deserialize_from_file(file: impl AsRef<Path>) -> Result<Self, Error> {
+        Self::deserialize_from(BufReader::new(File::open(file)?))
+    }
+
+    /// Deserialize a instance from given reader, preferably pass in a buffered reader.
+    #[allow(dead_code)] //FIXME is used by training (added in part 3 of this PR)
+    fn deserialize_from(reader: impl Read) -> Result<Self, Error> {
+        let self_: Self = bincode::DefaultOptions::new().deserialize_from(reader)?;
+        debug!("Loaded {} samples.", self_.data.len());
+        Ok(self_)
+    }
+
+    fn load_sample_helper(&self, id: DataId) -> Result<Sample, StorageError> {
+        let raw = &self.data[id];
+
+        // len == nr_document * nr_features + nr_documents * 1
+        let nr_documents = raw.len() / (ListNet::INPUT_NR_FEATURES + 1);
+        let start_of_target_prob_dist = nr_documents * ListNet::INPUT_NR_FEATURES;
+        debug_assert_eq!(start_of_target_prob_dist + nr_documents, raw.len());
+
+        let inputs = ArrayView::from_shape(
+            (nr_documents, ListNet::INPUT_NR_FEATURES),
+            &raw[..start_of_target_prob_dist],
+        )
+        .map_err(|_| StorageError::BrokenInvariants { at_index: id })?;
+        let target_prob_dist =
+            ArrayView::from_shape((nr_documents,), &raw[start_of_target_prob_dist..])
+                .map_err(|_| StorageError::BrokenInvariants { at_index: id })?;
+
+        Ok(Sample {
+            inputs,
+            target_prob_dist,
+        })
+    }
+
+    /// Add a new sample.
+    ///
+    /// # Panics
+    ///
+    /// - If the number of documents in `inputs` doesn't match the number of probabilities in
+    /// `target_prob_dist`.
+    /// - If the number of features per document is not equal to `[ListNet::INPUT_NR_FEATURES]`.
+    pub(crate) fn add_sample(
+        &mut self,
+        inputs: ArrayView2<f32>,
+        target_prob_dist: ArrayView1<f32>,
+    ) -> Result<(), Error> {
+        if inputs.shape() != [target_prob_dist.len(), ListNet::INPUT_NR_FEATURES] {
+            bail!("Sample with bad array shapes. Expected shapes [{nr_docs}, {nr_feats}] & [{nr_docs}] but got shapes {inputs_shape:?} & {prob_dist_shape:?}",
+                nr_docs=inputs.shape()[0],
+                nr_feats=ListNet::INPUT_NR_FEATURES,
+                inputs_shape=inputs.shape(),
+                prob_dist_shape=target_prob_dist.shape(),
+            );
+        }
+        let mut data = Vec::with_capacity(inputs.len() + target_prob_dist.len());
+        extend_vec_with_ndarray(&mut data, inputs);
+        extend_vec_with_ndarray(&mut data, target_prob_dist);
+        self.data.push(data);
+        Ok(())
+    }
+}
+
+/// Extend a vec with the elements of given array in logical order.
+fn extend_vec_with_ndarray<T: Clone>(
+    data: &mut Vec<T>,
+    array: ArrayBase<impl Data<Elem = T>, impl Dimension>,
+) {
+    if let Some(slice) = array.as_slice() {
+        data.extend_from_slice(slice);
+    } else {
+        data.extend(array.iter().cloned());
+    }
+}
+
+impl Storage for InMemorySamples {
+    type Error = StorageError;
+
+    fn data_ids(&self) -> Result<RangeTo<usize>, Self::Error> {
+        Ok(..self.data.len())
+    }
+
+    fn load_sample(&mut self, id: DataId) -> Result<Sample, Self::Error> {
+        self.load_sample_helper(id)
+    }
+
+    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<Sample<'a>>, Self::Error> {
+        let mut samples = Vec::new();
+        for id in ids {
+            samples.push(self.load_sample_helper(*id)?)
+        }
+        Ok(samples)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ndarray::Array;
+    use rand::thread_rng;
+    use xayn_ai::assert_approx_eq;
+
+    use super::*;
+
+    fn dummy_storage() -> InMemorySamples {
+        let mut storage = InMemorySamples::default();
+
+        let inputs = Array::zeros((10, 50));
+        let target_prob_dist = Array::ones((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap();
+
+        let inputs = Array::ones((10, 50));
+        let target_prob_dist = Array::zeros((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap();
+
+        let inputs = Array::from_elem((10, 50), 4.);
+        let target_prob_dist = Array::ones((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap();
+
+        storage
+    }
+
+    #[test]
+    fn test_adding_bad_matrices_fails() {
+        let mut storage = InMemorySamples::default();
+        let inputs = Array::zeros((10, 48));
+        let target_prob_dist = Array::ones((10,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap_err();
+
+        let inputs = Array::zeros((10, 50));
+        let target_prob_dist = Array::ones((12,));
+        storage
+            .add_sample(inputs.view(), target_prob_dist.view())
+            .unwrap_err();
+
+        assert!(storage.data.is_empty());
+    }
+
+    #[test]
+    fn test_runtime_representation_of_in_memory_storage() {
+        let storage = dummy_storage();
+
+        assert_eq!(storage.data.len(), 3);
+
+        for f in &storage.data[0][..500] {
+            assert_approx_eq!(f32, f, 0.0, ulps = 0);
+        }
+        for f in &storage.data[0][500..] {
+            assert_approx_eq!(f32, f, 1.0, ulps = 0);
+        }
+        assert_eq!(storage.data[0].len(), 510);
+
+        for f in &storage.data[1][..500] {
+            assert_approx_eq!(f32, f, 1.0, ulps = 0);
+        }
+        for f in &storage.data[1][500..] {
+            assert_approx_eq!(f32, f, 0.0, ulps = 0);
+        }
+        assert_eq!(storage.data[1].len(), 510);
+
+        for f in &storage.data[2][..500] {
+            assert_approx_eq!(f32, f, 4.0, ulps = 0);
+        }
+        for f in &storage.data[2][500..] {
+            assert_approx_eq!(f32, f, 1.0, ulps = 0);
+        }
+        assert_eq!(storage.data[2].len(), 510);
+    }
+
+    #[test]
+    fn test_get_samples_from_in_memory_storage() {
+        let mut storage = dummy_storage();
+
+        {
+            let sample = storage.load_sample(0).unwrap();
+            assert_eq!(sample.inputs.shape(), &[10, 50]);
+            for f in sample.inputs.iter() {
+                assert_approx_eq!(f32, f, 0.0, ulps = 0);
+            }
+            assert_eq!(sample.target_prob_dist.shape(), &[10]);
+            for f in sample.target_prob_dist.iter() {
+                assert_approx_eq!(f32, f, 1.0, ulps = 0);
+            }
+        }
+        {
+            let sample = storage.load_sample(1).unwrap();
+            assert_eq!(sample.inputs.shape(), &[10, 50]);
+            for f in sample.inputs.iter() {
+                assert_approx_eq!(f32, f, 1.0, ulps = 0);
+            }
+            assert_eq!(sample.target_prob_dist.shape(), &[10]);
+            for f in sample.target_prob_dist.iter() {
+                assert_approx_eq!(f32, f, 0.0, ulps = 0);
+            }
+        }
+        {
+            let sample = storage.load_sample(2).unwrap();
+            assert_eq!(sample.inputs.shape(), &[10, 50]);
+            for f in sample.inputs.iter() {
+                assert_approx_eq!(f32, f, 4.0, ulps = 0);
+            }
+            assert_eq!(sample.target_prob_dist.shape(), &[10]);
+            for f in sample.target_prob_dist.iter() {
+                assert_approx_eq!(f32, f, 1.0, ulps = 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_get_batch_from_in_memory_storage() {
+        let mut storage = dummy_storage();
+
+        assert_eq!(storage.load_batch(&[]).unwrap().len(), 0);
+
+        {
+            let samples = storage.load_batch(&[1, 1, 0, 1]).unwrap();
+            assert_eq!(samples.len(), 4);
+
+            assert_approx_eq!(f32, &samples[0].inputs, &samples[1].inputs, ulps = 0);
+            assert_approx_eq!(
+                f32,
+                &samples[0].target_prob_dist,
+                &samples[1].target_prob_dist,
+                ulps = 0
+            );
+            assert_approx_eq!(f32, &samples[0].inputs, &samples[3].inputs, ulps = 0);
+            assert_approx_eq!(
+                f32,
+                &samples[0].target_prob_dist,
+                &samples[3].target_prob_dist,
+                ulps = 0
+            );
+
+            assert_approx_eq!(f32, samples[0].inputs[[0, 0]], 1.0, ulps = 0);
+            assert_approx_eq!(f32, samples[2].inputs[[0, 0]], 0.0, ulps = 0);
+        }
+    }
+
+    #[test]
+    fn test_serialization_of_in_memory_storage_works() {
+        let storage = dummy_storage();
+
+        let mut buffer = Vec::new();
+        storage.serialize_into(&mut buffer).unwrap();
+        let storage2 = InMemorySamples::deserialize_from(&*buffer).unwrap();
+
+        assert_approx_eq!(f32, storage.data, storage2.data);
+    }
+
+    #[test]
+    fn test_data_lookup_order_changes_on_reset() {
+        let mut rng = thread_rng();
+        let mut dlo = DataLookupOrder::new(vec![0, 1, 2, 3, 4]);
+
+        dlo.reset(&mut rng);
+        let all = dlo.next_batch(5);
+        dlo.reset(&mut rng);
+        let all2 = dlo.next_batch(5);
+        assert_ne!(all, all2);
+    }
+
+    #[test]
+    fn test_data_lookup_order_does_not_return_partial_batches() {
+        let mut dlo = DataLookupOrder::new(vec![0, 1, 2, 3, 4]);
+        assert_eq!(dlo.next_batch(2), [0, 1]);
+        assert_eq!(dlo.next_batch(2), [2, 3]);
+        assert!(dlo.next_batch(2).is_empty());
+        assert!(dlo.next_batch(2).is_empty());
+    }
+
+    #[test]
+    fn test_data_lookup_order_returns_samples_in_order() {
+        let mut dlo = DataLookupOrder::new(vec![0, 1, 4]);
+        assert_eq!(dlo.next(), Some(0));
+        assert_eq!(dlo.next(), Some(1));
+        assert_eq!(dlo.next(), Some(4));
+        assert_eq!(dlo.next(), None);
+        assert_eq!(dlo.next(), None);
+    }
+}

--- a/dev-tool/src/list_net/inspect.rs
+++ b/dev-tool/src/list_net/inspect.rs
@@ -1,0 +1,662 @@
+#![cfg(not(tarpaulin))]
+
+use std::{
+    collections::HashSet,
+    convert::TryInto,
+    fmt::{self, Display},
+    iter,
+    ops::RangeInclusive,
+    path::PathBuf,
+    str::FromStr,
+};
+
+use anyhow::{bail, Error};
+use displaydoc::Display;
+use itertools::Itertools;
+use log::debug;
+use ndarray::{ArrayBase, ArrayD, Data, Dimension};
+use structopt::StructOpt;
+
+use xayn_ai::list_net::ndutils::io::BinParams;
+
+use super::data_source::{InMemorySamples, Storage};
+use crate::exit_code::{NON_FATAL_ERROR, NO_ERROR};
+
+/// Inspect data dumps (binparams, samples).
+#[derive(StructOpt, Debug)]
+pub struct InspectCmd {
+    //FIXME[followup pr] add a tag to the begin of bincode serialized files to
+    //   automatically select the right deserializer and prevent confusion when
+    //   accidentally mixing up this files.
+    /// Type of the file (either "binparams" or "samples")
+    #[structopt(short, long, parse(try_from_str))]
+    r#type: FileType,
+
+    /// Prints the elements of all inspected matrices.
+    #[structopt(short, long)]
+    print_data: bool,
+
+    /// If set only skip arrays which names are not in the filter.
+    ///
+    /// This accepts comma separated lists, as well as including the option multiple times.
+    #[structopt(short, long)]
+    filter: Option<Vec<String>>,
+
+    /// Prints stats including `min`, `max`, `mean`, `std`, `has_nans`, `has_infs`, `has_subnormals`.
+    #[structopt(short = "s", long)]
+    stats: bool,
+
+    /// Checks if all elements in all matrices are "normal".
+    #[structopt(short = "c", long)]
+    check_normal: bool,
+
+    /// Checks if all values in all matrices are in given range.
+    ///
+    /// Format: <from>..=<to>
+    ///
+    /// E.g.: --check-range="-10..=20"
+    ///
+    /// Currently only full inclusive ranges are supported.
+    #[structopt(short = "r", long)]
+    check_range: Option<String>,
+
+    /// Path to a input file.
+    file: PathBuf,
+}
+
+#[derive(Debug, Display, Clone, Copy)]
+/// Supported file types.
+pub enum FileType {
+    /// BinParams file
+    BinParams,
+    /// Samples file
+    Samples,
+}
+
+impl FromStr for FileType {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use FileType::*;
+        match &*s.trim().to_lowercase() {
+            "binparams" | "bin-params" => Ok(BinParams),
+            "samples" => Ok(Samples),
+            _ => bail!("Unexpected file type. Supported types are: \"binparams\", \"samples\""),
+        }
+    }
+}
+
+type MatricesIter = Box<dyn Iterator<Item = Result<(String, ArrayD<f32>), Error>>>;
+
+impl InspectCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        debug!("Loading Matrices from {}.", self.r#type);
+        let matrices = self.load_matrices()?;
+
+        debug!("Inspecting Matrices");
+        self.run_inspect_matrices(matrices)
+    }
+
+    fn load_matrices(&self) -> Result<MatricesIter, Error> {
+        match self.r#type {
+            FileType::BinParams => {
+                let bin_params = BinParams::deserialize_from_file(&self.file)?;
+                Ok(bin_params_to_matrices_iter(bin_params))
+            }
+            FileType::Samples => {
+                let samples = InMemorySamples::deserialize_from_file(&self.file)?;
+                samples_to_matrices_iter(samples)
+            }
+        }
+    }
+
+    fn run_inspect_matrices(self, matrices: MatricesIter) -> Result<i32, Error> {
+        let Self {
+            r#type: _,
+            print_data,
+            file: _,
+            stats,
+            check_normal,
+            check_range,
+            filter,
+        } = self;
+
+        let check_range = check_range.map(parse_range).transpose()?;
+        let filter = filter.map(parse_filter);
+
+        let mut failed_normal_checks = Vec::new();
+        let mut failed_range_checks = Vec::new();
+        for result in matrices {
+            let (name, array) = result?;
+            if let Some(filter) = &filter {
+                if !filter.contains(&name) {
+                    debug!("Skipping Array: {}", name);
+                    continue;
+                }
+            }
+
+            println!("----------------------------------------");
+            println!("Name: {}", name);
+            println!("Shape: {:?}", array.shape());
+            if stats || check_normal || check_range.is_some() {
+                let array_stats =
+                    Stats::calculate(array.view(), check_normal, check_range.as_ref());
+                if stats {
+                    println!("Stats: {}", array_stats);
+                }
+                if check_normal && array_stats.normal_checks_failed {
+                    failed_normal_checks.push(name.clone());
+                }
+                if check_range.is_some() && array_stats.range_checks_failed {
+                    failed_range_checks.push(name);
+                }
+            }
+
+            if print_data {
+                println!("Array: {:?}", array);
+            }
+        }
+
+        failed_normal_checks.sort();
+        failed_range_checks.sort();
+
+        if failed_range_checks.is_empty() && failed_normal_checks.is_empty() {
+            Ok(NO_ERROR)
+        } else {
+            let mut msg = "Checks Failed:\n".to_owned();
+            if check_normal {
+                write_failure_message(&mut msg, "Failed normal checks", &failed_normal_checks)?;
+            }
+            if let Some(check_range) = check_range {
+                write_failure_message(
+                    &mut msg,
+                    &format!(
+                        "Failed range checks ({}..={})",
+                        check_range.start(),
+                        check_range.end()
+                    ),
+                    &failed_range_checks,
+                )?;
+            }
+            eprintln!("{}", msg);
+            Ok(NON_FATAL_ERROR)
+        }
+    }
+}
+
+/// Turns a [`BinParams`] instance into a iterator over it's matrices and their names.
+///
+/// - The matrices are converted to the `ArrayD` type.
+/// - The matrices are returned sorted by their names.
+fn bin_params_to_matrices_iter(bin_params: BinParams) -> MatricesIter {
+    let iter = bin_params
+        .into_iter()
+        .map(|(name, array)| (name, array.try_into()))
+        .sorted_by_key(|(name, _)| name.clone())
+        .into_iter()
+        .map(|(name, array_res)| Ok((name, array_res?)));
+
+    Box::new(iter)
+}
+
+/// Turns an [`InMemorySamples`] instance into a iterator over all it's matrices and their names.
+///
+/// - Matrices are returned in order of the samples, and for each the sample it's matrices are
+///   returned sorted by their name.
+/// - The name is created in the form of `{index}.{matrix_name}` the `index` will be
+///   formatted with leading `0` chars appropriate for the number of samples.
+fn samples_to_matrices_iter(mut samples: InMemorySamples) -> Result<MatricesIter, Error> {
+    let mut count = 0;
+    let end = samples.data_ids()?.end;
+    let nr_digits = format!("{}", end.saturating_sub(1)).len();
+    let iter = iter::from_fn(move || {
+        let idx = count / 2;
+        let for_inputs = count % 2 == 0;
+        count += 1;
+
+        if idx >= end {
+            return None;
+        }
+        let sample = match samples.load_sample(idx) {
+            Ok(sample) => sample,
+            Err(err) => return Some(Err(err.into())),
+        };
+        let (name, array) = if for_inputs {
+            ("inputs", sample.inputs.to_owned().into_dyn())
+        } else {
+            (
+                "target_prob_dist",
+                sample.target_prob_dist.to_owned().into_dyn(),
+            )
+        };
+        Some(Ok((
+            format!("{:0>width$}.{}", idx, name, width = nr_digits),
+            array,
+        )))
+    });
+    Ok(Box::new(iter))
+}
+
+fn write_failure_message(
+    out: &mut String,
+    title: &str,
+    array: &[String],
+) -> Result<(), fmt::Error> {
+    use fmt::Write;
+    writeln!(out, " {}:", title)?;
+    for array_name in array {
+        writeln!(out, " - {}", array_name)?;
+    }
+    Ok(())
+}
+
+/// Parses the filter by splitting each filter sequence and trimming each filter.
+fn parse_filter(filter: Vec<String>) -> HashSet<String> {
+    filter
+        .iter()
+        .flat_map(|names| {
+            names
+                .split(',')
+                .map(|name| name.trim().to_owned())
+                .filter(|name| !name.is_empty())
+        })
+        .collect::<HashSet<_>>()
+}
+
+/// Parses a `<from>..=<to>` (f32) range.
+fn parse_range(range: impl AsRef<str>) -> Result<RangeInclusive<f32>, Error> {
+    let mut split = range.as_ref().split("..=");
+    let first = split.next().unwrap();
+    if let Some(second) = split.next() {
+        if split.next().is_some() {
+            bail!("Only <from>..=<to> syntax is currently allowed.");
+        }
+        let first: f32 = first.trim().parse()?;
+        let second: f32 = second.trim().parse()?;
+        Ok(first..=second)
+    } else {
+        bail!("Only <from>..=<to> syntax is currently allowed.");
+    }
+}
+
+/// Stats for a matrix.
+struct Stats {
+    /// The max element in the matrix, or 0 if the matrix is empty.
+    min: f32,
+    /// The min element in the matrix, or 0 if the matrix is empty.
+    max: f32,
+    /// The arithmetic mean of the elements in the matrix, or 0 if the matrix is empty.
+    mean: f32,
+    /// The standard derivation (ddof=0) of the elements in the matrix.
+    std: f32,
+    /// Is `true`, if the matrix contains `NaN` elements.
+    has_nans: bool,
+    /// Is `true`, if the matrix contains `Inf` elements (independent of sign).
+    has_infs: bool,
+    /// Is `true`, if the matrix contains subnormal elements.
+    has_subnormals: bool,
+    /// True if any element is not normal.
+    normal_checks_failed: bool,
+    /// True if any range checks failed.
+    range_checks_failed: bool,
+}
+
+impl Stats {
+    fn calculate<S, D>(
+        array: ArrayBase<S, D>,
+        do_normal_checks: bool,
+        range_checks: Option<&RangeInclusive<f32>>,
+    ) -> Self
+    where
+        S: Data<Elem = f32>,
+        D: Dimension,
+    {
+        array.iter().copied().fold(
+            Self {
+                min: 0.0,
+                max: 0.0,
+                mean: array.mean().unwrap_or_default(),
+                std: array.std(0.),
+                has_nans: false,
+                has_infs: false,
+                has_subnormals: false,
+                normal_checks_failed: false,
+                range_checks_failed: false,
+            },
+            |mut self_, val| {
+                self_.min = self_.min.min(val);
+                self_.max = self_.max.max(val);
+                self_.has_nans |= val.is_nan();
+                self_.has_infs |= val.is_infinite();
+                // FIXME use once we switch to rust 1.53 on CI
+                // self_.has_subnormals |= val.is_subnormal();
+                self_.has_subnormals |= !val.is_normal() && !val.is_nan() && !val.is_infinite();
+                self_.normal_checks_failed |= do_normal_checks && !val.is_normal();
+                self_.range_checks_failed |= range_checks
+                    .map(|range| !range.contains(&val))
+                    .unwrap_or_default();
+                self_
+            },
+        )
+    }
+}
+
+impl Display for Stats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            min,
+            max,
+            mean,
+            std,
+            has_nans,
+            has_infs,
+            has_subnormals,
+            normal_checks_failed: normal_check_failed,
+            range_checks_failed,
+        } = self;
+        write!(
+            f,
+            concat!(
+                "min = {min}\n",
+                "  mean = {mean}\n",
+                "  max  = {max}\n",
+                "  std  = {std}\n",
+                "  NANs? {has_nans}\n",
+                "  Infs? {has_infs}\n",
+                "  Subnormals? {has_subnormals}\n",
+                "  Failed range check? {range_check}\n",
+                "  Failed normal check? {normal_check}\n",
+            ),
+            min = min,
+            max = max,
+            mean = mean,
+            std = std,
+            has_nans = highlight_if_true(*has_nans),
+            has_infs = highlight_if_true(*has_infs),
+            has_subnormals = highlight_if_true(*has_subnormals),
+            range_check = highlight_if_true(*range_checks_failed),
+            normal_check = highlight_if_true(*normal_check_failed),
+        )
+    }
+}
+
+/// Formats the boolean, "highlighting" true.
+fn highlight_if_true(val: bool) -> &'static str {
+    if val {
+        "<<TRUE>>"
+    } else {
+        "false"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::{Enumerate, FromIterator};
+
+    use ndarray::{arr1, arr2, Array, Array1, Array2};
+    use xayn_ai::assert_approx_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_range() {
+        let range = parse_range("-10.3..=-100.4").unwrap();
+        assert_approx_eq!(f32, range.start(), -10.3);
+        assert_approx_eq!(f32, range.end(), -100.4);
+
+        let range = parse_range("0..=10").unwrap();
+        assert_approx_eq!(f32, range.start(), 0.);
+        assert_approx_eq!(f32, range.end(), 10.);
+
+        let range = parse_range("-10..=10").unwrap();
+        assert_approx_eq!(f32, range.start(), -10.);
+        assert_approx_eq!(f32, range.end(), 10.);
+
+        let range = parse_range("0. ..= 10.").unwrap();
+        assert_approx_eq!(f32, range.start(), 0.);
+        assert_approx_eq!(f32, range.end(), 10.);
+    }
+
+    #[test]
+    fn test_parse_filter() {
+        assert_eq!(
+            parse_filter(vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]),
+            HashSet::from_iter(vec!["a".to_owned(), "b".to_owned(), "c".to_owned()])
+        );
+
+        assert_eq!(
+            parse_filter(vec!["a,b".to_owned(),]),
+            HashSet::from_iter(vec!["a".to_owned(), "b".to_owned()])
+        );
+
+        assert_eq!(
+            parse_filter(vec![
+                ",,".to_owned(),
+                " a ,,b , c,d,".to_owned(),
+                ",c,d d,".to_owned()
+            ]),
+            HashSet::from_iter(vec![
+                "a".to_owned(),
+                "b".to_owned(),
+                "c".to_owned(),
+                "d".to_owned(),
+                "d d".to_owned()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_calculate_stats() {
+        let Stats {
+            min,
+            max,
+            mean,
+            std,
+            has_nans,
+            has_infs,
+            has_subnormals,
+            normal_checks_failed,
+            range_checks_failed,
+        } = Stats::calculate(arr2(&[[0.25, 0.125, -10., 1.]]), false, None);
+
+        assert_approx_eq!(f32, min, -10.0, ulps = 0);
+        assert_approx_eq!(f32, max, 1.0, ulps = 0);
+        assert_approx_eq!(f32, mean, -2.15625, ulps = 0);
+        assert_approx_eq!(f32, std, 4.540938, ulps = 0);
+        assert!(!has_nans);
+        assert!(!has_infs);
+        assert!(!has_subnormals);
+        assert!(!normal_checks_failed);
+        assert!(!range_checks_failed);
+
+        let Stats {
+            has_nans,
+            has_infs,
+            has_subnormals,
+            ..
+        } = Stats::calculate(arr2(&[[f32::NAN, 0.125, -10., 1.]]), false, None);
+        assert!(has_nans);
+        assert!(!has_infs);
+        assert!(!has_subnormals);
+
+        let Stats {
+            has_nans,
+            has_infs,
+            has_subnormals,
+            ..
+        } = Stats::calculate(arr2(&[[4., 0.125], [f32::INFINITY, 1.]]), false, None);
+        assert!(!has_nans);
+        assert!(has_infs);
+        assert!(!has_subnormals);
+
+        let subnormal = 0.00000000000000000000000000000000000000001;
+        let Stats {
+            has_nans,
+            has_infs,
+            has_subnormals,
+            ..
+        } = Stats::calculate(arr2(&[[0.1, subnormal, -10., 1.]]), false, None);
+        assert!(!has_nans);
+        assert!(!has_infs);
+        assert!(has_subnormals);
+
+        let Stats {
+            normal_checks_failed,
+            range_checks_failed,
+            ..
+        } = Stats::calculate(arr2(&[[f32::NAN, 0.125, -10., 1.]]), true, None);
+        assert!(normal_checks_failed);
+        assert!(!range_checks_failed);
+
+        let Stats {
+            normal_checks_failed,
+            range_checks_failed,
+            ..
+        } = Stats::calculate(arr2(&[[10., 0.125, -10., 1.]]), true, Some(&(-0.5..=0.5)));
+        assert!(!normal_checks_failed);
+        assert!(range_checks_failed);
+
+        let Stats {
+            normal_checks_failed,
+            range_checks_failed,
+            ..
+        } = Stats::calculate(
+            arr2(&[[10., f32::NAN, -10., 1.]]),
+            true,
+            Some(&(-0.5..=0.5)),
+        );
+        assert!(normal_checks_failed);
+        assert!(range_checks_failed);
+    }
+
+    #[test]
+    fn test_failed_checks_affect_exit_status() {
+        let cmd = InspectCmd {
+            print_data: false,
+            filter: None,
+            stats: false,
+            check_normal: false,
+            check_range: Some("0..=0.5".to_owned()),
+            file: PathBuf::from("/my/path"),
+            r#type: FileType::BinParams,
+        };
+
+        let mut bin_params = BinParams::default();
+        bin_params.insert("foobar", arr2(&[[1., 3.], [-4., 0.24]]));
+        bin_params.insert("barfoot", arr1(&[0., 0.12]));
+
+        let matrices = bin_params_to_matrices_iter(bin_params);
+        let exit_code = cmd.run_inspect_matrices(matrices).unwrap();
+        assert_eq!(exit_code, NON_FATAL_ERROR);
+    }
+
+    #[test]
+    fn test_filter_works() {
+        let cmd = InspectCmd {
+            print_data: false,
+            filter: Some(vec!["foobar".to_owned()]),
+            stats: false,
+            check_normal: true,
+            check_range: None,
+            file: PathBuf::from("/my/path"),
+            r#type: FileType::BinParams,
+        };
+
+        let mut bin_params = BinParams::default();
+        bin_params.insert("foobar", arr2(&[[1., 3.], [-4., 0.24]]));
+        bin_params.insert("barfoot", arr1(&[0., f32::NAN, 0.12]));
+
+        let matrices = bin_params_to_matrices_iter(bin_params);
+        let exit_code = cmd.run_inspect_matrices(matrices).unwrap();
+
+        assert_eq!(exit_code, NO_ERROR);
+    }
+
+    #[test]
+    fn test_bin_params_to_matrices_iter() {
+        let mut bin_params = BinParams::default();
+        bin_params.insert("foobar", arr2(&[[1., 3.], [-4., 0.24]]));
+        bin_params.insert("x", arr1(&[]));
+        bin_params.insert("barfoot", arr1(&[0., f32::NAN, 0.12]));
+
+        let mut iter = bin_params_to_matrices_iter(bin_params);
+
+        test(iter.next(), ("barfoot", arr1(&[0., f32::NAN, 0.12])));
+        test(iter.next(), ("foobar", arr2(&[[1., 3.], [-4., 0.24]])));
+        test(iter.next(), ("x", arr1(&[])));
+        assert!(iter.next().is_none());
+
+        fn test(
+            got: Option<Result<(String, ArrayD<f32>), Error>>,
+            expected: (&str, Array<f32, impl Dimension>),
+        ) {
+            let (name, array) = got.expect("iter ended prematurely").unwrap();
+
+            assert_eq!(name, expected.0);
+            assert_approx_eq!(f32, array, expected.1, ulps = 0);
+        }
+    }
+
+    #[test]
+    fn test_samples_to_matrices_iter() {
+        let mut storage = InMemorySamples::default();
+
+        storage
+            .add_sample(
+                Array::from_elem((2, 50), 3.25).view(),
+                arr1(&[0.25, 0.50]).view(),
+            )
+            .unwrap();
+        storage
+            .add_sample(Array::from_elem((0, 50), 3.25).view(), arr1(&[]).view())
+            .unwrap();
+        storage
+            .add_sample(
+                Array::from_elem((5, 50), 3.25).view(),
+                arr1(&[0.25, 0.50, 1.25, 0.25, 0.44]).view(),
+            )
+            .unwrap();
+        storage
+            .add_sample(
+                Array::from_elem((2, 50), 3.25).view(),
+                arr1(&[0.52, 0.05]).view(),
+            )
+            .unwrap();
+
+        let mut iter = samples_to_matrices_iter(storage).unwrap().enumerate();
+        test(
+            &mut iter,
+            Array::from_elem((2, 50), 3.25),
+            arr1(&[0.25, 0.50]),
+        );
+        test(&mut iter, Array::from_elem((0, 50), 3.25), arr1(&[]));
+        test(
+            &mut iter,
+            Array::from_elem((5, 50), 3.25),
+            arr1(&[0.25, 0.50, 1.25, 0.25, 0.44]),
+        );
+        test(
+            &mut iter,
+            Array::from_elem((2, 50), 3.25),
+            arr1(&[0.52, 0.05]),
+        );
+        assert!(iter.next().is_none());
+
+        fn test(
+            iter: &mut Enumerate<MatricesIter>,
+            inputs: Array2<f32>,
+            target_prob_dist: Array1<f32>,
+        ) {
+            let (twice_idx, item) = iter.next().unwrap();
+            let (name, array) = item.unwrap();
+            let idx = twice_idx / 2;
+            assert_eq!(name, format!("{}.inputs", twice_idx / 2));
+            assert_approx_eq!(f32, array, inputs);
+            let (twice_idx_plus_1, item) = iter.next().unwrap();
+            let (name, array) = item.unwrap();
+            assert_eq!(name, format!("{}.target_prob_dist", idx));
+            assert_approx_eq!(f32, array, target_prob_dist);
+            assert_eq!(twice_idx_plus_1, idx * 2 + 1);
+        }
+    }
+}

--- a/dev-tool/src/list_net/train.rs
+++ b/dev-tool/src/list_net/train.rs
@@ -1,0 +1,101 @@
+#![cfg(not(tarpaulin))]
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Error};
+use structopt::StructOpt;
+use xayn_ai::list_net::{optimizer::MiniBatchSgd, ListNet, ListNetTrainer};
+
+use crate::exit_code::NO_ERROR;
+
+use super::{
+    cli_callbacks::CliTrainingControllerBuilder,
+    data_source::{DataSource, InMemorySamples},
+};
+
+/// Trains a ListNet.
+#[derive(StructOpt, Debug)]
+pub struct TrainCmd {
+    /// A file containing samples we can train and evaluate on.
+    #[structopt(long)]
+    samples: PathBuf,
+
+    /// The number of epochs to run.
+    #[structopt(long)]
+    epochs: usize,
+
+    /// The batch size to use.
+    #[structopt(long, default_value = "32")]
+    batch_size: usize,
+
+    /// The percent of samples to use for evaluation.
+    ///
+    /// The evaluation samples will be taken
+    /// from the back of the data source. This
+    /// means the same split used with the same
+    /// samples file will yield the exact same
+    /// training and evaluation samples every
+    /// time.
+    #[structopt(long, default_value = "0.2")]
+    evaluation_split: f32,
+
+    /// The learning rate to use.
+    #[structopt(long, default_value = "0.1")]
+    learning_rate: f32,
+
+    /// Uses given parameters instead of initializing them randomly.
+    #[structopt(long)]
+    use_initial_parameters: Option<PathBuf>,
+
+    /// Directory to store outputs in.
+    #[structopt(short, long, default_value = "./")]
+    out_dir: PathBuf,
+
+    /// After how many epochs a intermediate result should be dumped (if at all).
+    #[structopt(long)]
+    dump_every: Option<usize>,
+
+    /// Dumps the initial parameters before any training was done.
+    #[structopt(long)]
+    dump_initial_parameters: bool,
+}
+
+impl TrainCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        let TrainCmd {
+            samples,
+            epochs,
+            batch_size,
+            evaluation_split,
+            learning_rate,
+            use_initial_parameters,
+            out_dir,
+            dump_every,
+            dump_initial_parameters,
+        } = self;
+
+        let storage = InMemorySamples::deserialize_from_file(samples)
+            .context("Loading training & evaluation samples failed.")?;
+        let data_source =
+            DataSource::new(storage, evaluation_split).context("Creating DataSource failed.")?;
+
+        let callbacks = CliTrainingControllerBuilder {
+            out_dir,
+            dump_initial_parameters,
+            dump_every,
+        }
+        .build();
+
+        let optimizer = MiniBatchSgd { learning_rate };
+
+        let list_net = if let Some(initial_params_file) = use_initial_parameters {
+            ListNet::deserialize_from_file(initial_params_file)?
+        } else {
+            ListNet::new_with_random_weights()
+        };
+
+        let trainer = ListNetTrainer::new(list_net, data_source, callbacks, optimizer);
+        trainer.train(epochs, batch_size)?;
+        Ok(NO_ERROR)
+    }
+}

--- a/dev-tool/src/main.rs
+++ b/dev-tool/src/main.rs
@@ -1,36 +1,50 @@
 #![cfg(not(tarpaulin))]
+#![cfg(not(any(target_os = "android", target_os = "ios")))]
 use std::process::exit;
 
 use anyhow::Error;
+use log::error;
 use structopt::StructOpt;
 
-use crate::exit_code::FATAL_ERROR;
+use crate::exit_code::{FATAL_ERROR, NO_ERROR};
 
 mod call_data;
 mod exit_code;
+mod list_net;
 
 /// Tooling for the developers of XaynAi.
 #[derive(StructOpt, Debug)]
 enum CommandArgs {
     RunCallData(call_data::CallDataCmd),
+    ListNet(list_net::ListNetCmd),
 }
 
 impl CommandArgs {
     fn run(self) -> Result<i32, Error> {
+        use CommandArgs::*;
+
         match self {
-            CommandArgs::RunCallData(cmd) => cmd.run(),
+            RunCallData(cmd) => cmd.run(),
+            ListNet(cmd) => cmd.run(),
         }
     }
 }
 
 fn main() {
+    env_logger::init();
+
     let exit_code = match CommandArgs::from_args().run() {
         Ok(exit_code) => exit_code,
         Err(error) => {
-            eprintln!("{:?}", error);
+            error!("FATAL: {}\n{:?}", error, error);
             FATAL_ERROR
         }
     };
 
+    if exit_code == NO_ERROR {
+        eprintln!("DONE");
+    } else {
+        eprintln!("EXIT WITH ERRORS");
+    }
     exit(exit_code);
 }

--- a/download_data.sh
+++ b/download_data.sh
@@ -45,5 +45,5 @@ download()
 download asset smbert v0000
 download asset qambert v0001
 download asset ltr v0000
-download misc ltr_feature_extraction_tests v0000
 download misc bench_matmul v0000
+download misc ltr_test_data v0000

--- a/xayn-ai/src/data/document.rs
+++ b/xayn-ai/src/data/document.rs
@@ -104,7 +104,7 @@ pub struct Document {
 
 /// Represents a historical result from a query.
 #[cfg_attr(test, derive(Default))]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct DocumentHistory {
     /// Unique identifier of the document
     pub id: DocumentId,

--- a/xayn-ai/src/lib.rs
+++ b/xayn-ai/src/lib.rs
@@ -49,3 +49,7 @@ pub(crate) use rstest_reuse as rstest_reuse;
 // Reexport for assert_approx_eq for usage in FFI crates.
 #[doc(hidden)]
 pub use self::utils::ApproxAssertIterHelper;
+
+// Reexport for the dev-tool
+#[doc(hidden)]
+pub use crate::ltr::{list_net, list_net_training_data_from_history};

--- a/xayn-ai/src/ltr/features/mod.rs
+++ b/xayn-ai/src/ltr/features/mod.rs
@@ -1538,7 +1538,7 @@ mod tests {
         }
     }
 
-    const TEST_DATA_DIR: &str = "../data/ltr_feature_extraction_tests_v0000";
+    const TEST_DATA_DIR: &str = "../data/ltr_test_data_v0000/feature_extraction";
     const TEST_HISTORY_FILE_NAME: &str = "history.csv";
     const TEST_CURRENT_QUERY_FILE_NAME: &str = "current_query.csv";
     const TEST_FEATURES_FILE_NAME: &str = "features.csv";

--- a/xayn-ai/src/ltr/list_net/ndlayers/activation.rs
+++ b/xayn-ai/src/ltr/list_net/ndlayers/activation.rs
@@ -5,7 +5,7 @@ use super::super::ndutils::softmax;
 use super::ActivationFunction;
 
 /// reLu activation function.
-#[cfg_attr(test, derive(Clone))]
+#[derive(Clone)]
 pub(crate) struct Relu;
 
 impl<A> ActivationFunction<A> for Relu
@@ -46,7 +46,7 @@ impl Relu {
 /// with an relative axis index of 10 on an array which
 /// is 2-dimensional (and as such only has support the
 /// relative axis indices 0,1,-1,-2).
-#[cfg_attr(test, derive(Clone))]
+#[derive(Clone)]
 pub(crate) struct Softmax {
     rel_axis_idx: isize,
 }
@@ -98,7 +98,7 @@ where
 ///
 /// Like common this is a identity function used
 /// in cases where there no activation function is needed.
-#[cfg_attr(test, derive(Clone))]
+#[derive(Clone)]
 pub(crate) struct Linear;
 
 impl<A> ActivationFunction<A> for Linear {

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -257,6 +257,26 @@ where
     }
 }
 
+impl<'a, T: 'a> ApproxAssertIterHelper<'a> for &'a Option<T>
+where
+    &'a T: ApproxAssertIterHelper<'a>,
+{
+    type LeafElement = <&'a T as ApproxAssertIterHelper<'a>>::LeafElement;
+
+    fn indexed_iter_logical_order(
+        self,
+        prefix: Vec<Ix>,
+    ) -> Box<dyn Iterator<Item = (Vec<Ix>, Self::LeafElement)> + 'a> {
+        let iter = self.iter().flat_map(move |el| {
+            let mut new_prefix = prefix.clone();
+            new_prefix.push(0);
+            el.indexed_iter_logical_order(new_prefix)
+        });
+
+        Box::new(iter)
+    }
+}
+
 impl<'a, T: 'a> ApproxAssertIterHelper<'a> for &'a Vec<T>
 where
     &'a T: ApproxAssertIterHelper<'a>,


### PR DESCRIPTION
This adds a sub-command which can be used to inspect the matrices in `.binparams` and `.samples` files.

For examples this is use-full to e.g. find the last dumped list net which doesn't contain `NaN` or `Inf` and
similar.