### PR TITLE
TY-2002 Add rayon for running bert models in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,6 +2379,7 @@ dependencies = [
  "paste",
  "rand",
  "rand_distr",
+ "rayon",
  "rstest",
  "rstest_reuse",
  "rubert",

--- a/xayn-ai-ffi/Cargo.toml
+++ b/xayn-ai-ffi/Cargo.toml
@@ -14,3 +14,6 @@ xayn-ai = { path = "../xayn-ai" }
 
 [build-dependencies]
 cbindgen = "=0.20.0"
+
+[features]
+parallel = ["xayn-ai/parallel"]

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -23,6 +23,9 @@ smallvec = "1.6.1"
 thiserror = "1.0.26"
 uuid = { version = "0.8.2", features = ["serde", "wasm-bindgen", "v4"] }
 
+# parallel feature
+rayon = { version = "1.5.1", optional = true}
+
 [dev-dependencies]
 csv = "1.1.6"
 test-utils = { path = "../test-utils" }
@@ -33,3 +36,6 @@ once_cell = "1.8.0"
 paste = "1.0.5"
 rstest = "0.11.0"
 rstest_reuse = "0.1.3"
+
+[features]
+parallel = ["rayon"]

--- a/xayn-ai/src/embedding/smbert.rs
+++ b/xayn-ai/src/embedding/smbert.rs
@@ -6,14 +6,20 @@ use crate::{
     reranker::systems::SMBertSystem,
 };
 
+#[cfg(feature = "parallel")]
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
 impl SMBertSystem for SMBert {
     fn compute_embedding(
         &self,
         documents: Vec<DocumentDataWithDocument>,
     ) -> Result<Vec<DocumentDataWithSMBert>, Error> {
-        // TODO: optional parallelization
+        #[cfg(not(feature = "parallel"))]
+        let documents = documents.into_iter();
+        #[cfg(feature = "parallel")]
+        let documents = documents.into_par_iter();
+
         documents
-            .into_iter()
             .map(|document| {
                 let embedding = self.run(document.document_content.title.as_str());
                 embedding


### PR DESCRIPTION
**Ticket:**

- [TY-2002]

**Summary**

- adds a `parallel` feature flag that parallelizes the loops over the documents in the S/QAMbertSystem's implementations with rayon's par_iter()

I will do the integration for the mobile version in [TY-2042]


[TY-2002]: https://xainag.atlassian.net/browse/TY-2002
[TY-2042]: https://xainag.atlassian.net/browse/TY-2042