### PR TITLE
TY-2042 add init thread pool function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
       - name: Test Android library ${{ matrix.target }}
         env:
           RUSTFLAGS: ${{ env.OPT_TESTS_RUSTFLAGS }}
-        run: cross test --target ${{ matrix.target }} --all-targets -- -Z unstable-options --report-time
+        run: cross test --target ${{ matrix.target }} --all-targets --no-default-features -- -Z unstable-options --report-time
 
   build-ios-libs:
     name: build-ios-libs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
  "cbindgen",
  "float-cmp 0.9.0",
  "itertools",
+ "rayon",
  "tempfile",
  "test-utils",
  "uuid",

--- a/bindings/dart/lib/src/common/result/error.dart
+++ b/bindings/dart/lib/src/common/result/error.dart
@@ -105,6 +105,9 @@ enum Code {
 
   /// Sync data bytes null pointer error.
   syncDataBytesPointer,
+
+  /// A global thread pool initialization error.
+  initGlobalThreadPool,
 }
 
 extension CodeToInt on Code {
@@ -179,6 +182,8 @@ extension CodeToInt on Code {
         return CCode.Synchronization;
       case Code.syncDataBytesPointer:
         return CCode.SyncDataBytesPointer;
+      case Code.initGlobalThreadPool:
+        return CCode.InitGlobalThreadPool;
       default:
         throw UnsupportedError('Undefined enum variant.');
     }
@@ -257,6 +262,8 @@ extension IntToCode on int {
         return Code.synchronization;
       case CCode.SyncDataBytesPointer:
         return Code.syncDataBytesPointer;
+      case CCode.InitGlobalThreadPool:
+        return Code.initGlobalThreadPool;
       default:
         throw UnsupportedError('Undefined enum variant.');
     }

--- a/bindings/dart/lib/src/mobile/reranker/ai.dart
+++ b/bindings/dart/lib/src/mobile/reranker/ai.dart
@@ -40,7 +40,8 @@ class XaynAi implements common.XaynAi {
   /// new one.
   static Future<XaynAi> create(SetupData data, [Uint8List? serialized]) async {
     final error = XaynAiError();
-    ffi.xaynai_init_thread_pool(Platform.numberOfProcessors, error.ptr);
+    ffi.xaynai_init_thread_pool(
+        selectThreadPoolSize(Platform.numberOfProcessors), error.ptr);
 
     try {
       if (error.isError()) {
@@ -216,5 +217,13 @@ class XaynAi implements common.XaynAi {
       ffi.xaynai_drop(_ai);
       _ai = nullptr;
     }
+  }
+}
+
+int selectThreadPoolSize(int numberOfHardwareThreads) {
+  if (numberOfHardwareThreads > 1) {
+    return numberOfHardwareThreads - 1;
+  } else {
+    return numberOfHardwareThreads;
   }
 }

--- a/bindings/dart/lib/src/mobile/reranker/ai.dart
+++ b/bindings/dart/lib/src/mobile/reranker/ai.dart
@@ -220,10 +220,15 @@ class XaynAi implements common.XaynAi {
   }
 }
 
-int selectThreadPoolSize(int numberOfHardwareThreads) {
-  if (numberOfHardwareThreads > 1) {
-    return numberOfHardwareThreads - 1;
+/// Selects the number of threads used by the [`XaynAi`] thread pool.
+///
+/// On a single core system the thread pool consists of only one thread.
+/// On a multicore system the thread pool consists of
+/// (the number of logical cores - 1) threads.
+int selectThreadPoolSize(int numberOfProcessors) {
+  if (numberOfProcessors > 1) {
+    return numberOfProcessors - 1;
   } else {
-    return numberOfHardwareThreads;
+    return numberOfProcessors;
   }
 }

--- a/bindings/dart/lib/src/mobile/reranker/ai.dart
+++ b/bindings/dart/lib/src/mobile/reranker/ai.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi' show nullptr, Pointer, Uint8;
+import 'dart:io' show Platform;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:ffi/ffi.dart' show malloc, StringUtf8Pointer;
@@ -38,8 +39,18 @@ class XaynAi implements common.XaynAi {
   /// Optionally accepts the serialized reranker database, otherwise creates a
   /// new one.
   static Future<XaynAi> create(SetupData data, [Uint8List? serialized]) async {
-    return XaynAi._(data.smbertVocab, data.smbertModel, data.qambertVocab,
-        data.qambertModel, data.ltrModel, serialized);
+    final error = XaynAiError();
+    ffi.xaynai_init_thread_pool(Platform.numberOfProcessors, error.ptr);
+
+    try {
+      if (error.isError()) {
+        throw error.toException();
+      }
+      return XaynAi._(data.smbertVocab, data.smbertModel, data.qambertVocab,
+          data.qambertModel, data.ltrModel, serialized);
+    } finally {
+      error.free();
+    }
   }
 
   /// Creates and initializes the Xayn AI.

--- a/xayn-ai-ffi-c/Cargo.toml
+++ b/xayn-ai-ffi-c/Cargo.toml
@@ -8,9 +8,11 @@ edition = "2018"
 
 [dependencies]
 uuid = "0.8.2"
-rayon = { version = "1.5.1", optional = true }
 xayn-ai = { path = "../xayn-ai" }
 xayn-ai-ffi = { path = "../xayn-ai-ffi" }
+
+# parallel feature
+rayon = { version = "1.5.1", optional = true }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/xayn-ai-ffi-c/Cargo.toml
+++ b/xayn-ai-ffi-c/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 uuid = "0.8.2"
-rayon = "1.5.1"
-xayn-ai = { path = "../xayn-ai", features = ["parallel"] }
-xayn-ai-ffi = { path = "../xayn-ai-ffi", features = ["parallel"] }
+rayon = { version = "1.5.1", optional = true }
+xayn-ai = { path = "../xayn-ai" }
+xayn-ai-ffi = { path = "../xayn-ai-ffi" }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
@@ -23,3 +23,7 @@ cbindgen = "=0.20.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
+
+[features]
+default = ["parallel"]
+parallel = ["rayon", "xayn-ai/parallel"]

--- a/xayn-ai-ffi-c/Cargo.toml
+++ b/xayn-ai-ffi-c/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2018"
 
 [dependencies]
 uuid = "0.8.2"
-xayn-ai = { path = "../xayn-ai" }
-xayn-ai-ffi = { path = "../xayn-ai-ffi" }
+rayon = "1.5.1"
+xayn-ai = { path = "../xayn-ai", features = ["parallel"] }
+xayn-ai-ffi = { path = "../xayn-ai-ffi", features = ["parallel"] }
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }

--- a/xayn-ai-ffi-c/src/reranker/ai.rs
+++ b/xayn-ai-ffi-c/src/reranker/ai.rs
@@ -1,8 +1,12 @@
-use std::{panic::AssertUnwindSafe, sync::Once};
+use std::panic::AssertUnwindSafe;
 
-use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
 use xayn_ai::{Builder, RerankMode, Reranker};
 use xayn_ai_ffi::{CCode, Error};
+
+#[cfg(feature = "parallel")]
+use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
+#[cfg(feature = "parallel")]
+use std::sync::Once;
 
 use crate::{
     data::{
@@ -195,6 +199,7 @@ impl CXaynAi {
 ///
 /// The behavior is undefined if:
 /// - A non-null `error` doesn't point to an aligned, contiguous area of memory with a [`CError`].
+#[cfg(feature = "parallel")]
 #[no_mangle]
 pub unsafe extern "C" fn xaynai_init_thread_pool(num_cpus: u64, error: Option<&mut CError>) {
     static mut INIT_ERROR: Result<(), ThreadPoolBuildError> = Ok(());
@@ -217,6 +222,7 @@ pub unsafe extern "C" fn xaynai_init_thread_pool(num_cpus: u64, error: Option<&m
 }
 
 /// See [`xaynai_init_thread_pool()`] for more.
+#[cfg(feature = "parallel")]
 fn init_thread_pool(num_cpus: usize) -> Result<(), ThreadPoolBuildError> {
     let num_threads = if num_cpus > 1 { num_cpus - 1 } else { num_cpus };
 

--- a/xayn-ai-ffi-c/src/reranker/ai.rs
+++ b/xayn-ai-ffi-c/src/reranker/ai.rs
@@ -177,7 +177,7 @@ impl CXaynAi {
 }
 
 /// Initializes the global thread pool. The thread pool is used by the AI to
-/// parallel some of its tasks.
+/// parallelize some of its tasks.
 ///
 /// The number of threads used by the pool depends on `num_cpus`:
 ///

--- a/xayn-ai-ffi-c/src/utils.rs
+++ b/xayn-ai-ffi-c/src/utils.rs
@@ -154,12 +154,4 @@ pub(crate) mod tests {
             Some(self)
         }
     }
-
-    #[test]
-    fn test_call_init_thread_pool_twice() {
-        let mut error = CError::default();
-        unsafe { xaynai_init_thread_pool(1, Some(&mut error)) };
-        unsafe { xaynai_init_thread_pool(1, Some(&mut error)) };
-        assert_eq!(error.code, CCode::None)
-    }
 }

--- a/xayn-ai-ffi-c/src/utils.rs
+++ b/xayn-ai-ffi-c/src/utils.rs
@@ -74,7 +74,7 @@ unsafe impl IntoRaw for () {
 /// # Safety
 ///
 /// It is safe to call this function multiple times but it must be invoked
-/// before calling anything else of this library.
+/// before calling any of the `xaynai_*` functions.
 ///
 /// The behavior is undefined if:
 /// - A non-null `error` doesn't point to an aligned, contiguous area of memory with a [`CError`].

--- a/xayn-ai-ffi-c/src/utils.rs
+++ b/xayn-ai-ffi-c/src/utils.rs
@@ -1,11 +1,9 @@
 //! Utilities.
 
-use std::{ffi::CStr, fmt::Display, sync::Once};
+use std::{ffi::CStr, fmt::Display};
 
-use rayon::{ThreadPoolBuildError, ThreadPoolBuilder};
 use xayn_ai_ffi::{CCode, Error};
 
-use crate::result::{call_with_result, error::CError};
 #[cfg(doc)]
 pub use crate::slice::CBoxedSlice;
 
@@ -57,55 +55,6 @@ unsafe impl IntoRaw for () {
 
     #[inline]
     fn into_raw(self) -> Self::Value {}
-}
-
-/// Initializes the global thread pool. The thread pool is used by the AI to
-/// parallel some of its tasks.
-///
-/// The number of threads used by the pool depends on `num_cpus`:
-///
-/// On a single core system the thread pool consists of only one thread.
-/// On a multicore system the thread pool consists of (the number of logical cores - 1) threads.
-///
-/// # Error
-/// - If the initialization of the thread pool has failed.
-/// - An unexpected panic happened during the initialization of the thread pool.
-///
-/// # Safety
-///
-/// It is safe to call this function multiple times but it must be invoked
-/// before calling any of the `xaynai_*` functions.
-///
-/// The behavior is undefined if:
-/// - A non-null `error` doesn't point to an aligned, contiguous area of memory with a [`CError`].
-#[no_mangle]
-pub unsafe extern "C" fn xaynai_init_thread_pool(num_cpus: u64, error: Option<&mut CError>) {
-    static mut INIT_ERROR: Result<(), ThreadPoolBuildError> = Ok(());
-    static INIT: Once = Once::new();
-
-    let init_pool = || unsafe {
-        INIT.call_once(|| {
-            INIT_ERROR = init_thread_pool(num_cpus as usize);
-        });
-
-        if let Err(cause) = INIT_ERROR.as_ref() {
-            Err(CCode::InitGlobalThreadPool
-                .with_context(format!("Failed to initialize thread pool: {}", cause)))
-        } else {
-            Ok(())
-        }
-    };
-
-    call_with_result(init_pool, error)
-}
-
-/// See [`xaynai_init_thread_pool()`] for more.
-fn init_thread_pool(num_cpus: usize) -> Result<(), ThreadPoolBuildError> {
-    let num_threads = if num_cpus > 1 { num_cpus - 1 } else { num_cpus };
-
-    ThreadPoolBuilder::new()
-        .num_threads(num_threads)
-        .build_global()
 }
 
 #[cfg(test)]

--- a/xayn-ai-ffi/Cargo.toml
+++ b/xayn-ai-ffi/Cargo.toml
@@ -14,6 +14,3 @@ xayn-ai = { path = "../xayn-ai" }
 
 [build-dependencies]
 cbindgen = "=0.20.0"
-
-[features]
-parallel = ["xayn-ai/parallel"]

--- a/xayn-ai-ffi/src/error.rs
+++ b/xayn-ai-ffi/src/error.rs
@@ -82,6 +82,8 @@ pub enum CCode {
     Synchronization,
     /// Sync data bytes null pointer error.
     SyncDataBytesPointer,
+    /// A global thread pool initialization error.
+    InitGlobalThreadPool,
 }
 
 impl CCode {


### PR DESCRIPTION
**Ticket:**

- [TY-2024]

**Summary:**

- added the initialization of thread pool in the mobile target
- Android tests compiled with the default feature `parallel` are failing when running them via `cross`. However, they are not failing on the emulator/real device. We agreed to run the Android test without the feature `parallel` and tackle this issue in a later pr.

Checks:

- [x] we can spawn the global rayon thread pool in dart isolate iOS/Android
- [x] the global thread pool still usable after a panic in the bert model loops
- [x] we can run two AIs in parallel on the global thread pool 
- [x] a panic during the `init_once` invokation is caught 


[TY-2024]: https://xainag.atlassian.net/browse/TY-2024