### PR TITLE
TY-1899 tests for sync & merge

### DIFF
--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -32,6 +32,7 @@ impl NegativeCoi {
 }
 
 /// A pair of CoIs.
+#[cfg_attr(test, derive(Debug, PartialEq))]
 #[derive(Clone)]
 struct CoiPair<C>(C, C);
 
@@ -169,4 +170,171 @@ fn merge_params(a1: f32, b1: f32, a2: f32, b2: f32) -> (f32, f32) {
 
     let factor = avg_mean * (1. - avg_mean) / avg_var - 1.;
     (avg_mean * factor, (1. - avg_mean) * factor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        tests::{mocked_smbert_system, pos_cois_from_words, pos_cois_from_words_with_ids},
+        utils::mock_coi_id,
+    };
+
+    impl PositiveCoi {
+        fn from_word(word: &str, id: usize) -> Self {
+            pos_cois_from_words_with_ids(&[word], mocked_smbert_system(), id)
+                .pop()
+                .unwrap()
+        }
+
+        fn mock() -> Self {
+            Self::from_word("", 0)
+        }
+    }
+
+    #[test]
+    fn test_coipair_distinct() {
+        let cois = pos_cois_from_words(&["a", "b"], mocked_smbert_system());
+        assert_eq!(cois.len(), 2);
+
+        let pair = CoiPair::new(cois[0].clone(), cois[1].clone());
+        assert_eq!(pair.0, cois[0]);
+        assert_eq!(pair.1, cois[1]);
+
+        let pair_rev = CoiPair::new(cois[1].clone(), cois[0].clone());
+        assert_eq!(pair_rev, pair);
+    }
+
+    #[test]
+    fn test_coipair_dupes() {
+        let coi_a = PositiveCoi::from_word("a", 0);
+        let coi_b = PositiveCoi::from_word("b", 0);
+
+        let pair = CoiPair::new(coi_a.clone(), coi_b.clone());
+        assert_eq!(pair.0, coi_a);
+        assert_eq!(pair.1, coi_b);
+
+        let pair_rev = CoiPair::new(coi_b.clone(), coi_a.clone());
+        assert_eq!(pair_rev.0, coi_b);
+        assert_eq!(pair_rev.1, coi_a);
+    }
+
+    #[test]
+    fn test_coipair_contains() {
+        let coi_a = PositiveCoi::from_word("a", 0);
+        let coi_b = PositiveCoi::from_word("b", 1);
+        let coi_c = PositiveCoi::from_word("c", 2);
+        let coi_d = PositiveCoi::from_word("d", 3);
+
+        let pair_ab = CoiPair::new(coi_a.clone(), coi_b.clone());
+        let pair_ac = CoiPair::new(coi_a, coi_c.clone());
+        let pair_bc = CoiPair::new(coi_b, coi_c.clone());
+        let pair_cd = CoiPair::new(coi_c, coi_d);
+
+        assert!(pair_ab.contains(mock_coi_id(0)));
+        assert!(pair_ab.contains(mock_coi_id(1)));
+        assert!(!pair_ab.contains(mock_coi_id(2)));
+        assert!(!pair_ab.contains(mock_coi_id(3)));
+
+        assert!(pair_ab.contains_any(&pair_ab));
+        assert!(pair_ab.contains_any(&pair_ac));
+        assert!(pair_ab.contains_any(&pair_bc));
+        assert!(!pair_ab.contains_any(&pair_cd));
+    }
+
+    #[test]
+    fn test_merge() {
+        let coi_a = PositiveCoi::from_word("a", 0);
+        let coi_z = PositiveCoi::from_word("z", 1);
+        let pair_az = CoiPair::new(coi_a.clone(), coi_z.clone());
+        let merged = pair_az.merge_min();
+        assert_eq!(merged.id, coi_a.id);
+
+        let dist_az = dist(&coi_a, &coi_z);
+        assert!(dist(&coi_a, &merged) < dist_az);
+        assert!(dist(&merged, &coi_z) < dist_az);
+        // TODO check merged beta params once refactoring is done
+    }
+
+    #[test]
+    fn test_coipair_compare() {
+        let coi_a = PositiveCoi::from_word("a", 0);
+        let coi_b = PositiveCoi::from_word("b", 1);
+        let coi_c = PositiveCoi::from_word("c", 2);
+        let coi_d = PositiveCoi::from_word("d", 3);
+
+        let pair_ac = CoiPair::new(coi_a, coi_c.clone());
+        let pair_bc = CoiPair::new(coi_b.clone(), coi_c.clone());
+        let pair_cd = CoiPair::new(coi_c, coi_d.clone());
+        let pair_bd = CoiPair::new(coi_b, coi_d);
+
+        assert_eq!(pair_bc.compare(&pair_bc), Ordering::Equal);
+        assert_eq!(pair_bc.compare(&pair_ac), Ordering::Greater);
+        assert_eq!(pair_bc.compare(&pair_cd), Ordering::Less);
+        assert_eq!(pair_bc.compare(&pair_bd), Ordering::Less);
+    }
+
+    #[test]
+    fn test_coiple_compare() {
+        let coi_a = PositiveCoi::from_word("a", 0);
+        let coi_b = PositiveCoi::from_word("b", 1);
+        let coi_c = PositiveCoi::from_word("c", 2);
+        let coi_d = PositiveCoi::from_word("d", 3);
+        let coiple_bc = Coiple::new(coi_b, coi_c, 5.);
+
+        assert_eq!(coiple_bc.compare(&coiple_bc), Ordering::Equal);
+        let close = Coiple::new(PositiveCoi::mock(), PositiveCoi::mock(), 1.);
+        assert_eq!(coiple_bc.compare(&close), Ordering::Greater);
+        let far = Coiple::new(PositiveCoi::mock(), PositiveCoi::mock(), 10.);
+        assert_eq!(coiple_bc.compare(&far), Ordering::Less);
+
+        let coiple_aa = Coiple::new(coi_a.clone(), coi_a, 5.);
+        let coiple_dd = Coiple::new(coi_d.clone(), coi_d, 5.);
+        assert_eq!(coiple_bc.compare(&coiple_aa), Ordering::Greater);
+        assert_eq!(coiple_bc.compare(&coiple_dd), Ordering::Less);
+    }
+
+    #[test]
+    fn test_reduce_cois_empty() {
+        let mut empty: Vec<PositiveCoi> = vec![];
+        reduce_cois(&mut empty);
+        assert!(empty.is_empty())
+    }
+
+    #[test]
+    fn test_reduce_cois_distant() {
+        let coi_a = PositiveCoi::from_word("a", 0);
+        let coi_m = PositiveCoi::from_word("m", 1);
+        let coi_z = PositiveCoi::from_word("z", 2);
+        let mut cois = vec![coi_a, coi_m, coi_z];
+        let cois_before = cois.clone();
+
+        reduce_cois(&mut cois);
+        assert_eq!(cois, cois_before);
+    }
+
+    #[test]
+    fn test_reduce_cois_coiples() {
+        let coi_a = PositiveCoi::from_word("a", 0);
+        let coi_k = PositiveCoi::from_word("k", 1);
+        let coi_m = PositiveCoi::from_word("m", 2);
+        let coi_n = PositiveCoi::from_word("n", 3);
+        let coi_z = PositiveCoi::from_word("z", 4);
+        let mut cois = vec![
+            coi_a.clone(),
+            coi_k.clone(),
+            coi_m.clone(),
+            coi_n.clone(),
+            coi_z.clone(),
+        ];
+
+        reduce_cois(&mut cois);
+        assert_eq!(cois.len(), 3);
+        assert!(cois.contains(&coi_a));
+        assert!(cois.contains(&coi_z));
+
+        let coi_mn = CoiPair::new(coi_m, coi_n).merge_min();
+        let coi_k_mn = CoiPair::new(coi_k, coi_mn).merge_min();
+        assert!(cois.contains(&coi_k_mn));
+    }
 }

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -193,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn test_coipair_distinct() {
+    fn test_coipair_new_distinct() {
         let cois = pos_cois_from_words(&["a", "b"], mocked_smbert_system());
         assert_eq!(cois.len(), 2);
 
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    fn test_coipair_dupes() {
+    fn test_coipair_new_dupes() {
         let coi_a = PositiveCoi::from_word("a", 0);
         let coi_b = PositiveCoi::from_word("b", 0);
 
@@ -295,14 +295,14 @@ mod tests {
     }
 
     #[test]
-    fn test_reduce_cois_empty() {
+    fn test_reduce_empty() {
         let mut empty: Vec<PositiveCoi> = vec![];
         reduce_cois(&mut empty);
         assert!(empty.is_empty())
     }
 
     #[test]
-    fn test_reduce_cois_distant() {
+    fn test_reduce_distant() {
         let coi_a = PositiveCoi::from_word("a", 0);
         let coi_m = PositiveCoi::from_word("m", 1);
         let coi_z = PositiveCoi::from_word("z", 2);
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reduce_cois_coiples() {
+    fn test_reduce_coiples_idempotent() {
         let coi_a = PositiveCoi::from_word("a", 0);
         let coi_k = PositiveCoi::from_word("k", 1);
         let coi_m = PositiveCoi::from_word("m", 2);
@@ -336,5 +336,9 @@ mod tests {
         let coi_mn = CoiPair::new(coi_m, coi_n).merge_min();
         let coi_k_mn = CoiPair::new(coi_k, coi_mn).merge_min();
         assert!(cois.contains(&coi_k_mn));
+
+        let cois_after = cois.clone();
+        reduce_cois(&mut cois);
+        assert_eq!(cois, cois_after);
     }
 }

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -79,11 +79,17 @@ mod tests {
         pos_cois_from_words_with_ids,
     };
 
-    impl SyncData {
+    impl UserInterests {
         fn from_words(words: &[&str], start_id: usize) -> Self {
             let positive = pos_cois_from_words_with_ids(words, mocked_smbert_system(), start_id);
             let negative = neg_cois_from_words_with_ids(words, mocked_smbert_system(), start_id);
-            let user_interests = UserInterests { positive, negative };
+            Self { positive, negative }
+        }
+    }
+
+    impl SyncData {
+        fn from_words(words: &[&str], start_id: usize) -> Self {
+            let user_interests = UserInterests::from_words(words, start_id);
             Self { user_interests }
         }
 
@@ -105,6 +111,17 @@ mod tests {
         fn eq_up_to_reordering(&self, other: &SyncData) -> bool {
             self.contains(other) && other.contains(self)
         }
+    }
+
+    #[test]
+    fn test_append_user_interests() {
+        let mut cois = UserInterests::from_words(&["a", "b", "c"], 0); // ids 0, 1, 2
+        let extra = UserInterests::from_words(&["b", "c", "d"], 1); // ids 1, 2, 3
+
+        cois.append(extra);
+
+        let expected = UserInterests::from_words(&["a", "b", "c", "d"], 0);
+        assert_eq!(cois, expected);
     }
 
     #[test]

--- a/xayn-ai/src/reranker/sync.rs
+++ b/xayn-ai/src/reranker/sync.rs
@@ -2,6 +2,7 @@ use crate::{
     coi::reduce_cois,
     data::{CoiPoint, UserInterests},
     error::Error,
+    utils::serialize_with_version,
 };
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
@@ -38,13 +39,7 @@ impl SyncData {
 
     /// Serializes a `SyncData` to a byte representation.
     pub(crate) fn serialize(&self) -> Result<Vec<u8>, Error> {
-        let size = bincode::serialized_size(self)? + 1;
-        let mut serialized = Vec::with_capacity(size as usize);
-        // version encoded in first byte
-        serialized.push(CURRENT_SCHEMA_VERSION);
-        bincode::serialize_into(&mut serialized, self)?;
-
-        Ok(serialized)
+        serialize_with_version(self, CURRENT_SCHEMA_VERSION)
     }
 
     /// Synchronizes with another `SyncData`.
@@ -71,4 +66,146 @@ impl UserInterests {
 fn append_cois<C: CoiPoint>(locals: &mut Vec<C>, remotes: &mut Vec<C>) {
     remotes.retain(|rem| !locals.iter().any(|loc| loc.id() == rem.id()));
     locals.append(remotes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{
+        mocked_smbert_system,
+        neg_cois_from_words,
+        neg_cois_from_words_with_ids,
+        pos_cois_from_words,
+        pos_cois_from_words_with_ids,
+    };
+
+    impl SyncData {
+        fn from_words(words: &[&str], start_id: usize) -> Self {
+            let positive = pos_cois_from_words_with_ids(words, mocked_smbert_system(), start_id);
+            let negative = neg_cois_from_words_with_ids(words, mocked_smbert_system(), start_id);
+            let user_interests = UserInterests { positive, negative };
+            Self { user_interests }
+        }
+
+        /// True if the `SyncData` contains all elements of `other`.
+        fn contains(&self, other: &SyncData) -> bool {
+            let cois = &self.user_interests;
+            let other_cois = &other.user_interests;
+            other_cois
+                .positive
+                .iter()
+                .all(|coi| cois.positive.contains(coi))
+                && other_cois
+                    .negative
+                    .iter()
+                    .all(|coi| cois.negative.contains(coi))
+        }
+
+        /// True if the `SyncData` equals `other` up to reordering of cois.
+        fn eq_up_to_reordering(&self, other: &SyncData) -> bool {
+            self.contains(other) && other.contains(self)
+        }
+    }
+
+    #[test]
+    fn test_syncdata_serialize_deserialize() {
+        let syncdata = SyncData::from_words(&["a", "b", "c"], 0);
+        let serialized = syncdata.serialize().expect("serialized data");
+        let deserialized = SyncData::deserialize(&serialized).expect("deserialized data");
+
+        assert_eq!(deserialized, syncdata);
+    }
+
+    #[test]
+    fn test_synchronize_nonempty_empty() {
+        // NOTE words deliberately chosen to be "far enough apart" to avoid merges
+        let mut syncdata = SyncData::from_words(&["a", "m", "z"], 0);
+        let syncdata_before = syncdata.clone();
+        let empty = SyncData::default();
+
+        syncdata.synchronize(empty);
+        // check no change after sync
+        assert_eq!(syncdata, syncdata_before);
+    }
+
+    #[test]
+    fn test_synchronize_empty_nonempty() {
+        let nonempty = SyncData::from_words(&["a", "m", "z"], 0);
+        let mut empty = SyncData::default();
+
+        empty.synchronize(nonempty.clone());
+        // check empty becomes nonempty
+        assert_eq!(empty, nonempty);
+    }
+
+    #[test]
+    fn test_synchronize_commutative_distinct() {
+        let words = &["a", "g", "m", "s", "z"];
+        let mut pos_cois = pos_cois_from_words(words, mocked_smbert_system());
+        let mut neg_cois = neg_cois_from_words(words, mocked_smbert_system());
+        let pos_cois_union = pos_cois.clone();
+        let neg_cois_union = neg_cois.clone();
+
+        // split [a, g, m, s, z] -> [a, g, m], [s, z]
+        let pos_cois2 = pos_cois.split_off(3);
+        let neg_cois2 = neg_cois.split_off(3);
+
+        let user_interests = UserInterests {
+            positive: pos_cois,
+            negative: neg_cois,
+        };
+        let mut data1 = SyncData { user_interests };
+        let data1_before = data1.clone();
+
+        let user_interests = UserInterests {
+            positive: pos_cois2,
+            negative: neg_cois2,
+        };
+        let mut data2 = SyncData { user_interests };
+
+        data1.synchronize(data2.clone());
+        assert_eq!(data1.user_interests.positive, pos_cois_union);
+        assert_eq!(data1.user_interests.negative, neg_cois_union);
+
+        data2.synchronize(data1_before);
+        assert!(data2.eq_up_to_reordering(&data1));
+    }
+
+    #[test]
+    fn test_synchronize_commutative_dupes() {
+        let mut data1 = SyncData::from_words(&["a", "g", "m"], 0); // ids 0, 1, 2
+        let data1_before = data1.clone();
+        let mut data2 = SyncData::from_words(&["g", "m", "s"], 1); // ids 1, 2, 3
+
+        // data1 becomes: { a, g, m, s }
+        data1.synchronize(data2.clone());
+        assert!(data1.contains(&data1_before));
+        assert!(data1.contains(&data2));
+        assert_eq!(data1.user_interests.positive.len(), 4);
+        assert_eq!(data1.user_interests.negative.len(), 4);
+
+        data2.synchronize(data1_before);
+        assert!(data2.eq_up_to_reordering(&data1));
+    }
+
+    #[test]
+    fn test_synchronize_commutative_merge() {
+        let mut data1 = SyncData::from_words(&["a", "g", "m"], 0); // ids 0, 1, 2
+        let data1_before = data1.clone();
+        let mut data2 = SyncData::from_words(&["s", "f", "b"], 3); // ids 3, 4, 5
+
+        // data1 becomes: { merge(a, b), merge(g, f), m, s }
+        data1.synchronize(data2.clone());
+        assert_eq!(data1.user_interests.positive.len(), 4);
+        assert_eq!(data1.user_interests.negative.len(), 4);
+        assert!(!data1.contains(&data1_before)); // no longer contains a, g
+        assert!(!data1.contains(&data2)); // doesn't contain f, b
+
+        // a is close to b, g is close to f, leaving m and s intact
+        let data_unmerged = SyncData::from_words(&["m", "s"], 2); // ids 2, 3
+        assert!(data1.contains(&data_unmerged)); // does contain m, s
+
+        data2.synchronize(data1_before);
+        assert!(data2.eq_up_to_reordering(&data1));
+    }
 }

--- a/xayn-ai/src/tests/mod.rs
+++ b/xayn-ai/src/tests/mod.rs
@@ -16,7 +16,9 @@ pub(crate) use self::{
         from_ids,
         history_for_prev_docs,
         neg_cois_from_words,
+        neg_cois_from_words_with_ids,
         pos_cois_from_words,
+        pos_cois_from_words_with_ids,
     },
 };
 

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -53,7 +53,11 @@ pub(crate) fn documents_from_words(
     .collect()
 }
 
-fn cois_from_words<CP: CoiPoint>(titles: &[&str], smbert: impl SMBertSystem) -> Vec<CP> {
+fn cois_from_words<CP: CoiPoint>(
+    titles: &[&str],
+    smbert: impl SMBertSystem,
+    start_id: usize,
+) -> Vec<CP> {
     let documents = titles
         .iter()
         .enumerate()
@@ -76,16 +80,32 @@ fn cois_from_words<CP: CoiPoint>(titles: &[&str], smbert: impl SMBertSystem) -> 
         .unwrap()
         .into_iter()
         .enumerate()
-        .map(|(id, doc)| CP::new(mock_coi_id(id), doc.smbert.embedding))
+        .map(|(offset, doc)| CP::new(mock_coi_id(start_id + offset), doc.smbert.embedding))
         .collect()
 }
 
 pub(crate) fn pos_cois_from_words(titles: &[&str], smbert: impl SMBertSystem) -> Vec<PositiveCoi> {
-    cois_from_words(titles, smbert)
+    cois_from_words(titles, smbert, 0)
 }
 
 pub(crate) fn neg_cois_from_words(titles: &[&str], smbert: impl SMBertSystem) -> Vec<NegativeCoi> {
-    cois_from_words(titles, smbert)
+    cois_from_words(titles, smbert, 0)
+}
+
+pub(crate) fn pos_cois_from_words_with_ids(
+    titles: &[&str],
+    smbert: impl SMBertSystem,
+    start_id: usize,
+) -> Vec<PositiveCoi> {
+    cois_from_words(titles, smbert, start_id)
+}
+
+pub(crate) fn neg_cois_from_words_with_ids(
+    titles: &[&str],
+    smbert: impl SMBertSystem,
+    start_id: usize,
+) -> Vec<NegativeCoi> {
+    cois_from_words(titles, smbert, start_id)
 }
 
 pub(crate) fn history_for_prev_docs(

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -1,6 +1,9 @@
 use std::cmp::Ordering;
 
 use ndarray::{ArrayBase, Data, Dimension, IntoDimension, Ix};
+use serde::Serialize;
+
+use crate::Error;
 
 #[macro_export]
 macro_rules! to_vec_of_ref_of {
@@ -82,6 +85,17 @@ pub(crate) fn mock_uuid(sub_id: usize) -> uuid::Uuid {
 #[cfg(test)]
 pub(crate) fn mock_coi_id(sub_id: usize) -> crate::CoiId {
     mock_uuid(sub_id).into()
+}
+
+/// Serializes the given data, tagged with the given version number.
+pub(crate) fn serialize_with_version(data: &impl Serialize, version: u8) -> Result<Vec<u8>, Error> {
+    let size = bincode::serialized_size(data)? + 1;
+    let mut serialized = Vec::with_capacity(size as usize);
+    // version is encoded in the first byte
+    serialized.push(version);
+    bincode::serialize_into(&mut serialized, data)?;
+
+    Ok(serialized)
 }
 
 /// Compares two "things" with approximate equality.


### PR DESCRIPTION
**Summary**

previous related: #143, #152, #154.

adds unit tests for the `sync` and `merge` modules.

* adds a migration test to `database` module, factors out `serialize_with_version` into test utils.
* tests for `SyncData` methods, specifically `deserialize` and `synchronize`.
  * particular cases for "identity" and "commutativity" laws.
* tests for `CoiPair` & `Coiple` methods, and `reduce_cois` function.