### PR TITLE
Ty 1932 part 4 support chunking data source

### DIFF
--- a/dev-tool/src/list_net/convert.rs
+++ b/dev-tool/src/list_net/convert.rs
@@ -29,7 +29,7 @@ use xayn_ai::{
     UserFeedback,
 };
 
-use super::data_source::InMemorySamples;
+use super::data_source::InMemoryStorage;
 use crate::{exit_code::NO_ERROR, utils::progress_spin_until_done};
 
 /// Converts different file formats.
@@ -65,7 +65,7 @@ impl ConvertCmd {
             )
         })?;
 
-        let storage = Arc::new(Mutex::new(InMemorySamples::with_sample_capacity(nr_users)));
+        let storage = Arc::new(Mutex::new(InMemoryStorage::with_sample_capacity(nr_users)));
 
         let progress_bar = ProgressBar::new(nr_users.try_into().unwrap()).with_style(
             ProgressStyle::default_bar()
@@ -86,7 +86,7 @@ impl ConvertCmd {
                                 path.display()
                             )
                         })?;
-                    let new_samples = InMemorySamples::prepare_samples(new_samples)?;
+                    let new_samples = InMemoryStorage::prepare_samples(new_samples)?;
                     let mut storage = storage.lock().unwrap();
                     storage.add_prepared_samples(new_samples);
                     drop(storage);

--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -38,11 +38,10 @@ impl DataSource {
     ///
     /// # Errors
     ///
-    /// - If `evaluation_split` is less than 0, greater then 1.0 or not a normal float.
-    /// - If there are no training samples with the given `evaluation_split`, which is not exactly 1.0.
-    /// - If there are no evaluation samples with the given `evaluation_split`, which is not exactly 0.0.
-    ///   but the split is not `0`.
-    /// - If the `batch_size` is larger then the number of training samples.
+    /// - If `evaluation_split` is less than 0, greater then 1.0, NaN, Inf or subnormal.
+    /// - If there are no training samples with the given `evaluation_split` and the split is not exactly 1.0.
+    /// - If there are no evaluation samples with the given `evaluation_split` and the split is not exactly 0.0.
+    /// - If the `batch_size` is greater than the number of training samples.
     pub(crate) fn new(
         storage: Arc<InMemoryStorage>,
         evaluation_split: f32,
@@ -65,7 +64,7 @@ impl DataSource {
         })
     }
 
-    /// Create multiple `DataSources` from one storage instance..
+    /// Creates multiple `DataSources` from one storage instance.
     ///
     /// This will create multiple training only data sources based
     /// on chunking the training samples with the given `chunk_size`,
@@ -77,7 +76,7 @@ impl DataSource {
     /// Has the same errors as [`DataSource.new()`] as well as:
     ///
     /// - Failure if the `chunk_size` is `0`.
-    /// - Failure if the `batch_size` is greater then the `chunk_size`.
+    /// - Failure if the `batch_size` is greater than the `chunk_size`.
     #[allow(dead_code)]
     pub(crate) fn new_split(
         storage: Arc<InMemoryStorage>,
@@ -125,7 +124,7 @@ impl DataSource {
         })
     }
 
-    /// Calculates `(nr_training_samples, nr_evaluation_samples)` and checks for consistency/invariants.
+    /// Calculates `(nr_training_samples, nr_evaluation_samples)` and checks for invariants.
     fn calculate_evaluation_split(
         evaluation_split: f32,
         nr_all_samples: usize,
@@ -188,7 +187,7 @@ pub enum DataSourceError {
         batch_size: usize,
         /// Number of training samples.
         ///
-        /// In XaynNet emulation mode this is the number of samples per user.
+        /// In XayNet the emulation mode this is the number of samples per user.
         nr_training_samples: usize,
     },
     /// Empty database cannot be used for training.
@@ -341,7 +340,7 @@ pub enum StorageError {
     /// The database was parsed successfully but contains broken invariants at index {at_index}.
     BrokenInvariants { at_index: usize },
 
-    /// A out-of-bounds DataId (failed: {id} < {exclusive_id_upper_bound}) was used with the storage, this is most likely a bug.
+    /// An out-of-bounds DataId (failed: {id} < {exclusive_id_upper_bound}) was used in the storage, this is most likely a bug.
     OutOfBoundsId {
         id: DataId,
         exclusive_id_upper_bound: DataId,
@@ -382,7 +381,7 @@ impl InMemoryStorage {
         Ok(self_)
     }
 
-    /// Returns the number of samples in the storages.
+    /// Returns the number of samples in the storage.
     ///
     /// The samples can be referred to by usize ids from
     /// `0` to `number_of_samples`.
@@ -707,7 +706,7 @@ mod tests {
     fn mock_storage() -> Arc<InMemoryStorage> {
         let multiplier = ListNet::INPUT_NR_FEATURES + 1;
         let storage = InMemoryStorage {
-            // Invariant: len= (INPUT_NR_FEATURES+1)*nr_document
+            // Invariant: len = (INPUT_NR_FEATURES + 1) * nr_document
             data: vec![
                 vec![0.0; multiplier * 10],
                 vec![1.2; multiplier * 3],

--- a/dev-tool/src/list_net/train.rs
+++ b/dev-tool/src/list_net/train.rs
@@ -1,6 +1,5 @@
 #![cfg(not(tarpaulin))]
-
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Error};
 use structopt::StructOpt;
@@ -10,7 +9,7 @@ use crate::{exit_code::NO_ERROR, utils::progress_spin_until_done};
 
 use super::{
     cli_callbacks::CliTrainingControllerBuilder,
-    data_source::{DataSource, InMemorySamples},
+    data_source::{DataSource, InMemoryStorage},
 };
 
 /// Trains a ListNet.
@@ -83,9 +82,9 @@ impl TrainCmd {
         } = self;
 
         let data_source = progress_spin_until_done("Loading samples", || {
-            let storage = InMemorySamples::deserialize_from_file(samples)
+            let storage = InMemoryStorage::deserialize_from_file(samples)
                 .context("Loading training & evaluation samples failed.")?;
-            DataSource::new(storage, evaluation_split, batch_size)
+            DataSource::new(Arc::new(storage), evaluation_split, batch_size)
                 .context("Creating DataSource failed.")
         })?;
 

--- a/xayn-ai/src/ltr/list_net/mod.rs
+++ b/xayn-ai/src/ltr/list_net/mod.rs
@@ -598,7 +598,7 @@ where
             .map_err(TrainingError::Control)?;
 
         for _ in 0..epochs {
-            self.data_source.reset().map_err(TrainingError::Data)?;
+            self.data_source.reset();
 
             self.callbacks
                 .begin_of_epoch(self.data_source.number_of_training_batches())
@@ -745,7 +745,7 @@ pub trait DataSource: Send {
     /// before every epoch.
     ///
     /// This is called at the *beginning* of every epoch.
-    fn reset(&mut self) -> Result<(), Self::Error>;
+    fn reset(&mut self);
 
     /// Returns the expected number of training batches.
     fn number_of_training_batches(&self) -> usize;

--- a/xayn-ai/src/ltr/list_net/tests/training.rs
+++ b/xayn-ai/src/ltr/list_net/tests/training.rs
@@ -49,10 +49,9 @@ struct BatchSize0Error;
 impl DataSource for VecDataSource {
     type Error = BatchSize0Error;
 
-    fn reset(&mut self) -> Result<(), Self::Error> {
+    fn reset(&mut self) {
         self.training_data_idx = 0;
         self.evaluation_data_idx = 0;
-        Ok(())
     }
 
     fn number_of_training_batches(&self) -> usize {


### PR DESCRIPTION
The data source currently has one sample per user but we treat it as many samples for one user.

For XaynNet training emulation we need to pretend each user has multiple samples (in PR part-6 each
user has multiple samples but we still need to merge some them as users in the training database have 
too little history compared to real users).