### PR TITLE
Fix bug in cargo make build-mobile.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,7 @@ jobs:
 
       - name: Build iOS library ${{ matrix.target }}
         working-directory: ./xayn-ai-ffi-c
-        run: cargo lipo --targets ${{ matrix.target }}
+        run: cargo lipo --targets ${{ matrix.target }} -p xayn-ai-ffi-c
 
       - name: Prepare lib for upload
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -314,7 +314,7 @@ jobs:
       - name: Build iOS library
         env:
           RUSTFLAGS: ${{ env.PRODUCTION_RUSTFLAGS }}
-        run: cargo lipo --targets ${{ matrix.target }} --release  -p xayn-ai-ffi-c
+        run: cargo lipo --targets ${{ matrix.target }} --release -p xayn-ai-ffi-c
 
       - name: Strip symbols
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -258,7 +258,7 @@ jobs:
             -t ${{ matrix.target }} \
             -p ${{ env.ANDROID_PLATFORM_VERSION }} \
             -o ${{ env.ANDROID_LIBS_DIR }} \
-            build --release --workspace --exclude xayn-ai-ffi-wasm
+            build --release -p xayn-ai-ffi-c
 
       - name: Upload artifact
         uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
@@ -314,7 +314,7 @@ jobs:
       - name: Build iOS library
         env:
           RUSTFLAGS: ${{ env.PRODUCTION_RUSTFLAGS }}
-        run: cargo lipo --targets ${{ matrix.target }} --release
+        run: cargo lipo --targets ${{ matrix.target }} --release  -p xayn-ai-ffi-c
 
       - name: Strip symbols
         run: |

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,13 +34,13 @@ dependencies = ["build-android", "build-ios", "generate_assets_metadata"]
 [tasks.build-android]
 dependencies = ["build-dart"]
 script = ["""
-  cargo ndk $(echo $ANDROID_TARGETS | sed 's/[^ ]* */-t &/g') -p $ANDROID_PLATFORM_VERSION -o $ANDROID_LIBS_DIR build --release
+  cargo ndk $(echo $ANDROID_TARGETS | sed 's/[^ ]* */-t &/g') -p $ANDROID_PLATFORM_VERSION -o $ANDROID_LIBS_DIR build --release -p xayn-ai-ffi-c
 """]
 
 [tasks.build-ios]
 dependencies = ["build-dart"]
 script = ["""
-  cargo lipo --targets $IOS_TARGETS --release
+  cargo lipo --targets $IOS_TARGETS --release -p xayn-ai-ffi-c
   cp target/universal/release/libxayn_ai_ffi_c.a bindings/dart/ios
 """]
 


### PR DESCRIPTION
Specifically both `build-ios` and `build-android` tried to potentially build _all_ workspaces. Including `xayn-ai-ffi-wasm` and
`dev-tool`. But `dev-tool` has neither lib nor main entry point on mobile and `cargo ndk` still tries to forceful build a
binary. This then fail making `cargo make build-android` fail.

The `cargo lipo` command used on `cargo make build-ios` has conceptually the same problem but only considers workspaces which create `staticlib`s, which means the bug should not have triggered.