### PR TITLE
TY 2023 Don't push tags to release repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -675,6 +675,4 @@ jobs:
             https://github.com/xaynetwork/xayn_ai/commit/$SRC_COMMIT
             https://github.com/xaynetwork/xayn_ai/tree/$BRANCH"
             git push -u origin HEAD:$BRANCH
-            git fetch --tags git@github.com:xaynetwork/xayn_ai.git
-            git push --tags
           fi


### PR DESCRIPTION
Pushing a tag to the release repository will create a tag that points to a commit hash in the original repository and not the release repository.