### PR TITLE
Ty 1932 part 2 further improve dev tool training

### DIFF
--- a/dev-tool/src/list_net.rs
+++ b/dev-tool/src/list_net.rs
@@ -10,7 +10,7 @@ mod data_source;
 mod evaluate;
 mod train;
 
-/// Commands related to training ListNet (train, convert, inspect).
+/// Commands related to training ListNet (train, convert, evaluate).
 #[derive(StructOpt, Debug)]
 pub enum ListNetCmd {
     Convert(ConvertCmd),

--- a/dev-tool/src/list_net.rs
+++ b/dev-tool/src/list_net.rs
@@ -2,11 +2,12 @@
 use anyhow::Error;
 use structopt::StructOpt;
 
-use self::{convert::ConvertCmd, train::TrainCmd};
+use self::{convert::ConvertCmd, evaluate::EvaluateCmd, train::TrainCmd};
 
 mod cli_callbacks;
 mod convert;
 mod data_source;
+mod evaluate;
 mod train;
 
 /// Commands related to training ListNet (train, convert, inspect).
@@ -14,6 +15,7 @@ mod train;
 pub enum ListNetCmd {
     Convert(ConvertCmd),
     Train(TrainCmd),
+    Evaluate(EvaluateCmd),
 }
 
 impl ListNetCmd {
@@ -22,6 +24,7 @@ impl ListNetCmd {
         match self {
             Convert(cmd) => cmd.run(),
             Train(cmd) => cmd.run(),
+            Evaluate(cmd) => cmd.run(),
         }
     }
 }

--- a/dev-tool/src/list_net/cli_callbacks.rs
+++ b/dev-tool/src/list_net/cli_callbacks.rs
@@ -1,12 +1,12 @@
 #![cfg(not(tarpaulin))]
 
-use std::{convert::TryInto, path::PathBuf, sync::Mutex, time::Instant};
+use std::{ops::Add, path::PathBuf, sync::Mutex, time::Instant};
 
 use bincode::Error;
 use indicatif::{FormattedDuration, MultiProgress, ProgressBar, ProgressStyle};
 use log::{debug, info, trace};
 use rayon::prelude::*;
-use xayn_ai::list_net::{GradientSet, ListNet, Sample, TrainingController};
+use xayn_ai::list_net::{GradientSet, ListNet, SampleOwned, SampleView, TrainingController};
 
 /// Builder to create a [`CliTrainingController`].
 pub(crate) struct CliTrainingControllerBuilder {
@@ -25,6 +25,9 @@ pub(crate) struct CliTrainingControllerBuilder {
     /// The ListNet will be written to the output folder in the form of
     /// `list_net_{epoch}.binparams`.
     pub(crate) dump_every: Option<usize>,
+
+    /// If true a progress bar for the current batch is shown
+    pub(crate) show_sample_progress: bool,
 }
 
 impl CliTrainingControllerBuilder {
@@ -44,6 +47,17 @@ impl CliTrainingControllerBuilder {
                 .template("Batches: [{bar:30.green}] {percent:>3}% ({pos:>5}/{len:>5}) {msg}")
                 .progress_chars("=> "),
         );
+        let sample_progress_bar = if self.show_sample_progress {
+            let bar = ProgressBar::new(0);
+            bar.set_style(
+                ProgressStyle::default_bar()
+                    .template("Samples: [{bar:30.green}] {percent:>3}% ({pos:>5}/{len:>5})")
+                    .progress_chars("=> "),
+            );
+            bar
+        } else {
+            ProgressBar::hidden()
+        };
         let eval_progress_bar = ProgressBar::new(0);
         eval_progress_bar.set_style(
             ProgressStyle::default_bar()
@@ -56,10 +70,10 @@ impl CliTrainingControllerBuilder {
             current_epoch: 0,
             current_batch: 0,
             start_time: None,
+            sample_progress_bar,
             epoch_progress_bar,
             train_progress_bar,
             eval_progress_bar,
-            current_mean_evaluation_cost_and_len: None,
         }
     }
 }
@@ -74,14 +88,14 @@ pub(crate) struct CliTrainingController {
     current_batch: usize,
     /// The time at which the training did start.
     start_time: Option<Instant>,
+    /// A (CLI) progress bar used to track the progress of the current batch.
+    sample_progress_bar: ProgressBar,
     /// A (CLI) progress bar used to track the progress of the current training.
     train_progress_bar: ProgressBar,
     /// A (CLI) progress bar used to track the progress of the current epoch.
     epoch_progress_bar: ProgressBar,
     /// A (CLI) progress bar used to track the progress of the current evaluation.
     eval_progress_bar: ProgressBar,
-    /// The current mean of an in-progress evaluation as well as the nr of samples.
-    current_mean_evaluation_cost_and_len: Option<(f32, usize)>,
 }
 
 impl CliTrainingController {
@@ -105,9 +119,13 @@ impl TrainingController for CliTrainingController {
 
     fn run_batch(
         &mut self,
-        batch: Vec<Sample>,
-        map_fn: impl Fn(Sample) -> (GradientSet, f32) + Send + Sync,
-    ) -> Vec<GradientSet> {
+        batch: Vec<SampleView>,
+        map_fn: impl Fn(SampleView) -> (GradientSet, f32) + Send + Sync,
+    ) -> Result<Vec<GradientSet>, Self::Error> {
+        trace!("Start of batch #{}", self.current_batch);
+        self.sample_progress_bar.set_position(0);
+        self.sample_progress_bar.set_length(batch.len() as u64);
+
         let losses = Mutex::new(Vec::new());
         let gradient_sets = batch
             .into_par_iter()
@@ -115,26 +133,66 @@ impl TrainingController for CliTrainingController {
                 let (gradient_set, loss) = map_fn(sample);
                 let mut losses = losses.lock().unwrap();
                 losses.push(loss);
+                self.sample_progress_bar.inc(1);
                 gradient_set
             })
             .collect();
 
         let losses = losses.into_inner().unwrap();
         let mean_loss = mean_loss(&losses);
+
+        self.epoch_progress_bar.inc(1);
         self.epoch_progress_bar
             .set_message(format!("loss={:.5}", mean_loss));
-        gradient_sets
-    }
-
-    fn begin_of_batch(&mut self) -> Result<(), Self::Error> {
-        trace!("Start of batch #{}", self.current_batch);
-        Ok(())
-    }
-
-    fn end_of_batch(&mut self) -> Result<(), Self::Error> {
         trace!("End of batch #{}", self.current_batch);
-        self.epoch_progress_bar.inc(1);
         self.current_batch += 1;
+
+        Ok(gradient_sets)
+    }
+
+    fn run_evaluation<I>(
+        &mut self,
+        samples: I,
+        nr_samples: usize,
+        eval_fn: impl Fn(SampleOwned) -> f32 + Send + Sync,
+    ) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = SampleOwned>,
+        I::IntoIter: Send,
+    {
+        trace!("Begin of evaluation");
+        if nr_samples == 0 {
+            trace!("Skipping evaluation.");
+            return Ok(());
+        }
+
+        self.eval_progress_bar.set_message("");
+        self.eval_progress_bar.set_position(0);
+        self.eval_progress_bar.set_length(nr_samples as u64);
+
+        let mean_cost = samples
+            .into_iter()
+            .par_bridge()
+            .map(|sample| {
+                let cost = eval_fn(sample);
+                self.eval_progress_bar.inc(1);
+                cost / nr_samples as f32
+            })
+            .reduce_with(Add::add)
+            .unwrap();
+
+        //FIXME This can always happen (after a longer training, mainly
+        //      if training with inadequate data or parameters). Still
+        //      we want to handle this better in the future.
+        if mean_cost.is_nan() {
+            panic!("evaluation KL-Divergence cost is NaN");
+        }
+
+        self.eval_progress_bar
+            .set_message(format!("cost={:.5}", mean_cost));
+        self.train_progress_bar
+            .println(format!("Evaluation Cost: {}", mean_cost));
+        trace!("End of evaluation, cost={}", mean_cost);
         Ok(())
     }
 
@@ -145,8 +203,7 @@ impl TrainingController for CliTrainingController {
         );
         self.current_batch = 0;
         self.epoch_progress_bar.set_position(0);
-        self.epoch_progress_bar
-            .set_length(nr_batches.try_into().unwrap());
+        self.epoch_progress_bar.set_length(nr_batches as u64);
         self.eval_progress_bar.set_position(0);
         Ok(())
     }
@@ -166,39 +223,6 @@ impl TrainingController for CliTrainingController {
         Ok(())
     }
 
-    fn begin_of_evaluation(&mut self, nr_samples: usize) -> Result<(), Self::Error> {
-        self.current_mean_evaluation_cost_and_len = Some((0.0, nr_samples));
-        self.eval_progress_bar.set_message("");
-        self.eval_progress_bar.set_position(0);
-        self.eval_progress_bar
-            .set_length(nr_samples.try_into().unwrap());
-        Ok(())
-    }
-
-    fn evaluation_result(&mut self, cost: f32) -> Result<(), Self::Error> {
-        //FIXME This can always happen (after a longer training, mainly
-        //      if training with inadequate data or parameters). Still
-        //      we want to handle this better in the future.
-        if cost.is_nan() {
-            panic!("evaluation KL-Divergence cost is NaN");
-        }
-
-        let (mean, len) = self.current_mean_evaluation_cost_and_len.as_mut().unwrap();
-        *mean += cost / *len as f32;
-
-        self.eval_progress_bar.inc(1);
-        Ok(())
-    }
-
-    fn end_of_evaluation(&mut self) -> Result<(), Self::Error> {
-        let (cost, _) = self.current_mean_evaluation_cost_and_len.take().unwrap();
-        self.eval_progress_bar
-            .set_message(format!("cost={:.5}", cost));
-        self.train_progress_bar
-            .println(format!("Evaluation Cost: {}", cost));
-        Ok(())
-    }
-
     fn begin_of_training(
         &mut self,
         nr_epochs: usize,
@@ -214,12 +238,12 @@ impl TrainingController for CliTrainingController {
         let multi_bar = MultiProgress::new();
         multi_bar.add(self.train_progress_bar.clone());
         multi_bar.add(self.epoch_progress_bar.clone());
+        multi_bar.add(self.sample_progress_bar.clone());
         multi_bar.add(self.eval_progress_bar.clone());
         // Needed or else bars won't print to the screen.
         std::thread::spawn(move || multi_bar.join());
 
-        self.train_progress_bar
-            .set_length(nr_epochs.try_into().unwrap());
+        self.train_progress_bar.set_length(nr_epochs as u64);
 
         self.train_progress_bar.enable_steady_tick(100);
         self.epoch_progress_bar.tick();

--- a/dev-tool/src/list_net/cli_callbacks.rs
+++ b/dev-tool/src/list_net/cli_callbacks.rs
@@ -25,9 +25,6 @@ pub(crate) struct CliTrainingControllerBuilder {
     /// The ListNet will be written to the output folder in the form of
     /// `list_net_{epoch}.binparams`.
     pub(crate) dump_every: Option<usize>,
-
-    /// If true a progress bar for the current batch is shown
-    pub(crate) show_sample_progress: bool,
 }
 
 impl CliTrainingControllerBuilder {
@@ -47,17 +44,13 @@ impl CliTrainingControllerBuilder {
                 .template("Batches: [{bar:30.green}] {percent:>3}% ({pos:>5}/{len:>5}) {msg}")
                 .progress_chars("=> "),
         );
-        let sample_progress_bar = if self.show_sample_progress {
-            let bar = ProgressBar::new(0);
-            bar.set_style(
-                ProgressStyle::default_bar()
-                    .template("Samples: [{bar:30.green}] {percent:>3}% ({pos:>5}/{len:>5})")
-                    .progress_chars("=> "),
-            );
-            bar
-        } else {
-            ProgressBar::hidden()
-        };
+        let sample_progress_bar = ProgressBar::new(0);
+        sample_progress_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("Samples: [{bar:30.green}] {percent:>3}% ({pos:>5}/{len:>5})")
+                .progress_chars("=> "),
+        );
+        sample_progress_bar.set_draw_rate(10);
         let eval_progress_bar = ProgressBar::new(0);
         eval_progress_bar.set_style(
             ProgressStyle::default_bar()

--- a/dev-tool/src/list_net/cli_callbacks.rs
+++ b/dev-tool/src/list_net/cli_callbacks.rs
@@ -79,7 +79,7 @@ pub(crate) struct CliTrainingController {
     current_epoch: usize,
     /// The current active (or just ended) batch.
     current_batch: usize,
-    /// The time at which the training did start.
+    /// The time at which the training started.
     start_time: Option<Instant>,
     /// A (CLI) progress bar used to track the progress of the current batch.
     sample_progress_bar: ProgressBar,
@@ -92,7 +92,7 @@ pub(crate) struct CliTrainingController {
 }
 
 impl CliTrainingController {
-    /// Safe the current ListNet parameters to the output dir using the given suffix.
+    /// Save the current ListNet parameters to the output dir using the given suffix.
     ///
     /// The file path will be:
     ///
@@ -153,7 +153,7 @@ impl TrainingController for CliTrainingController {
         I: IntoIterator<Item = SampleOwned>,
         I::IntoIter: Send,
     {
-        trace!("Begin of evaluation");
+        trace!("Beginning of evaluation");
         if nr_samples == 0 {
             trace!("Skipping evaluation.");
             return Ok(());
@@ -191,7 +191,7 @@ impl TrainingController for CliTrainingController {
 
     fn begin_of_epoch(&mut self, nr_batches: usize) -> Result<(), Self::Error> {
         debug!(
-            "Begin of epoch #{:0>4} (#batch {})",
+            "Beginning of epoch #{:0>4} (#batch {})",
             self.current_epoch, nr_batches
         );
         self.current_batch = 0;
@@ -222,7 +222,7 @@ impl TrainingController for CliTrainingController {
         list_net: &ListNet,
     ) -> Result<(), Self::Error> {
         self.start_time = Some(Instant::now());
-        info!("Begin of training for {}", nr_epochs);
+        info!("Beginning of training for {}", nr_epochs);
         if self.setting.dump_initial_parameters {
             trace!("Dumping initial parameters.");
             self.save_parameters(list_net.clone(), "initial")?;

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -438,6 +438,7 @@ impl Storage for InMemorySamples {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use ndarray::Array;
     use rand::thread_rng;
     use xayn_ai::assert_approx_eq;
@@ -594,7 +595,9 @@ mod tests {
     #[test]
     fn test_data_lookup_order_changes_on_reset() {
         let mut rng = thread_rng();
-        let mut dlo = DataLookupOrder::new(vec![0, 1, 2, 3, 4]);
+        // There is a ~1.2e-46% chance that this test randomly fails
+        // (assuming all shuffled results are equally likely).
+        let mut dlo = DataLookupOrder::new((0..40).collect_vec());
 
         dlo.reset(&mut rng);
         let all = dlo.next_batch(5);

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -88,10 +88,6 @@ where
             evaluation_data_order: DataLookupOrder::new(evaluation_ids),
         })
     }
-
-    pub fn batch_size(&self) -> usize {
-        self.batch_size
-    }
 }
 
 #[derive(Error, Debug, Display)]

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -436,7 +436,7 @@ impl Storage for InMemorySamples {
 mod tests {
     use itertools::Itertools;
     use ndarray::Array;
-    use rand::thread_rng;
+    use rand::{prelude::StdRng, SeedableRng};
     use xayn_ai::assert_approx_eq;
 
     use super::*;
@@ -590,9 +590,11 @@ mod tests {
 
     #[test]
     fn test_data_lookup_order_changes_on_reset() {
-        let mut rng = thread_rng();
-        // There is a ~1.2e-46% chance that this test randomly fails
-        // (assuming all shuffled results are equally likely).
+        // If we don't seed it, than the test might randomly fail as
+        // the two shuffles could randomly yield the same result. The
+        // `Rng` algorithm might change with updates to "rand" if this
+        // happens this test could still fail, but it would be reproducible.
+        let mut rng = StdRng::from_seed([2u8; 32]);
         let mut dlo = DataLookupOrder::new((0..40).collect_vec());
 
         dlo.reset(&mut rng);

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -19,7 +19,7 @@ use rand::{prelude::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use xayn_ai::list_net::{self, ListNet, Sample};
+use xayn_ai::list_net::{self, ListNet, SampleOwned, SampleView};
 
 /// A [`xayn_ai::list_net::DataSource`] implementation.
 pub(crate) struct DataSource<S>
@@ -53,13 +53,10 @@ where
     pub(crate) fn new(
         storage: S,
         evaluation_split: f32,
-        batch_size: usize,
+        mut batch_size: usize,
     ) -> Result<Self, DataSourceError<S::Error>> {
         if evaluation_split < 0. || !evaluation_split.is_normal() {
             return Err(DataSourceError::BadEvaluationSplit(evaluation_split));
-        }
-        if batch_size == 0 {
-            return Err(DataSourceError::BatchSize0);
         }
         let nr_all_samples = storage.data_ids().map_err(DataSourceError::Storage)?.end;
         if nr_all_samples == 0 {
@@ -78,6 +75,8 @@ where
                 batch_size,
                 nr_training_samples,
             });
+        } else if batch_size == 0 {
+            batch_size = nr_training_samples;
         }
         let evaluation_ids = (nr_training_samples..nr_all_samples).collect();
         let training_ids = (0..nr_training_samples).collect();
@@ -88,6 +87,10 @@ where
             training_data_order: DataLookupOrder::new(training_ids),
             evaluation_data_order: DataLookupOrder::new(evaluation_ids),
         })
+    }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
     }
 }
 
@@ -102,8 +105,6 @@ where
     TooLargeEvaluationSplit(f32),
     /// Unusable evaluation split: Assertion `nr_evaluation_samples > 0 || split == 0` failed (split = {0}).
     NoEvaluationSamples(f32),
-    /// A batch size of 0 is not usable for training.
-    BatchSize0,
     /// The batch size ({batch_size}) is larger than the number of samples ({nr_training_samples}).
     TooLargeBatchSize {
         batch_size: usize,
@@ -132,7 +133,7 @@ where
         self.training_data_order.number_of_batches(self.batch_size)
     }
 
-    fn next_training_batch(&mut self) -> Result<Vec<Sample>, Self::Error> {
+    fn next_training_batch(&mut self) -> Result<Vec<SampleView>, Self::Error> {
         let ids = self.training_data_order.next_batch(self.batch_size);
         if ids.is_empty() {
             return Ok(Vec::new());
@@ -146,10 +147,10 @@ where
         self.evaluation_data_order.number_of_samples()
     }
 
-    fn next_evaluation_sample(&mut self) -> Result<Option<Sample>, Self::Error> {
+    fn next_evaluation_sample(&mut self) -> Result<Option<SampleOwned>, Self::Error> {
         if let Some(id) = self.evaluation_data_order.next() {
             match self.storage.load_sample(id) {
-                Ok(sample) => Ok(Some(sample)),
+                Ok(sample) => Ok(Some(sample.to_owned())),
                 Err(error) => Err(DataSourceError::Storage(error)),
             }
         } else {
@@ -158,8 +159,8 @@ where
     }
 }
 
-pub(crate) trait Storage {
-    type Error: StdError + 'static;
+pub(crate) trait Storage: Send {
+    type Error: StdError + 'static + Send;
 
     /// Return all sample ids.
     ///
@@ -173,12 +174,12 @@ pub(crate) trait Storage {
     /// (due to loading/caching) and we also want to make sure that there
     /// are no more lend out samples, when `load_sample` or `load_batch` are
     /// called again.
-    fn load_sample(&mut self, id: DataId) -> Result<Sample, Self::Error>;
+    fn load_sample(&mut self, id: DataId) -> Result<SampleView, Self::Error>;
 
     /// Loads a batch of samples and returns a vector of references to them.
     ///
     /// See [`Storage.load_batch()`] about why this is `&mut self`.
-    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<Sample<'a>>, Self::Error>;
+    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<SampleView<'a>>, Self::Error>;
 }
 
 /// For now samples ids are always incremental integers from `0` to `nr_samples`.
@@ -312,7 +313,7 @@ impl InMemorySamples {
         Ok(self_)
     }
 
-    fn load_sample_helper(&self, id: DataId) -> Result<Sample, StorageError> {
+    fn load_sample_helper(&self, id: DataId) -> Result<SampleView, StorageError> {
         let raw = &self.data[id];
 
         // len == nr_document * nr_features + nr_documents * 1
@@ -329,7 +330,7 @@ impl InMemorySamples {
             ArrayView::from_shape((nr_documents,), &raw[start_of_target_prob_dist..])
                 .map_err(|_| StorageError::BrokenInvariants { at_index: id })?;
 
-        Ok(Sample {
+        Ok(SampleView {
             inputs,
             target_prob_dist,
         })
@@ -422,11 +423,11 @@ impl Storage for InMemorySamples {
         Ok(..self.data.len())
     }
 
-    fn load_sample(&mut self, id: DataId) -> Result<Sample, Self::Error> {
+    fn load_sample(&mut self, id: DataId) -> Result<SampleView, Self::Error> {
         self.load_sample_helper(id)
     }
 
-    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<Sample<'a>>, Self::Error> {
+    fn load_batch<'a>(&'a mut self, ids: &'_ [DataId]) -> Result<Vec<SampleView<'a>>, Self::Error> {
         let mut samples = Vec::new();
         for id in ids {
             samples.push(self.load_sample_helper(*id)?)

--- a/dev-tool/src/list_net/evaluate.rs
+++ b/dev-tool/src/list_net/evaluate.rs
@@ -25,7 +25,7 @@ pub struct EvaluateCmd {
     #[structopt(long)]
     parameters: PathBuf,
 
-    /// The percent of samples to use for evaluation.
+    /// The percentage of samples to use for evaluation.
     ///
     /// The percentage of evaluation samples will be taken
     /// from the end of the sample set.

--- a/dev-tool/src/list_net/evaluate.rs
+++ b/dev-tool/src/list_net/evaluate.rs
@@ -1,0 +1,95 @@
+#![cfg(not(tarpaulin))]
+
+use std::{iter, ops::Add, path::PathBuf};
+
+use anyhow::{bail, Context, Error};
+use indicatif::{ProgressBar, ProgressStyle};
+use rayon::iter::{ParallelBridge, ParallelIterator};
+use structopt::StructOpt;
+
+use xayn_ai::list_net::{ndutils::kl_divergence, DataSource as _, ListNet};
+
+use super::data_source::{DataSource, InMemorySamples};
+use crate::{exit_code::NO_ERROR, utils::progress_spin_until_done};
+
+/// Runs a single evaluation pass on a ListNet.
+#[derive(StructOpt, Debug)]
+pub struct EvaluateCmd {
+    /// A file containing samples we can train and evaluate on.
+    #[structopt(long)]
+    samples: PathBuf,
+
+    /// File containing a ListNet parameter set.
+    ///
+    /// E.g. `list_net.binparams`
+    #[structopt(long)]
+    parameters: PathBuf,
+
+    /// The percent of samples to use for evaluation.
+    ///
+    /// The percentage of evaluation samples will be taken
+    /// from the back.
+    #[structopt(long, default_value = "0.2")]
+    evaluation_split: f32,
+}
+
+impl EvaluateCmd {
+    pub fn run(self) -> Result<i32, Error> {
+        let Self {
+            samples,
+            parameters,
+            evaluation_split,
+        } = self;
+
+        let mut data_source = progress_spin_until_done("Loading samples", || {
+            let storage = InMemorySamples::deserialize_from_file(samples)
+                .context("Loading training & evaluation samples failed.")?;
+            DataSource::new(storage, evaluation_split, 1).context("Creating DataSource failed.")
+        })?;
+
+        let list_net = ListNet::deserialize_from_file(parameters)?;
+
+        let nr_samples = data_source.number_of_evaluation_samples();
+
+        if nr_samples == 0 {
+            bail!("No evaluation samples with given data source and evaluation split");
+        }
+
+        let progress_bar = ProgressBar::new(nr_samples as u64);
+        progress_bar.set_style(
+            ProgressStyle::default_bar()
+                .template("Evaluation: [{bar:27.green}] {percent:>3}% ({pos:>5}/{len:>5}) {elapsed_precise}")
+                .progress_chars("=> "),
+        );
+        progress_bar.tick();
+
+        let mut error_slot = None;
+        let iter = iter::from_fn(|| match data_source.next_evaluation_sample() {
+            Ok(v) => v,
+            Err(err) => {
+                error_slot = Some(err);
+                None
+            }
+        });
+
+        let nr_samples = nr_samples as f32;
+        let mean_cost = iter
+            .par_bridge()
+            .map(|sample| {
+                let cost = list_net.evaluate(kl_divergence, sample.as_view());
+                progress_bar.inc(1);
+                cost
+            })
+            .fold(|| 0.0, |acc, cost| acc + cost / nr_samples)
+            .reduce_with(Add::add)
+            .unwrap();
+
+        if let Some(error) = error_slot {
+            return Err(error.into());
+        }
+
+        progress_bar.finish();
+        println!("mean_evaluation_cost={}", mean_cost);
+        Ok(NO_ERROR)
+    }
+}

--- a/dev-tool/src/list_net/evaluate.rs
+++ b/dev-tool/src/list_net/evaluate.rs
@@ -28,7 +28,7 @@ pub struct EvaluateCmd {
     /// The percent of samples to use for evaluation.
     ///
     /// The percentage of evaluation samples will be taken
-    /// from the back.
+    /// from the end of the sample set.
     #[structopt(long, default_value = "0.2")]
     evaluation_split: f32,
 }

--- a/dev-tool/src/list_net/train.rs
+++ b/dev-tool/src/list_net/train.rs
@@ -32,7 +32,7 @@ pub struct TrainCmd {
     ///
     /// WARNING: This is not optimized for a `0` `batch-size`
     /// with huge number of samples in the batch. It's mainly
-    /// meant to be used with XaynNet emulation modes.
+    /// meant to be used with XayNet emulation modes.
     #[structopt(long, default_value = "32")]
     batch_size: usize,
 
@@ -93,7 +93,6 @@ impl TrainCmd {
             out_dir,
             dump_initial_parameters,
             dump_every,
-            show_sample_progress: data_source.batch_size() >= 256,
         }
         .build();
 

--- a/dev-tool/src/list_net/train.rs
+++ b/dev-tool/src/list_net/train.rs
@@ -25,6 +25,14 @@ pub struct TrainCmd {
     epochs: usize,
 
     /// The batch size to use.
+    ///
+    /// Setting the `batch-size` to `0` will automatically
+    /// set it to the number of training samples. I.e. there
+    /// will only be one batch per epoch.
+    ///
+    /// WARNING: This is not optimized for a `0` `batch-size`
+    /// with huge number of samples in the batch. It's mainly
+    /// meant to be used with XaynNet emulation modes.
     #[structopt(long, default_value = "32")]
     batch_size: usize,
 
@@ -85,6 +93,7 @@ impl TrainCmd {
             out_dir,
             dump_initial_parameters,
             dump_every,
+            show_sample_progress: data_source.batch_size() >= 256,
         }
         .build();
 

--- a/xayn-ai/src/ltr/list_net/mod.rs
+++ b/xayn-ai/src/ltr/list_net/mod.rs
@@ -3,8 +3,10 @@
 use std::{
     error::Error as StdError,
     io::{Read, Write},
+    iter,
     ops::{Add, Div, MulAssign},
     path::Path,
+    sync::Mutex,
 };
 
 use thiserror::Error;
@@ -313,14 +315,29 @@ impl ListNet {
         scores
     }
 
+    /// Evaluates the ListNet on given sample using given cost function.
+    pub fn evaluate(
+        &self,
+        cost_function: fn(ArrayView1<f32>, ArrayView1<f32>) -> f32,
+        sample: SampleView,
+    ) -> f32 {
+        let SampleView {
+            inputs,
+            target_prob_dist,
+        } = sample;
+        let (scores_y, _) = self.calculate_intermediate_scores(inputs, false);
+        let prob_dist_y = self.calculate_final_scores(&scores_y);
+        cost_function(target_prob_dist, prob_dist_y.view())
+    }
+
     /// Computes the gradients and loss for given inputs and target prob. dist.
     ///
     /// # Panics
     ///
     /// If inputs and relevances are not for exactly [`Self::INPUT_NR_DOCUMENTS`]
     /// documents.
-    fn gradients_for_query(&self, sample: Sample) -> (GradientSet, f32) {
-        let Sample {
+    fn gradients_for_query(&self, sample: SampleView) -> (GradientSet, f32) {
+        let SampleView {
             inputs,
             target_prob_dist,
         } = sample;
@@ -623,15 +640,11 @@ where
             return Ok(false);
         }
 
-        callbacks.begin_of_batch().map_err(TrainingError::Control)?;
-
-        let gradient_sets =
-            callbacks.run_batch(batch, |sample| list_net.gradients_for_query(sample));
+        let gradient_sets = callbacks
+            .run_batch(batch, |sample| list_net.gradients_for_query(sample))
+            .map_err(TrainingError::Control)?;
 
         optimizer.apply_gradients(list_net, gradient_sets);
-
-        callbacks.end_of_batch().map_err(TrainingError::Control)?;
-
         Ok(true)
     }
 
@@ -640,37 +653,41 @@ where
         &mut self,
         cost_function: fn(ArrayView1<f32>, ArrayView1<f32>) -> f32,
     ) -> Result<(), TrainingError<D::Error, C::Error>> {
-        self.callbacks
-            .begin_of_evaluation(self.data_source.number_of_evaluation_samples())
+        let Self {
+            data_source,
+            callbacks,
+            list_net,
+            ..
+        } = self;
+
+        let nr_samples = data_source.number_of_evaluation_samples();
+        let error_slot = Mutex::new(None);
+        let sample_iter = iter::from_fn(|| match data_source.next_evaluation_sample() {
+            Ok(v) => v,
+            Err(err) => {
+                let mut error_slot = error_slot.lock().unwrap();
+                *error_slot = Some(err);
+                None
+            }
+        });
+
+        callbacks
+            .run_evaluation(sample_iter, nr_samples, |sample| {
+                list_net.evaluate(cost_function, sample.as_view())
+            })
             .map_err(TrainingError::Control)?;
 
-        while let Some(Sample {
-            inputs,
-            target_prob_dist,
-        }) = self
-            .data_source
-            .next_evaluation_sample()
-            .map_err(TrainingError::Data)?
-        {
-            let (scores_y, _) = self.list_net.calculate_intermediate_scores(inputs, false);
-            let prob_dist_y = self.list_net.calculate_final_scores(&scores_y);
-            let cost = cost_function(target_prob_dist, prob_dist_y.view());
-            self.callbacks
-                .evaluation_result(cost)
-                .map_err(TrainingError::Control)?;
+        if let Some(error) = error_slot.into_inner().unwrap() {
+            Err(TrainingError::Data(error))
+        } else {
+            Ok(())
         }
-
-        self.callbacks
-            .end_of_evaluation()
-            .map_err(TrainingError::Control)?;
-
-        Ok(())
     }
 }
 
 /// A single sample you can train on.
-pub struct Sample<'a> {
-    /// Input used for training.
+pub struct SampleView<'a> {
+    /// Inputs used for training.
     ///
     /// (At least for now) this must be a `(10, 50)` array
     /// view.
@@ -682,12 +699,44 @@ pub struct Sample<'a> {
     pub target_prob_dist: ArrayView1<'a, f32>,
 }
 
+impl<'a> SampleView<'a> {
+    pub fn to_owned(&self) -> SampleOwned {
+        SampleOwned {
+            inputs: self.inputs.to_owned(),
+            target_prob_dist: self.target_prob_dist.to_owned(),
+        }
+    }
+}
+
+/// A owned version of [`SampleRef`]
+pub struct SampleOwned {
+    /// Inputs used for training.
+    ///
+    /// (At least for now) this must be a `(10, 50)` array
+    /// view.
+    pub inputs: Array2<f32>,
+
+    /// Target probability distribution.
+    ///
+    /// Needs to have the same length as `inputs.shape()[0]`.
+    pub target_prob_dist: Array1<f32>,
+}
+
+impl SampleOwned {
+    pub fn as_view(&self) -> SampleView {
+        SampleView {
+            inputs: self.inputs.view(),
+            target_prob_dist: self.target_prob_dist.view(),
+        }
+    }
+}
+
 /// A source of training and evaluation data.
 ///
 /// Settings like the batch size or evaluation split need
 /// to be handled when creating this instance.
-pub trait DataSource {
-    type Error: StdError + 'static;
+pub trait DataSource: Send {
+    type Error: StdError + 'static + Send;
 
     /// Resets/initializes the "iteration" of training and evaluation samples.
     ///
@@ -704,7 +753,7 @@ pub trait DataSource {
     /// Returns the next batch of training samples.
     ///
     /// Returns a empty vector once all training samples have been returned.
-    fn next_training_batch(&mut self) -> Result<Vec<Sample>, Self::Error>;
+    fn next_training_batch(&mut self) -> Result<Vec<SampleView>, Self::Error>;
 
     /// Returns the expected number of evaluation samples.
     fn number_of_evaluation_samples(&self) -> usize;
@@ -712,7 +761,7 @@ pub trait DataSource {
     /// Returns the next evaluation sample.
     ///
     /// Returns `None` once all training sample have been returned.
-    fn next_evaluation_sample(&mut self) -> Result<Option<Sample>, Self::Error>;
+    fn next_evaluation_sample(&mut self) -> Result<Option<SampleOwned>, Self::Error>;
 }
 
 /// A trait providing various callbacks used during training.
@@ -725,15 +774,20 @@ pub trait TrainingController {
     /// Implementations can be both sequential or parallel.
     fn run_batch(
         &mut self,
-        batch: Vec<Sample>,
-        map_fn: impl Fn(Sample) -> (GradientSet, f32) + Send + Sync,
-    ) -> Vec<GradientSet>;
+        batch: Vec<SampleView>,
+        map_fn: impl Fn(SampleView) -> (GradientSet, f32) + Send + Sync,
+    ) -> Result<Vec<GradientSet>, Self::Error>;
 
-    /// Called before started training a batch.
-    fn begin_of_batch(&mut self) -> Result<(), Self::Error>;
-
-    /// Called after training a batch, the loss for each sample will be passed in.
-    fn end_of_batch(&mut self) -> Result<(), Self::Error>;
+    /// Runs the processing of sample evaluation.
+    fn run_evaluation<I>(
+        &mut self,
+        samples: I,
+        nr_samples: usize,
+        eval_fn: impl Fn(SampleOwned) -> f32 + Send + Sync,
+    ) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = SampleOwned>,
+        I::IntoIter: Send;
 
     /// Called at the begin of each epoch.
     fn begin_of_epoch(&mut self, nr_batches: usize) -> Result<(), Self::Error>;
@@ -743,12 +797,6 @@ pub trait TrainingController {
     /// The passed in reference to `list_net` can be used to e.g. bump the intermediate training
     /// result every 10 epochs.
     fn end_of_epoch(&mut self, list_net: &ListNet) -> Result<(), Self::Error>;
-
-    fn begin_of_evaluation(&mut self, nr_samples: usize) -> Result<(), Self::Error>;
-
-    fn evaluation_result(&mut self, cost: f32) -> Result<(), Self::Error>;
-
-    fn end_of_evaluation(&mut self) -> Result<(), Self::Error>;
 
     /// Called at the begin of training.
     fn begin_of_training(

--- a/xayn-ai/src/ltr/list_net/mod.rs
+++ b/xayn-ai/src/ltr/list_net/mod.rs
@@ -708,7 +708,7 @@ impl<'a> SampleView<'a> {
     }
 }
 
-/// A owned version of [`SampleRef`]
+/// An owned version of [`SampleRef`]
 pub struct SampleOwned {
     /// Inputs used for training.
     ///
@@ -744,7 +744,7 @@ pub trait DataSource: Send {
     /// samples and/or their order. E.g. this could shuffle them
     /// before every epoch.
     ///
-    /// This is called at the *begin* of every epoch.
+    /// This is called at the *beginning* of every epoch.
     fn reset(&mut self) -> Result<(), Self::Error>;
 
     /// Returns the expected number of training batches.
@@ -752,7 +752,7 @@ pub trait DataSource: Send {
 
     /// Returns the next batch of training samples.
     ///
-    /// Returns a empty vector once all training samples have been returned.
+    /// Returns an empty vector once all training samples have been returned.
     fn next_training_batch(&mut self) -> Result<Vec<SampleView>, Self::Error>;
 
     /// Returns the expected number of evaluation samples.
@@ -760,7 +760,7 @@ pub trait DataSource: Send {
 
     /// Returns the next evaluation sample.
     ///
-    /// Returns `None` once all training sample have been returned.
+    /// Returns `None` once all training samples have been returned.
     fn next_evaluation_sample(&mut self) -> Result<Option<SampleOwned>, Self::Error>;
 }
 
@@ -789,7 +789,7 @@ pub trait TrainingController {
         I: IntoIterator<Item = SampleOwned>,
         I::IntoIter: Send;
 
-    /// Called at the begin of each epoch.
+    /// Called at the beginning of each epoch.
     fn begin_of_epoch(&mut self, nr_batches: usize) -> Result<(), Self::Error>;
 
     /// Called at the end of each epoch.
@@ -798,7 +798,7 @@ pub trait TrainingController {
     /// result every 10 epochs.
     fn end_of_epoch(&mut self, list_net: &ListNet) -> Result<(), Self::Error>;
 
-    /// Called at the begin of training.
+    /// Called at the beginning of training.
     fn begin_of_training(
         &mut self,
         nr_epochs: usize,

--- a/xayn-ai/src/ltr/list_net/mod.rs
+++ b/xayn-ai/src/ltr/list_net/mod.rs
@@ -315,7 +315,7 @@ impl ListNet {
         scores
     }
 
-    /// Evaluates the ListNet on given sample using given cost function.
+    /// Evaluates the ListNet on a given sample using the given cost function.
     pub fn evaluate(
         &self,
         cost_function: fn(ArrayView1<f32>, ArrayView1<f32>) -> f32,
@@ -344,7 +344,7 @@ impl ListNet {
         assert_eq!(inputs.shape()[0], ListNet::INPUT_NR_DOCUMENTS);
         assert_eq!(target_prob_dist.len(), ListNet::INPUT_NR_DOCUMENTS);
         let results = self.forward_pass(inputs);
-        //FIXME[followup PR] if we don't track loss in XaynNet when used in the app we don't need to calculate it.
+        //FIXME[followup PR] if we don't track loss in XayNet when used in the app we don't need to calculate it.
         let loss = kl_divergence(target_prob_dist.view(), results.prob_dist_y.view());
         //UNWRAP_SAFE: Document are not empty.
         let gradients = self
@@ -778,7 +778,7 @@ pub trait TrainingController {
         map_fn: impl Fn(SampleView) -> (GradientSet, f32) + Send + Sync,
     ) -> Result<Vec<GradientSet>, Self::Error>;
 
-    /// Runs the processing of sample evaluation.
+    /// Runs the processing of the sample evaluation.
     fn run_evaluation<I>(
         &mut self,
         samples: I,


### PR DESCRIPTION
Based on PR #163.

This does some refactoring as well as:

- Adds a `dev-tool list-net evaluate` command allowing the comparison of existing ListNets.
- Adds support for parallel evaluation of samples.
- Adds a single batch training mode  (batch_size=0 => batch_size=nr_of_training_samples).