### PR TITLE
TY 2034 Add parallel WASM initializer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spmc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2252,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-rayon"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df87c67450805c305d3ae44a3ac537b0253d029153c25afc3ecd2edc36ccafb1"
+dependencies = [
+ "js-sys",
+ "rayon",
+ "spmc",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,6 +2445,7 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+ "wasm-bindgen-rayon",
  "wasm-bindgen-test",
  "xayn-ai",
  "xayn-ai-ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "xayn-ai-ffi-c",
     "xayn-ai-ffi-wasm",
 ]
+resolver = "2"
 
 [workspace.metadata]
 # minimum supported rust version

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -100,20 +100,13 @@ env = { WASM_VERION="wasm_bindings", WASM_OUT_DIR_PATH="bindings/dart/example/as
 run_task = { name = [ "build-dart", "build-wasm", "generate_assets_metadata"] }
 
 [tasks.build-wasm]
-dependencies = ["build-wasm-parallel", "build-wasm-sequential"]
+env = { DISABLE_WASM_THREADS = { value = "0", condition = { env_not_set = ["DISABLE_WASM_THREADS"] } } }
+run_task = { name= ["build-wasm-parallel", "build-wasm-sequential"] }
+
 
 [tasks.build-wasm-parallel]
 env = { RUSTC_BOOTSTRAP=1 }
-condition_script = ["""
-  # We can't use env_false as it requires the variable to be set
-  # and trying to set a default value for it in `tasks.build-wasm`
-  # seems to not work well either.
-  if [ "${DISABLE_WASM_THREADS:-0}" = 0 ]; then
-    exit 0
-  else
-    exit 1
-  fi
-"""]
+condition = { env_false = ["DISABLE_WASM_THREADS"] }
 script = ["""
   if ! [ "$(wasm-opt --version | grep -oE "version [0-9]+" | grep -oE "[0-9]+" )" -ge 101 ]; then
       echo "Make sure wasm-opt is in the PATH and has version >= 101" >&2
@@ -126,7 +119,7 @@ script = ["""
       --no-typescript \
       --target web \
       --release \
-      --out-dir ../$WASM_OUT_DIR_PATH --out-name genesis \
+      --out-dir ../${WASM_OUT_DIR_PATH:?WASM_OUT_DIR_PATH needs to be set} --out-name genesis \
       -- \
       -Z build-std=panic_abort,std
   rm $WASM_OUT_DIR_PATH/.gitignore
@@ -138,7 +131,7 @@ script = ["""
   echo "build sequential wasm"
   wasm-pack build xayn-ai-ffi-wasm \
     --no-typescript \
-    --out-dir ../$WASM_OUT_DIR_PATH --out-name genesis \
+    --out-dir ../${WASM_OUT_DIR_PATH:?WASM_OUT_DIR_PATH needs to be set} --out-name genesis \
     --target web \
     --release
   # remove glob gitignore (https://rustwasm.github.io/docs/wasm-pack/commands/build.html#footnote-0)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,6 +7,9 @@ ANDROID_TARGETS = "arm64-v8a x86_64 x86"
 
 IOS_TARGETS = "aarch64-apple-ios x86_64-apple-ios"
 
+DART_WORKSPACE = "bindings/dart"
+DART_EXAMPLE_WORKSPACE = "bindings/dart/example"
+
 [config]
 skip_core_tasks = true
 # this avoids cargo make to run these tasks for each crate
@@ -51,7 +54,7 @@ dependencies = ["build-bindgen-dart", "build-codegen-dart"]
 workspace = false
 dependencies = ["build-local", "flutter-pub-get"]
 script = ["""
-  cd bindings/dart
+  cd "${DART_WORKSPACE}"
   flutter pub run ffigen --config ffigen_common.yaml
   flutter pub run ffigen --config ffigen_mobile.yaml
 
@@ -66,14 +69,14 @@ script = ["""
 workspace = false
 dependencies = ["flutter-pub-get"]
 script = ["""
-  cd bindings/dart
+  cd "${DART_WORKSPACE}"
   flutter pub run build_runner build
 """]
 
 [tasks.flutter-pub-get]
 workspace = false
 script = ["""
-  cd bindings/dart
+  cd "${DART_WORKSPACE}"
   flutter pub get
 """]
 
@@ -82,14 +85,62 @@ script = ["""
   ./generate_assets_metadata.sh assets_manifest.json $WASM_VERION $WASM_OUT_DIR_PATH
 """]
 
+[tasks.run-web]
+script = ["""
+    # We don't call build web as we want to be able to not re-build rust/wasm
+    # every time we change dart code, for the same reason we don't run
+    # `flutter pub get`.
+    echo WARNING: 'THIS DOES NOT CALL "build-web" or "flutter pub get"' >&2
+    ${DART_EXAMPLE_WORKSPACE}/flutter_run_web.sh
+"""]
+
 [tasks.build-web]
 # This will run build-local "unnecessarily". This will be fixed in a later PR.
 env = { WASM_VERION="wasm_bindings", WASM_OUT_DIR_PATH="bindings/dart/example/assets/wasm_bindings" }
 run_task = { name = [ "build-dart", "build-wasm", "generate_assets_metadata"] }
 
 [tasks.build-wasm]
+dependencies = ["build-wasm-parallel", "build-wasm-sequential"]
+
+[tasks.build-wasm-parallel]
+condition_script = ["""
+  # We can't use env_false as it requires the variable to be set
+  # and trying to set a default value for it in `tasks.build-wasm`
+  # seems to not work well either.
+  if [ "${DISABLE_WASM_THREADS:-0}" = 0 ]; then
+    exit 0
+  else
+    exit 1
+  fi
+"""]
 script = ["""
-  wasm-pack build xayn-ai-ffi-wasm --no-typescript --out-dir ../$WASM_OUT_DIR_PATH --out-name genesis --target web --release
+  if ! [ "$(wasm-opt --version | grep -oE "version [0-9]+" | grep -oE "[0-9]+" )" -ge 101 ]; then
+      echo "Make sure wasm-opt is in the PATH and has version >= 101" >&2
+      echo "Download Url: https://github.com/WebAssembly/binaryen/releases/tag/version_101" >&2
+      exit 1
+  fi
+  echo "build parallel wasm"
+  RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
+    rustup run nightly \
+    wasm-pack build xayn-ai-ffi-wasm \
+      --no-typescript \
+      --target web \
+      --release \
+      --out-dir ../$WASM_OUT_DIR_PATH --out-name genesis \
+      -- \
+      -Z build-std=panic_abort,std
+  rm $WASM_OUT_DIR_PATH/.gitignore
+"""]
+
+[tasks.build-wasm-sequential]
+condition = { env_true = ["DISABLE_WASM_THREADS"] }
+script = ["""
+  echo "build sequential wasm"
+  wasm-pack build xayn-ai-ffi-wasm \
+    --no-typescript \
+    --out-dir ../$WASM_OUT_DIR_PATH --out-name genesis \
+    --target web \
+    --release
   # remove glob gitignore (https://rustwasm.github.io/docs/wasm-pack/commands/build.html#footnote-0)
   rm $WASM_OUT_DIR_PATH/.gitignore
 """]
@@ -104,7 +155,7 @@ script = ["""
 
 [tasks.clean-bindgen]
 script = ["""
-  cd bindings/dart
+  cd "${DART_WORKSPACE}"
   rm -f ios/Classes/XaynAiFFiCommon.h
   rm -f ios/Classes/XaynAiFFiDart.h
   rm -f lib/src/common/ffi/genesis.dart
@@ -112,9 +163,17 @@ script = ["""
   rm -f example/assets/wasm_bindings/genesis_bg.wasm
   rm -f example/assets/wasm_bindings/genesis.js
   rm -f example/assets/wasm_bindings/package.json
+  rm -rf example/assets/wasm_bindings/snippets/
+"""]
+
+[tasks.clean-flutter-build]
+script = ["""
+    cd "${DART_WORKSPACE}"
+    rm -rf build
+    rm -rf example/build
 """]
 
 [tasks.clean-codegen]
 script = ["""
-  find ./bindings/dart -type f -regex '.*\\.g\\.dart' -exec rm {} \\;
+  find "${DART_WORKSPACE}" -type f -regex '.*\\.g\\.dart' -exec rm {} \\;
 """]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -103,6 +103,7 @@ run_task = { name = [ "build-dart", "build-wasm", "generate_assets_metadata"] }
 dependencies = ["build-wasm-parallel", "build-wasm-sequential"]
 
 [tasks.build-wasm-parallel]
+env = { RUSTC_BOOTSTRAP=1 }
 condition_script = ["""
   # We can't use env_false as it requires the variable to be set
   # and trying to set a default value for it in `tasks.build-wasm`
@@ -121,7 +122,6 @@ script = ["""
   fi
   echo "build parallel wasm"
   RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
-    rustup run nightly \
     wasm-pack build xayn-ai-ffi-wasm \
       --no-typescript \
       --target web \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ To build the library for web you can use:
 cargo make build-web
 ```
 
+or
+
+```
+DISABLE_WASM_THREADS=1 cargo make build-web
+```
+
+to build a version which doesn't require the browser to
+support `SharedArrayBuffer` and `Atomics`.
+
 ### Android
 
 To build for Android the following targets are needed:

--- a/bindings/dart/example/flutter_run_web.sh
+++ b/bindings/dart/example/flutter_run_web.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+set -eu
+
+# This provides a way to run flutter web which is compatible with using
+# threads in wasm. In difference to e.g. `flutter run -d Chrome` this doesn't
+# support live reloading and similar features. The reason for this is that
+# we need to run a custom server to set the required http headers.
+
+error() {
+    echo $1 >&2
+    exit 1
+}
+
+ROOT="$(dirname $0)"
+cd "$ROOT"
+BUILD_OUT="./build/web"
+SNIPPETS_DIR="$BUILD_OUT/assets/assets/wasm_bindings/snippets"
+CANVASKIT_OUT="$BUILD_OUT/canvaskit"
+
+# The default canvaskit is hosted on `https://unpkg.com/` but that CDN
+# doesn't yet set the Cross-Origin-Resource-Policy header. This makes it
+# unusable if our site uses `Cross-Origin-Embedder-Policy: require-corp`.
+# But we need to set that header to be able to use `SharedArrayBuffer`.
+#
+# Issue: https://github.com/mjackson/unpkg/issues/290
+flutter build web \
+    --dart-define=FLUTTER_WEB_CANVASKIT_URL=./canvaskit/
+
+# Fetch JS libs from CDN to avoid problems with COOP/COEP
+
+# Usage: download_unpkg <on-cdn-project> <version> <file-name> [(<output_dir>|"") [<on-cdn-in-dir>]]
+#
+# Downloads a file from the unpkg CDN.
+#
+# Output folders will be created like necessary.
+download_unpkg() {
+    if [ -z "$4" ]; then
+        OUT="$3"
+    else
+        OUT="$4/$3"
+    fi
+    mkdir -p "$(dirname "$OUT")"
+    curl "https://unpkg.com/$1@$2${5:-}/$3" > "$OUT"
+}
+
+# Downloads a file from the canvaskit project which was placed in the `bin/` directory.
+download_canvaskit_file() {
+    OUT="$CANVASKIT_OUT/$1"
+    download_unpkg canvaskit-wasm 0.28.1 $1 $CANVASKIT_OUT /bin
+}
+if [ ! -e "$CANVASKIT_OUT/canvaskit.js" ]; then
+    echo "Downloading canvaskit" >&2
+    mkdir -p "$CANVASKIT_OUT"
+    download_canvaskit_file "canvaskit.js"
+    download_canvaskit_file "canvaskit.wasm"
+    download_canvaskit_file "profiling/canvaskit.js"
+    download_canvaskit_file "profiling/canvaskit.wasm"
+fi
+
+# Fetch polyfill for firefox
+if [ ! -e "$BUILD_OUT/module-workers-polyfill.min.js" ]; then
+        echo "Downloading module-workers-polyfill" >&2
+        download_unpkg module-workers-polyfill 0.3.2 module-workers-polyfill.min.js "$BUILD_OUT"
+fi
+
+# Flutter does not recursively include assets even if we list an asset dir.
+# Neither does flutter support platform specific assets.
+#
+# Because of this we would need to add the following to the list of assets:
+# - assets/wasm_bindings/snippets/wasm-bindgen-rayon-7afa899f36665473/sc/workerHelpers.no-bundler.js
+#
+# But that is a problem as:
+# - This asset only exist for web builds.
+# - This path contains the crate hash, which changes with patch updates
+#
+# So we instead manually include all snippets it in the build output dir
+SNIPPET_SOURCE_DIR="./assets/wasm_bindings/snippets"
+if [ -d  "$SNIPPET_SOURCE_DIR" ]; then
+    mkdir -p "$SNIPPETS_DIR"
+    cp -R "$SNIPPET_SOURCE_DIR"/* "$SNIPPETS_DIR"
+fi
+
+echo "Running Sever"
+/usr/bin/env python3 "./server.py" "$BUILD_OUT"

--- a/bindings/dart/example/flutter_run_web.sh
+++ b/bindings/dart/example/flutter_run_web.sh
@@ -81,5 +81,5 @@ if [ -d  "$SNIPPET_SOURCE_DIR" ]; then
     cp -R "$SNIPPET_SOURCE_DIR"/* "$SNIPPETS_DIR"
 fi
 
-echo "Running Sever"
+echo "Running Server"
 /usr/bin/env python3 "./server.py" "$BUILD_OUT"

--- a/bindings/dart/example/server.py
+++ b/bindings/dart/example/server.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from http import server
+
+class MyHTTPRequestHandler(server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+
+        server.SimpleHTTPRequestHandler.end_headers(self)
+
+def main(data_dir):
+    import os
+    os.chdir(data_dir)
+    print("Now hosting web example at http://localhost:8000")
+    print("DO NOT USE AN IP ADDRESS TO OPEN THE WEB SITE, IT WILL NOT WORK")
+    httpd = server.HTTPServer(('localhost', 8000), MyHTTPRequestHandler)
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) == 2 and sys.argv[1] not in ["-h", "--help"]:
+        main(data_dir=sys.argv[1])
+    else:
+        print(f"Usage {sys.argv[0]} <data_dir>", file=sys.stderr)

--- a/bindings/dart/example/web/index.html
+++ b/bindings/dart/example/web/index.html
@@ -2,6 +2,7 @@
 <head>
   <title>xayn_search_web</title>
   <meta charset="utf-8">
+  <script async src="module-workers-polyfill.min.js"></script>
   <script defer src="main.dart.js"></script>
 </head>
 <html>

--- a/bindings/dart/lib/src/common/data/history.dart
+++ b/bindings/dart/lib/src/common/data/history.dart
@@ -1,6 +1,6 @@
-import 'package:meta/meta.dart' show immutable;
 import 'package:json_annotation/json_annotation.dart'
     show JsonSerializable, JsonValue;
+import 'package:meta/meta.dart' show immutable;
 import 'package:xayn_ai_ffi_dart/src/common/ffi/genesis.dart' as ffi
     show Relevance, UserFeedback, DayOfWeek, UserAction;
 

--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -75,3 +75,16 @@ class XaynAi {
   /// Frees the memory.
   void free() => throw UnsupportedError('Unsupported platform.');
 }
+
+/// Selects the number of threads used by the [`XaynAi`] thread pool.
+///
+/// On a single core system the thread pool consists of only one thread.
+/// On a multicore system the thread pool consists of
+/// (the number of logical cores - 1) threads.
+int selectThreadPoolSize(int numberOfProcessors) {
+  if (numberOfProcessors > 1) {
+    return numberOfProcessors - 1;
+  } else {
+    return numberOfProcessors;
+  }
+}

--- a/bindings/dart/lib/src/common/reranker/debug.dart
+++ b/bindings/dart/lib/src/common/reranker/debug.dart
@@ -2,10 +2,11 @@ import 'dart:convert' show base64Decode, base64Encode, jsonDecode, jsonEncode;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:json_annotation/json_annotation.dart'
-    show JsonSerializable, JsonKey;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
+    show JsonKey, JsonSerializable;
+
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
 
 part 'debug.g.dart';
 

--- a/bindings/dart/lib/src/mobile/reranker/ai.dart
+++ b/bindings/dart/lib/src/mobile/reranker/ai.dart
@@ -7,16 +7,14 @@ import 'package:ffi/ffi.dart' show malloc, StringUtf8Pointer;
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart'
-    show RerankMode, RerankModeToInt;
+    show RerankMode, RerankModeToInt, selectThreadPoolSize;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' as common
     show XaynAi;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
     show Analytics;
-import 'package:xayn_ai_ffi_dart/src/common/utils.dart' show assertNeq;
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
-import 'package:xayn_ai_ffi_dart/src/mobile/result/outcomes.dart'
-    show RerankingOutcomesBuilder;
+import 'package:xayn_ai_ffi_dart/src/common/utils.dart' show assertNeq;
 import 'package:xayn_ai_ffi_dart/src/mobile/data/document.dart' show Documents;
 import 'package:xayn_ai_ffi_dart/src/mobile/data/history.dart' show Histories;
 import 'package:xayn_ai_ffi_dart/src/mobile/ffi/genesis.dart' show CXaynAi;
@@ -28,6 +26,8 @@ import 'package:xayn_ai_ffi_dart/src/mobile/reranker/data_provider.dart'
     show SetupData;
 import 'package:xayn_ai_ffi_dart/src/mobile/result/error.dart' show XaynAiError;
 import 'package:xayn_ai_ffi_dart/src/mobile/result/fault.dart' show Faults;
+import 'package:xayn_ai_ffi_dart/src/mobile/result/outcomes.dart'
+    show RerankingOutcomesBuilder;
 
 /// The Xayn AI.
 class XaynAi implements common.XaynAi {
@@ -217,18 +217,5 @@ class XaynAi implements common.XaynAi {
       ffi.xaynai_drop(_ai);
       _ai = nullptr;
     }
-  }
-}
-
-/// Selects the number of threads used by the [`XaynAi`] thread pool.
-///
-/// On a single core system the thread pool consists of only one thread.
-/// On a multicore system the thread pool consists of
-/// (the number of logical cores - 1) threads.
-int selectThreadPoolSize(int numberOfProcessors) {
-  if (numberOfProcessors > 1) {
-    return numberOfProcessors - 1;
-  } else {
-    return numberOfProcessors;
   }
 }

--- a/bindings/dart/lib/src/mobile/result/outcomes.dart
+++ b/bindings/dart/lib/src/mobile/result/outcomes.dart
@@ -1,12 +1,12 @@
 import 'dart:ffi' show nullptr, Pointer, StructPointer;
 
-import 'package:xayn_ai_ffi_dart/src/mobile/result/slice.dart'
-    show BoxedSliceF32List, BoxedSliceU16List;
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
 import 'package:xayn_ai_ffi_dart/src/mobile/ffi/genesis.dart'
     show CRerankingOutcomes;
 import 'package:xayn_ai_ffi_dart/src/mobile/ffi/library.dart' show ffi;
+import 'package:xayn_ai_ffi_dart/src/mobile/result/slice.dart'
+    show BoxedSliceF32List, BoxedSliceU16List;
 
 class RerankingOutcomesBuilder {
   final Pointer<CRerankingOutcomes> _cOutcomes;

--- a/bindings/dart/lib/src/web/ffi/library.dart
+++ b/bindings/dart/lib/src/web/ffi/library.dart
@@ -1,8 +1,11 @@
 @JS()
 library library;
 
+import 'dart:html' show WorkerGlobalScope;
 import 'package:js/js.dart' show JS;
 import 'package:js/js_util.dart' show promiseToFuture;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart'
+    show selectThreadPoolSize;
 
 @JS('Promise')
 class _Promise<T> {}
@@ -16,9 +19,21 @@ external _Promise<Wasm> _init([
   dynamic module_or_path,
 ]);
 
+@JS('xayn_ai_ffi_wasm.initThreadPool')
+external _Promise<void> _initThreadPool(int numberOfThreads);
+
 /// Initializes the wasm module.
 ///
 /// If `moduleOrPath` is a `RequestInfo` or `URL`, makes a request and
 /// for everything else, calls `WebAssembly.instantiate` directly.
-Future<Wasm> init([dynamic moduleOrPath]) async =>
-    promiseToFuture(_init(moduleOrPath));
+Future<Wasm> init([dynamic moduleOrPath]) async {
+  final wasm = await promiseToFuture<Wasm>(_init(moduleOrPath));
+
+  // Most devices have 4+ hardware threads, but if the browser doesn't support
+  // the property it's probably old so we default to 2.
+  var hardwareThreads = selectThreadPoolSize(
+      WorkerGlobalScope.instance.navigator.hardwareConcurrency ?? 2);
+
+  await promiseToFuture<void>(_initThreadPool(hardwareThreads));
+  return wasm;
+}

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -7,12 +7,12 @@ import 'package:js/js.dart' show JS;
 
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
-    show Analytics;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart'
     show RerankMode, RerankModeToInt;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' as common
     show XaynAi;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
+    show Analytics;
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
 import 'package:xayn_ai_ffi_dart/src/web/data/document.dart'

--- a/bindings/dart/pubspec.yaml
+++ b/bindings/dart/pubspec.yaml
@@ -1,6 +1,5 @@
 name: 'xayn_ai_ffi_dart'
 version: '2.0.0'
-author: 'Xayn Engineering <engineering@xaynet.dev>'
 
 environment:
   sdk: '>=2.13.4 <3.0.0'

--- a/bindings/dart/test/mobile/reranker/ai_test.dart
+++ b/bindings/dart/test/mobile/reranker/ai_test.dart
@@ -3,8 +3,8 @@ import 'dart:typed_data' show Uint8List;
 import 'package:flutter_test/flutter_test.dart'
     show contains, equals, expect, group, isEmpty, isNot, test;
 
-import 'package:xayn_ai_ffi_dart/src/common/result/error.dart' show Code;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
+import 'package:xayn_ai_ffi_dart/src/common/result/error.dart' show Code;
 import 'package:xayn_ai_ffi_dart/src/mobile/reranker/ai.dart' show XaynAi;
 import '../utils.dart'
     show documents, histories, mkSetupData, throwsXaynAiException;

--- a/bindings/dart/test/mobile/result/outcomes_test.dart
+++ b/bindings/dart/test/mobile/result/outcomes_test.dart
@@ -25,10 +25,10 @@ import 'package:flutter_test/flutter_test.dart'
 
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
-import 'package:xayn_ai_ffi_dart/src/mobile/result/outcomes.dart'
-    show RerankingOutcomesBuilder;
 import 'package:xayn_ai_ffi_dart/src/mobile/ffi/genesis.dart'
     show CRerankingOutcomes;
+import 'package:xayn_ai_ffi_dart/src/mobile/result/outcomes.dart'
+    show RerankingOutcomesBuilder;
 
 class Delayed {
   final List<void Function()> _toClean;

--- a/xayn-ai-ffi-wasm/Cargo.toml
+++ b/xayn-ai-ffi-wasm/Cargo.toml
@@ -21,7 +21,7 @@ xayn-ai-ffi = { path = "../xayn-ai-ffi" }
 # setups represents fairly well.
 [target.'cfg(all(target_arch="wasm32", target_feature = "atomics"))'.dependencies]
 wasm-bindgen-rayon = {  version = "=1.0.3",  features = ["no-bundler"] }
-xayn-ai = { path = "../xayn-ai", features=["parallel"] }
+xayn-ai = { path = "../xayn-ai", features = ["parallel"] }
 
 [target.'cfg(not(all(target_arch="wasm32", target_feature = "atomics")))'.dependencies]
 xayn-ai = { path = "../xayn-ai" }

--- a/xayn-ai-ffi-wasm/Cargo.toml
+++ b/xayn-ai-ffi-wasm/Cargo.toml
@@ -12,8 +12,19 @@ getrandom = { version = "0.2.3", features = ["js"] }
 js-sys = "0.3.53"
 serde = { version = "1.0.130", features = ["derive"] }
 wasm-bindgen = { version = "=0.2.76", features = ["serde-serialize"] }
-xayn-ai = { path = "../xayn-ai" }
 xayn-ai-ffi = { path = "../xayn-ai-ffi" }
+
+# We use the "atomics" `target_feature` to enable parallelism instead of a
+# crate feature. This is necessary, as using a "normal" feature will break
+# "cargo clippy --all-targets --all-features" and similar. Furthermore we
+# always want to use parallelism if our target supports it, which this
+# setups represents fairly well.
+[target.'cfg(all(target_arch="wasm32", target_feature = "atomics"))'.dependencies]
+wasm-bindgen-rayon = {  version = "=1.0.3",  features = ["no-bundler"] }
+xayn-ai = { path = "../xayn-ai", features=["parallel"] }
+
+[target.'cfg(not(all(target_arch="wasm32", target_feature = "atomics")))'.dependencies]
+xayn-ai = { path = "../xayn-ai" }
 
 [dev-dependencies]
 itertools = "0.10.1"

--- a/xayn-ai-ffi-wasm/src/lib.rs
+++ b/xayn-ai-ffi-wasm/src/lib.rs
@@ -1,6 +1,12 @@
 //! WASM FFI for the Xayn AI.
 #![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
 
+#[cfg(not(all(target_arch = "wasm32", target_feature = "atomics")))]
+use ::{
+    js_sys::Promise,
+    wasm_bindgen::{prelude::wasm_bindgen, JsValue},
+};
+
 #[cfg(not(tarpaulin))]
 mod ai;
 #[cfg(not(tarpaulin))]
@@ -8,3 +14,14 @@ mod error;
 
 #[cfg(all(not(tarpaulin), doc))]
 pub use crate::ai::WXaynAi;
+
+/// Reexport to allow initialization of a WebWorker based on the rayon thread pool.
+#[cfg(all(target_arch = "wasm32", target_feature = "atomics"))]
+pub use wasm_bindgen_rayon::init_thread_pool;
+
+/// Stub which is used when the wasm blob was compiled without the `parallel` feature.
+#[cfg(not(all(target_arch = "wasm32", target_feature = "atomics")))]
+#[wasm_bindgen(js_name = initThreadPool)]
+pub fn init_thread_pool(_num_threads: usize) -> Promise {
+    Promise::resolve(&JsValue::UNDEFINED)
+}


### PR DESCRIPTION
Adds support for building parallelized WASM:

- [x] support both parallelized and non parallelized WASM
- [x] update Makefile.toml
- [x] make sure commands like `cargo check` or `cargo clippy` still run like before.
- [x] make sure the dart example works on chrome
- [x] make sure that besides the `Atomic.wait()` on main thread issue it seem to work on firefox
- [x] consider removing `xayn-ai-ffi-wasm/example/` there seem to be little value for this by now,
      it doesn't manual test the dart bindings (which is what matters) and it's a bunch of additional
      maintenance overhead.

- This does not update the CI, the CI will run like before, but this also mean it won't run or build the parallelized
WASM.

- This doesn't run wasm bindgen tests with parallelized wasm, it's not clear how to do so tbh.

- This doesn't include a bundler, at least for now we don't need it.

This should be merged after similar changes for the C-FFI had been made.