### PR TITLE
increase timeout to 30 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
     name: test-android-libs
     needs: [cargo-registry-cache, cargo-test]
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The CI is sometimes falling because the tests of `test-android-libs (aarch64-linux-android)`[ take longer than 20 min](https://github.com/xaynetwork/xayn_ai/runs/3289654229).
This RP increases the timeout to 30 min.

