### PR TITLE
TY-2069 Update assets script

### DIFF
--- a/.ci/build-asset-artifacts/action.yml
+++ b/.ci/build-asset-artifacts/action.yml
@@ -4,11 +4,14 @@ inputs:
   dart-ws:
     description: 'The Dart workspace'
     required: true
-  wasm-version:
-    description: 'The version of the WASM artifacts.'
-    required: false
   wasm-out-dir-path:
     description: 'The relative path (wrt the repository root) of the WASM artifacts.'
+    required: false
+  wasm-sequential-version:
+    description: 'The version of the `sequential` WASM artifacts.'
+    required: false
+  wasm-parallel-version:
+    description: 'The version of the `parallel` WASM artifacts.'
     required: false
 outputs:
   dart-metadata:
@@ -37,7 +40,7 @@ runs:
           brew install coreutils
         fi
 
-        bash generate_assets_metadata.sh assets_manifest.json ${{ inputs.wasm-version }} ${{ inputs.wasm-out-dir-path }}/${{ inputs.wasm-version }}
+        bash generate_assets_metadata.sh assets_manifest.json ${{ inputs.wasm-out-dir-path }} ${{ inputs.wasm-sequential-version }} ${{ inputs.wasm-parallel-version }}
 
         echo "::group::Dart metadata"
         cat ${{ steps.artifact-paths.outputs.dart-metadata }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -502,7 +502,7 @@ jobs:
           secret-key: ${{ secrets.AI_ASSETS_STG_BUCKET_SECRET_KEY }}
 
       - name: Install s3cmd (production)
-        if: github.ref = 'refs/heads/release'
+        if: github.ref == 'refs/heads/release'
         uses: ./.ci/install-s3cmd
         with:
           access-key: ${{ secrets.AI_ASSETS_PROD_BUCKET_ACCESS_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -447,8 +447,9 @@ jobs:
         uses: ./.ci/build-asset-artifacts
         with:
           dart-ws: ${{ env.DART_WORKSPACE }}
-          wasm-version: ${{ needs.build-release-wasm-libs.outputs.sequential-version }}
           wasm-out-dir-path: ${{ needs.build-release-wasm-libs.outputs.out-dir }}
+          wasm-sequential-version: ${{ needs.build-release-wasm-libs.outputs.sequential-version }}
+          wasm-parallel-version: ${{ needs.build-release-wasm-libs.outputs.parallel-version }}
 
       - name: Generate asset artifacts name
         id: asset-artifacts

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -119,10 +119,11 @@ script = ["""
       --no-typescript \
       --target web \
       --release \
-      --out-dir ../${WASM_OUT_DIR_PATH:?WASM_OUT_DIR_PATH needs to be set} --out-name genesis \
+      --out-dir ../${WASM_OUT_DIR_PATH/$WASM_VERION:?WASM_OUT_DIR_PATH needs to be set} \
+      --out-name genesis \
       -- \
       -Z build-std=panic_abort,std
-  rm $WASM_OUT_DIR_PATH/.gitignore
+  rm $WASM_OUT_DIR_PATH/$WASM_VERION/.gitignore
 """]
 
 [tasks.build-wasm-sequential]
@@ -131,11 +132,12 @@ script = ["""
   echo "build sequential wasm"
   wasm-pack build xayn-ai-ffi-wasm \
     --no-typescript \
-    --out-dir ../${WASM_OUT_DIR_PATH:?WASM_OUT_DIR_PATH needs to be set} --out-name genesis \
+    --out-dir ../${WASM_OUT_DIR_PATH/$WASM_VERION:?WASM_OUT_DIR_PATH needs to be set} \
+    --out-name genesis \
     --target web \
     --release
   # remove glob gitignore (https://rustwasm.github.io/docs/wasm-pack/commands/build.html#footnote-0)
-  rm $WASM_OUT_DIR_PATH/.gitignore
+  rm $WASM_OUT_DIR_PATH/$WASM_VERION/.gitignore
 """]
 
 [tasks.test-wasm]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -82,36 +82,42 @@ script = ["""
 
 [tasks.generate_assets_metadata]
 script = ["""
-  ./generate_assets_metadata.sh assets_manifest.json $WASM_OUT_DIR_PATH $WASM_VERION
+  if [ "$DISABLE_WASM_THREADS" = "1" ]
+  then
+    ./generate_assets_metadata.sh assets_manifest.json $WASM_OUT_DIR_PATH $WASM_VERSION ""
+  elif [ "$DISABLE_WASM_THREADS" = "0" ]
+  then
+    ./generate_assets_metadata.sh assets_manifest.json $WASM_OUT_DIR_PATH "" $WASM_VERSION
+  else
+    ./generate_assets_metadata.sh assets_manifest.json "" "" ""
+  fi
 """]
 
 [tasks.run-web]
 script = ["""
-    # We don't call build web as we want to be able to not re-build rust/wasm
-    # every time we change dart code, for the same reason we don't run
-    # `flutter pub get`.
-    echo WARNING: 'THIS DOES NOT CALL "build-web" or "flutter pub get"' >&2
-    ${DART_EXAMPLE_WORKSPACE}/flutter_run_web.sh
+  # We don't call build web as we want to be able to not re-build rust/wasm
+  # every time we change dart code, for the same reason we don't run
+  # `flutter pub get`.
+  echo WARNING: 'THIS DOES NOT CALL "build-web" or "flutter pub get"' >&2
+  ${DART_EXAMPLE_WORKSPACE}/flutter_run_web.sh
 """]
 
 [tasks.build-web]
 # This will run build-local "unnecessarily". This will be fixed in a later PR.
-env = { WASM_VERION="wasm_bindings", WASM_OUT_DIR_PATH="bindings/dart/example/assets" }
-run_task = { name = [ "build-dart", "build-wasm", "generate_assets_metadata"] }
+env = { WASM_VERSION = "wasm_bindings", WASM_OUT_DIR_PATH = "bindings/dart/example/assets", DISABLE_WASM_THREADS = { value = "0", condition = { env_not_set = ["DISABLE_WASM_THREADS"] } } }
+run_task = { name = ["build-dart", "build-wasm", "generate_assets_metadata"] }
 
 [tasks.build-wasm]
-env = { DISABLE_WASM_THREADS = { value = "0", condition = { env_not_set = ["DISABLE_WASM_THREADS"] } } }
 run_task = { name= ["build-wasm-parallel", "build-wasm-sequential"] }
-
 
 [tasks.build-wasm-parallel]
 env = { RUSTC_BOOTSTRAP=1 }
 condition = { env_false = ["DISABLE_WASM_THREADS"] }
 script = ["""
   if ! [ "$(wasm-opt --version | grep -oE "version [0-9]+" | grep -oE "[0-9]+" )" -ge 101 ]; then
-      echo "Make sure wasm-opt is in the PATH and has version >= 101" >&2
-      echo "Download Url: https://github.com/WebAssembly/binaryen/releases/tag/version_101" >&2
-      exit 1
+    echo "Make sure wasm-opt is in the PATH and has version >= 101" >&2
+    echo "Download Url: https://github.com/WebAssembly/binaryen/releases/tag/version_101" >&2
+    exit 1
   fi
   echo "build parallel wasm"
   RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
@@ -119,11 +125,12 @@ script = ["""
       --no-typescript \
       --target web \
       --release \
-      --out-dir ../${WASM_OUT_DIR_PATH/$WASM_VERION:?WASM_OUT_DIR_PATH needs to be set} \
+      --out-dir ../${WASM_OUT_DIR_PATH:?WASM_OUT_DIR_PATH needs to be set}/$WASM_VERSION \
       --out-name genesis \
       -- \
       -Z build-std=panic_abort,std
-  rm $WASM_OUT_DIR_PATH/$WASM_VERION/.gitignore
+  # remove glob gitignore (https://rustwasm.github.io/docs/wasm-pack/commands/build.html#footnote-0)
+  rm $WASM_OUT_DIR_PATH/$WASM_VERSION/.gitignore
 """]
 
 [tasks.build-wasm-sequential]
@@ -132,12 +139,12 @@ script = ["""
   echo "build sequential wasm"
   wasm-pack build xayn-ai-ffi-wasm \
     --no-typescript \
-    --out-dir ../${WASM_OUT_DIR_PATH/$WASM_VERION:?WASM_OUT_DIR_PATH needs to be set} \
+    --out-dir ../${WASM_OUT_DIR_PATH:?WASM_OUT_DIR_PATH needs to be set}/$WASM_VERSION \
     --out-name genesis \
     --target web \
     --release
   # remove glob gitignore (https://rustwasm.github.io/docs/wasm-pack/commands/build.html#footnote-0)
-  rm $WASM_OUT_DIR_PATH/$WASM_VERION/.gitignore
+  rm $WASM_OUT_DIR_PATH/$WASM_VERSION/.gitignore
 """]
 
 [tasks.test-wasm]
@@ -163,12 +170,14 @@ script = ["""
 
 [tasks.clean-flutter-build]
 script = ["""
-    cd "${DART_WORKSPACE}"
-    rm -rf build
-    rm -rf example/build
+  cd "${DART_WORKSPACE}"
+  rm -rf build
+  rm -rf example/build
 """]
 
 [tasks.clean-codegen]
 script = ["""
   find "${DART_WORKSPACE}" -type f -regex '.*\\.g\\.dart' -exec rm {} \\;
+  rm -f "${DART_WORKSPACE}"/lib/src/common/reranker/assets.dart
+  rm -f out/assets_metadata.json
 """]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -108,7 +108,7 @@ env = { WASM_VERSION = "wasm_bindings", WASM_OUT_DIR_PATH = "bindings/dart/examp
 run_task = { name = ["build-dart", "build-wasm", "generate_assets_metadata"] }
 
 [tasks.build-wasm]
-run_task = { name= ["build-wasm-parallel", "build-wasm-sequential"] }
+dependencies = ["build-wasm-parallel", "build-wasm-sequential"]
 
 [tasks.build-wasm-parallel]
 env = { RUSTC_BOOTSTRAP=1 }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -82,7 +82,7 @@ script = ["""
 
 [tasks.generate_assets_metadata]
 script = ["""
-  ./generate_assets_metadata.sh assets_manifest.json $WASM_VERION $WASM_OUT_DIR_PATH
+  ./generate_assets_metadata.sh assets_manifest.json $WASM_OUT_DIR_PATH $WASM_VERION
 """]
 
 [tasks.run-web]
@@ -96,7 +96,7 @@ script = ["""
 
 [tasks.build-web]
 # This will run build-local "unnecessarily". This will be fixed in a later PR.
-env = { WASM_VERION="wasm_bindings", WASM_OUT_DIR_PATH="bindings/dart/example/assets/wasm_bindings" }
+env = { WASM_VERION="wasm_bindings", WASM_OUT_DIR_PATH="bindings/dart/example/assets" }
 run_task = { name = [ "build-dart", "build-wasm", "generate_assets_metadata"] }
 
 [tasks.build-wasm]

--- a/assets_manifest.json
+++ b/assets_manifest.json
@@ -22,15 +22,5 @@
       "dart_enum_name": "ltrModel",
       "url_suffix": "ltr_v0000/ltr.binparams"
     }
-  ],
-  "wasm_assets" : [
-    {
-      "dart_enum_name": "wasmModule",
-      "filename": "genesis_bg.wasm"
-    },
-    {
-      "dart_enum_name": "wasmScript",
-      "filename": "genesis.js"
-    }
   ]
 }

--- a/bindings/dart/example/lib/data_provider/data_provider.dart
+++ b/bindings/dart/example/lib/data_provider/data_provider.dart
@@ -1,7 +1,7 @@
-import 'package:xayn_ai_ffi_dart/package.dart' show SetupData;
+import 'package:xayn_ai_ffi_dart/package.dart' show FeatureHint, SetupData;
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData() async =>
+Future<SetupData> getInputData([FeatureHint? hint]) async =>
     throw UnsupportedError('Unsupported platform.');
 
 String joinPaths(List<String> paths) {

--- a/bindings/dart/example/lib/data_provider/data_provider.dart
+++ b/bindings/dart/example/lib/data_provider/data_provider.dart
@@ -1,7 +1,7 @@
 import 'package:xayn_ai_ffi_dart/package.dart' show FeatureHint, SetupData;
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData([FeatureHint? hint]) async =>
+Future<SetupData> getInputData(FeatureHint hint) async =>
     throw UnsupportedError('Unsupported platform.');
 
 String joinPaths(List<String> paths) {

--- a/bindings/dart/example/lib/data_provider/data_provider.dart
+++ b/bindings/dart/example/lib/data_provider/data_provider.dart
@@ -1,7 +1,7 @@
-import 'package:xayn_ai_ffi_dart/package.dart' show SetupData;
+import 'package:xayn_ai_ffi_dart/package.dart' show Feature, SetupData;
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData({List<String> features = const []}) async =>
+Future<SetupData> getInputData({Set<Feature> features = const {}}) async =>
     throw UnsupportedError('Unsupported platform.');
 
 String joinPaths(List<String> paths) {

--- a/bindings/dart/example/lib/data_provider/data_provider.dart
+++ b/bindings/dart/example/lib/data_provider/data_provider.dart
@@ -1,7 +1,7 @@
-import 'package:xayn_ai_ffi_dart/package.dart' show FeatureHint, SetupData;
+import 'package:xayn_ai_ffi_dart/package.dart' show SetupData;
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData(FeatureHint hint) async =>
+Future<SetupData> getInputData({List<String> features = const []}) async =>
     throw UnsupportedError('Unsupported platform.');
 
 String joinPaths(List<String> paths) {

--- a/bindings/dart/example/lib/data_provider/mobile.dart
+++ b/bindings/dart/example/lib/data_provider/mobile.dart
@@ -16,7 +16,7 @@ const _baseAssetsPath = 'assets';
 ///
 /// This function needs to be called in the main thread because it will not be allowed
 /// to access the assets from an isolate.
-Future<SetupData> getInputData([FeatureHint? hint]) async {
+Future<SetupData> getInputData(FeatureHint hint) async {
   final baseDiskPath = await getApplicationDocumentsDirectory();
 
   final paths = <AssetType, String>{};
@@ -26,7 +26,7 @@ Future<SetupData> getInputData([FeatureHint? hint]) async {
     paths.putIfAbsent(asset.key, () => path);
   }
 
-  return SetupData(paths);
+  return SetupData(paths, hint);
 }
 
 /// Returns the path to the data, if the data is not on disk yet

--- a/bindings/dart/example/lib/data_provider/mobile.dart
+++ b/bindings/dart/example/lib/data_provider/mobile.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:path_provider/path_provider.dart'
     show getApplicationDocumentsDirectory;
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show AssetType, getAssets, SetupData;
+    show AssetType, FeatureHint, getAssets, SetupData;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     show joinPaths;
@@ -16,11 +16,11 @@ const _baseAssetsPath = 'assets';
 ///
 /// This function needs to be called in the main thread because it will not be allowed
 /// to access the assets from an isolate.
-Future<SetupData> getInputData() async {
+Future<SetupData> getInputData([FeatureHint? hint]) async {
   final baseDiskPath = await getApplicationDocumentsDirectory();
 
   final paths = <AssetType, String>{};
-  for (var asset in getAssets().entries) {
+  for (var asset in getAssets(hint).entries) {
     final path = await _getData(baseDiskPath.path, asset.value.urlSuffix,
         asset.value.checksum.checksumAsHex);
     paths.putIfAbsent(asset.key, () => path);

--- a/bindings/dart/example/lib/data_provider/mobile.dart
+++ b/bindings/dart/example/lib/data_provider/mobile.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:path_provider/path_provider.dart'
     show getApplicationDocumentsDirectory;
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show AssetType, getAssets, SetupData;
+    show AssetType, getAssets, Feature, SetupData;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     show joinPaths;
@@ -16,7 +16,7 @@ const _baseAssetsPath = 'assets';
 ///
 /// This function needs to be called in the main thread because it will not be allowed
 /// to access the assets from an isolate.
-Future<SetupData> getInputData({List<String> features = const []}) async {
+Future<SetupData> getInputData({Set<Feature> features = const {}}) async {
   final baseDiskPath = await getApplicationDocumentsDirectory();
 
   final paths = <AssetType, String>{};

--- a/bindings/dart/example/lib/data_provider/mobile.dart
+++ b/bindings/dart/example/lib/data_provider/mobile.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:path_provider/path_provider.dart'
     show getApplicationDocumentsDirectory;
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show AssetType, FeatureHint, getAssets, SetupData;
+    show AssetType, getAssets, SetupData;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     show joinPaths;
@@ -16,17 +16,17 @@ const _baseAssetsPath = 'assets';
 ///
 /// This function needs to be called in the main thread because it will not be allowed
 /// to access the assets from an isolate.
-Future<SetupData> getInputData(FeatureHint hint) async {
+Future<SetupData> getInputData({List<String> features = const []}) async {
   final baseDiskPath = await getApplicationDocumentsDirectory();
 
   final paths = <AssetType, String>{};
-  for (var asset in getAssets(hint).entries) {
+  for (var asset in getAssets(features: features).entries) {
     final path = await _getData(baseDiskPath.path, asset.value.urlSuffix,
         asset.value.checksum.checksumAsHex);
     paths.putIfAbsent(asset.key, () => path);
   }
 
-  return SetupData(paths, hint);
+  return SetupData(paths, features: features);
 }
 
 /// Returns the path to the data, if the data is not on disk yet

--- a/bindings/dart/example/lib/data_provider/web.dart
+++ b/bindings/dart/example/lib/data_provider/web.dart
@@ -10,7 +10,7 @@ import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
 const _baseAssetUrl = 'assets/assets';
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData([FeatureHint? hint]) async {
+Future<SetupData> getInputData(FeatureHint hint) async {
   final fetched = <AssetType, Uint8List>{};
 
   for (var asset in getAssets(hint).entries) {
@@ -19,7 +19,7 @@ Future<SetupData> getInputData([FeatureHint? hint]) async {
     fetched.putIfAbsent(asset.key, () => data);
   }
 
-  return SetupData(fetched);
+  return SetupData(fetched, hint);
 }
 
 Future<Uint8List> _fetchAsset(String url, String checksum) async {

--- a/bindings/dart/example/lib/data_provider/web.dart
+++ b/bindings/dart/example/lib/data_provider/web.dart
@@ -2,7 +2,7 @@ import 'dart:html' show window;
 import 'dart:typed_data' show Uint8List, ByteBuffer;
 
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show AssetType, getAssets, SetupData;
+    show AssetType, FeatureHint, getAssets, SetupData;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     show joinPaths;
@@ -10,10 +10,10 @@ import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
 const _baseAssetUrl = 'assets/assets';
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData() async {
+Future<SetupData> getInputData([FeatureHint? hint]) async {
   final fetched = <AssetType, Uint8List>{};
 
-  for (var asset in getAssets().entries) {
+  for (var asset in getAssets(hint).entries) {
     final path = joinPaths([_baseAssetUrl, asset.value.urlSuffix]);
     final data = await _fetchAsset(path, asset.value.checksum.checksumSri);
     fetched.putIfAbsent(asset.key, () => data);

--- a/bindings/dart/example/lib/data_provider/web.dart
+++ b/bindings/dart/example/lib/data_provider/web.dart
@@ -2,7 +2,7 @@ import 'dart:html' show window;
 import 'dart:typed_data' show Uint8List, ByteBuffer;
 
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show AssetType, getAssets, SetupData;
+    show AssetType, getAssets, Feature, SetupData;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     show joinPaths;
@@ -10,7 +10,7 @@ import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
 const _baseAssetUrl = 'assets/assets';
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData({List<String> features = const []}) async {
+Future<SetupData> getInputData({Set<Feature> features = const {}}) async {
   final fetched = <AssetType, Uint8List>{};
 
   for (var asset in getAssets(features: features).entries) {

--- a/bindings/dart/example/lib/data_provider/web.dart
+++ b/bindings/dart/example/lib/data_provider/web.dart
@@ -2,7 +2,7 @@ import 'dart:html' show window;
 import 'dart:typed_data' show Uint8List, ByteBuffer;
 
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show AssetType, FeatureHint, getAssets, SetupData;
+    show AssetType, getAssets, SetupData;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     show joinPaths;
@@ -10,16 +10,16 @@ import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
 const _baseAssetUrl = 'assets/assets';
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
-Future<SetupData> getInputData(FeatureHint hint) async {
+Future<SetupData> getInputData({List<String> features = const []}) async {
   final fetched = <AssetType, Uint8List>{};
 
-  for (var asset in getAssets(hint).entries) {
+  for (var asset in getAssets(features: features).entries) {
     final path = joinPaths([_baseAssetUrl, asset.value.urlSuffix]);
     final data = await _fetchAsset(path, asset.value.checksum.checksumSri);
     fetched.putIfAbsent(asset.key, () => data);
   }
 
-  return SetupData(fetched, hint);
+  return SetupData(fetched, features: features);
 }
 
 Future<Uint8List> _fetchAsset(String url, String checksum) async {

--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -53,7 +53,7 @@ class Logic {
   /// This normally should be called with the `rootBundle`,
   /// as it expects an `AssetManifest.json` asset.
   ///
-  static Future<Logic> load(AssetBundle bundle, [FeatureHint? hint]) async {
+  static Future<Logic> load(AssetBundle bundle, FeatureHint hint) async {
     final manifest = jsonDecode(await bundle.loadString('AssetManifest.json'))
         as Map<String, dynamic>;
 

--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -4,13 +4,7 @@ import 'package:flutter/material.dart' show debugPrint;
 import 'package:flutter/services.dart' show AssetBundle;
 import 'package:stats/stats.dart' show Stats;
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show
-        Document,
-        FeatureHint,
-        RerankDebugCallData,
-        RerankingOutcomes,
-        SetupData,
-        XaynAi;
+    show Document, RerankDebugCallData, RerankingOutcomes, SetupData, XaynAi;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     if (dart.library.io) 'data_provider/mobile.dart'
@@ -53,7 +47,10 @@ class Logic {
   /// This normally should be called with the `rootBundle`,
   /// as it expects an `AssetManifest.json` asset.
   ///
-  static Future<Logic> load(AssetBundle bundle, FeatureHint hint) async {
+  /// Optionally accepts a list of the following features:
+  /// - 'webParallel': enables multi-threading for the web targets
+  static Future<Logic> load(AssetBundle bundle,
+      {List<String> features = const []}) async {
     final manifest = jsonDecode(await bundle.loadString('AssetManifest.json'))
         as Map<String, dynamic>;
 
@@ -72,7 +69,7 @@ class Logic {
       currentCallDataKey = availableCallData.keys.first;
     }
 
-    final setupData = await getInputData(hint);
+    final setupData = await getInputData(features: features);
 
     final currentAi = await XaynAi.create(
         setupData, availableCallData[currentCallDataKey]?.serializedState);

--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -53,8 +53,8 @@ class Logic {
   /// This normally should be called with the `rootBundle`,
   /// as it expects an `AssetManifest.json` asset.
   ///
-  /// Optionally accepts a list of the following features:
-  /// - 'webParallel': enables multi-threading for the web targets
+  /// Optionally accepts a set of the following features:
+  /// - `webParallel`: enables multi-threading for the web targets
   static Future<Logic> load(AssetBundle bundle,
       {Set<Feature> features = const {}}) async {
     final manifest = jsonDecode(await bundle.loadString('AssetManifest.json'))

--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -4,7 +4,13 @@ import 'package:flutter/material.dart' show debugPrint;
 import 'package:flutter/services.dart' show AssetBundle;
 import 'package:stats/stats.dart' show Stats;
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show Document, RerankDebugCallData, RerankingOutcomes, SetupData, XaynAi;
+    show
+        Document,
+        FeatureHint,
+        RerankDebugCallData,
+        RerankingOutcomes,
+        SetupData,
+        XaynAi;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     if (dart.library.io) 'data_provider/mobile.dart'
@@ -47,7 +53,7 @@ class Logic {
   /// This normally should be called with the `rootBundle`,
   /// as it expects an `AssetManifest.json` asset.
   ///
-  static Future<Logic> load(AssetBundle bundle) async {
+  static Future<Logic> load(AssetBundle bundle, [FeatureHint? hint]) async {
     final manifest = jsonDecode(await bundle.loadString('AssetManifest.json'))
         as Map<String, dynamic>;
 
@@ -66,7 +72,7 @@ class Logic {
       currentCallDataKey = availableCallData.keys.first;
     }
 
-    final setupData = await getInputData();
+    final setupData = await getInputData(hint);
 
     final currentAi = await XaynAi.create(
         setupData, availableCallData[currentCallDataKey]?.serializedState);

--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -4,7 +4,13 @@ import 'package:flutter/material.dart' show debugPrint;
 import 'package:flutter/services.dart' show AssetBundle;
 import 'package:stats/stats.dart' show Stats;
 import 'package:xayn_ai_ffi_dart/package.dart'
-    show Document, RerankDebugCallData, RerankingOutcomes, SetupData, XaynAi;
+    show
+        Document,
+        Feature,
+        RerankDebugCallData,
+        RerankingOutcomes,
+        SetupData,
+        XaynAi;
 
 import 'package:xayn_ai_ffi_dart_example/data_provider/data_provider.dart'
     if (dart.library.io) 'data_provider/mobile.dart'
@@ -50,7 +56,7 @@ class Logic {
   /// Optionally accepts a list of the following features:
   /// - 'webParallel': enables multi-threading for the web targets
   static Future<Logic> load(AssetBundle bundle,
-      {List<String> features = const []}) async {
+      {Set<Feature> features = const {}}) async {
     final manifest = jsonDecode(await bundle.loadString('AssetManifest.json'))
         as Map<String, dynamic>;
 

--- a/bindings/dart/example/lib/main.dart
+++ b/bindings/dart/example/lib/main.dart
@@ -58,7 +58,7 @@ class _MyAppState extends State<MyApp> {
 
     // mobile is always loaded with multi-threading features, web only optionally
     debugPrint('start loading assets');
-    Logic.load(rootBundle, features: []).then((logic) {
+    Logic.load(rootBundle).then((logic) {
       debugPrint('loaded assets');
       // Calling `setState` after it was disposed is considered an error.
       if (mounted) {

--- a/bindings/dart/example/lib/main.dart
+++ b/bindings/dart/example/lib/main.dart
@@ -59,7 +59,8 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     // mobile is always loaded with multi-threading features, web only optionally
-    final hint = kIsWeb ? FeatureHint.wasmSequential : null;
+    final hint =
+        kIsWeb ? FeatureHint.webSequential : FeatureHint.mobileParallel;
 
     debugPrint('start loading assets');
     Logic.load(rootBundle, hint).then((logic) {

--- a/bindings/dart/example/lib/main.dart
+++ b/bindings/dart/example/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart'
     show
         AppBar,
@@ -32,7 +31,6 @@ import 'package:flutter/material.dart'
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:stats/stats.dart' show Stats;
 
-import 'package:xayn_ai_ffi_dart/package.dart' show FeatureHint;
 import 'package:xayn_ai_ffi_dart_example/debug/print.dart'
     if (dart.library.io) 'package:xayn_ai_ffi_dart_example/debug/mobile/print.dart'
     show debugPrintLongText;
@@ -59,11 +57,8 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     // mobile is always loaded with multi-threading features, web only optionally
-    final hint =
-        kIsWeb ? FeatureHint.webSequential : FeatureHint.mobileParallel;
-
     debugPrint('start loading assets');
-    Logic.load(rootBundle, hint).then((logic) {
+    Logic.load(rootBundle, features: []).then((logic) {
       debugPrint('loaded assets');
       // Calling `setState` after it was disposed is considered an error.
       if (mounted) {

--- a/bindings/dart/example/lib/main.dart
+++ b/bindings/dart/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart'
     show
         AppBar,
@@ -31,10 +32,10 @@ import 'package:flutter/material.dart'
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:stats/stats.dart' show Stats;
 
+import 'package:xayn_ai_ffi_dart/package.dart' show FeatureHint;
 import 'package:xayn_ai_ffi_dart_example/debug/print.dart'
     if (dart.library.io) 'package:xayn_ai_ffi_dart_example/debug/mobile/print.dart'
     show debugPrintLongText;
-
 import 'package:xayn_ai_ffi_dart_example/logic.dart' show Logic, Outcome;
 
 void main() {
@@ -57,8 +58,11 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
 
+    // mobile is always loaded with multi-threading features, web only optionally
+    final hint = kIsWeb ? FeatureHint.wasmSequential : null;
+
     debugPrint('start loading assets');
-    Logic.load(rootBundle).then((logic) {
+    Logic.load(rootBundle, hint).then((logic) {
       debugPrint('loaded assets');
       // Calling `setState` after it was disposed is considered an error.
       if (mounted) {

--- a/bindings/dart/lib/package.dart
+++ b/bindings/dart/lib/package.dart
@@ -6,7 +6,7 @@ export 'src/common/reranker/ai.dart'
     if (dart.library.io) 'src/mobile/reranker/ai.dart'
     if (dart.library.js) 'src/web/reranker/ai.dart' show XaynAi;
 export 'src/common/reranker/analytics.dart' show Analytics;
-export 'src/common/reranker/data_provider.dart' show Asset, AssetType;
+export 'src/common/reranker/data_provider.dart' show Asset, AssetType, Feature;
 export 'src/common/reranker/data_provider.dart'
     if (dart.library.io) 'src/mobile/reranker/data_provider.dart'
     if (dart.library.js) 'src/web/reranker/data_provider.dart'

--- a/bindings/dart/lib/package.dart
+++ b/bindings/dart/lib/package.dart
@@ -6,7 +6,8 @@ export 'src/common/reranker/ai.dart'
     if (dart.library.io) 'src/mobile/reranker/ai.dart'
     if (dart.library.js) 'src/web/reranker/ai.dart' show XaynAi;
 export 'src/common/reranker/analytics.dart' show Analytics;
-export 'src/common/reranker/data_provider.dart' show Asset, AssetType;
+export 'src/common/reranker/data_provider.dart'
+    show Asset, AssetType, FeatureHint;
 export 'src/common/reranker/data_provider.dart'
     if (dart.library.io) 'src/mobile/reranker/data_provider.dart'
     if (dart.library.js) 'src/web/reranker/data_provider.dart'

--- a/bindings/dart/lib/package.dart
+++ b/bindings/dart/lib/package.dart
@@ -6,8 +6,7 @@ export 'src/common/reranker/ai.dart'
     if (dart.library.io) 'src/mobile/reranker/ai.dart'
     if (dart.library.js) 'src/web/reranker/ai.dart' show XaynAi;
 export 'src/common/reranker/analytics.dart' show Analytics;
-export 'src/common/reranker/data_provider.dart'
-    show Asset, AssetType, FeatureHint;
+export 'src/common/reranker/data_provider.dart' show Asset, AssetType;
 export 'src/common/reranker/data_provider.dart'
     if (dart.library.io) 'src/mobile/reranker/data_provider.dart'
     if (dart.library.js) 'src/web/reranker/data_provider.dart'

--- a/bindings/dart/lib/src/common/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/common/reranker/data_provider.dart
@@ -56,26 +56,15 @@ class Checksum {
   String get checksumSri => 'sha256-' + base64.encode(HEX.decode(_checksum));
 }
 
-/// The feature hints to pick platform dependent assets.
-enum FeatureHint {
-  /// Mobile multi-threading features.
-  mobileParallel,
-
-  /// Web standard features.
-  webSequential,
-
-  /// Web multi-threading features.
-  webParallel,
-}
-
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<AssetType, Asset> getAssets(FeatureHint hint) {
+Map<AssetType, Asset> getAssets({List<String> features = const []}) {
   throw UnsupportedError('Unsupported platform.');
 }
 
 /// Data that is required to initialize [`XaynAi`].
 class SetupData {
-  SetupData(Map<AssetType, dynamic> assets, FeatureHint hint) {
+  SetupData(Map<AssetType, dynamic> assets,
+      {List<String> features = const []}) {
     throw UnsupportedError('Unsupported platform.');
   }
 }

--- a/bindings/dart/lib/src/common/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/common/reranker/data_provider.dart
@@ -56,12 +56,21 @@ class Checksum {
   String get checksumSri => 'sha256-' + base64.encode(HEX.decode(_checksum));
 }
 
+/// The feature hints to pick platform dependent assets.
+enum FeatureHint {
+  /// Wasm standard features.
+  wasmSequential,
+
+  /// Wasm multi-threading features.
+  wasmParallel,
+}
+
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<AssetType, Asset> getAssets() {
+Map<AssetType, Asset> getAssets([FeatureHint? hint]) {
   throw UnsupportedError('Unsupported platform.');
 }
 
 /// Data that is required to initialize [`XaynAi`].
 class SetupData {
-  SetupData(Map<AssetType, dynamic> assets);
+  SetupData(Map<AssetType, dynamic> assets, [FeatureHint? hint]);
 }

--- a/bindings/dart/lib/src/common/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/common/reranker/data_provider.dart
@@ -58,19 +58,24 @@ class Checksum {
 
 /// The feature hints to pick platform dependent assets.
 enum FeatureHint {
-  /// Wasm standard features.
-  wasmSequential,
+  /// Mobile multi-threading features.
+  mobileParallel,
 
-  /// Wasm multi-threading features.
-  wasmParallel,
+  /// Web standard features.
+  webSequential,
+
+  /// Web multi-threading features.
+  webParallel,
 }
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<AssetType, Asset> getAssets([FeatureHint? hint]) {
+Map<AssetType, Asset> getAssets(FeatureHint hint) {
   throw UnsupportedError('Unsupported platform.');
 }
 
 /// Data that is required to initialize [`XaynAi`].
 class SetupData {
-  SetupData(Map<AssetType, dynamic> assets, [FeatureHint? hint]);
+  SetupData(Map<AssetType, dynamic> assets, FeatureHint hint) {
+    throw UnsupportedError('Unsupported platform.');
+  }
 }

--- a/bindings/dart/lib/src/common/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/common/reranker/data_provider.dart
@@ -56,15 +56,21 @@ class Checksum {
   String get checksumSri => 'sha256-' + base64.encode(HEX.decode(_checksum));
 }
 
+/// The optional features to be enabled by picking platform dependent assets.
+enum Feature {
+  /// Web multi-threading features.
+  webParallel,
+}
+
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<AssetType, Asset> getAssets({List<String> features = const []}) {
+Map<AssetType, Asset> getAssets({Set<Feature> features = const {}}) {
   throw UnsupportedError('Unsupported platform.');
 }
 
 /// Data that is required to initialize [`XaynAi`].
 class SetupData {
   SetupData(Map<AssetType, dynamic> assets,
-      {List<String> features = const []}) {
+      {Set<Feature> features = const {}}) {
     throw UnsupportedError('Unsupported platform.');
   }
 }

--- a/bindings/dart/lib/src/mobile/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/mobile/reranker/data_provider.dart
@@ -12,6 +12,7 @@ Map<common.AssetType, common.Asset> getAssets(common.FeatureHint hint) {
     common.AssetType.wasmSequentialScript,
     common.AssetType.wasmParallelModule,
     common.AssetType.wasmParallelScript,
+    common.AssetType.wasmParallelSnippet,
   ];
   return Map.fromEntries(common.baseAssets.entries
       .where((asset) => wasmAssets.contains(asset.key) == false));

--- a/bindings/dart/lib/src/mobile/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/mobile/reranker/data_provider.dart
@@ -2,9 +2,9 @@ import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
     as common show Asset, AssetType, baseAssets, FeatureHint, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<common.AssetType, common.Asset> getAssets([common.FeatureHint? hint]) {
-  if (hint != null) {
-    throw ArgumentError('no feature hints available for mobile assets');
+Map<common.AssetType, common.Asset> getAssets(common.FeatureHint hint) {
+  if (hint != common.FeatureHint.mobileParallel) {
+    throw ArgumentError('unsupported feature hint for mobile: $hint');
   }
 
   final wasmAssets = [
@@ -25,9 +25,9 @@ class SetupData implements common.SetupData {
   late String qambertModel;
   late String ltrModel;
 
-  SetupData(Map<common.AssetType, String> assets, [common.FeatureHint? hint]) {
-    if (hint != null) {
-      throw ArgumentError('no feature hints available for mobile assets');
+  SetupData(Map<common.AssetType, String> assets, common.FeatureHint hint) {
+    if (hint != common.FeatureHint.mobileParallel) {
+      throw ArgumentError('unsupported feature hint for mobile: $hint');
     }
 
     smbertVocab = assets[common.AssetType.smbertVocab]!;

--- a/bindings/dart/lib/src/mobile/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/mobile/reranker/data_provider.dart
@@ -1,9 +1,9 @@
 import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
-    as common show Asset, AssetType, baseAssets, SetupData;
+    as common show Asset, AssetType, baseAssets, Feature, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
 Map<common.AssetType, common.Asset> getAssets(
-    {List<String> features = const []}) {
+    {Set<common.Feature> features = const {}}) {
   final wasmAssets = [
     common.AssetType.wasmSequentialModule,
     common.AssetType.wasmSequentialScript,
@@ -24,7 +24,7 @@ class SetupData implements common.SetupData {
   late String ltrModel;
 
   SetupData(Map<common.AssetType, String> assets,
-      {List<String> features = const []}) {
+      {Set<common.Feature> features = const {}}) {
     smbertVocab = assets[common.AssetType.smbertVocab]!;
     smbertModel = assets[common.AssetType.smbertModel]!;
     qambertVocab = assets[common.AssetType.qambertVocab]!;

--- a/bindings/dart/lib/src/mobile/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/mobile/reranker/data_provider.dart
@@ -1,9 +1,18 @@
 import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
-    as common show Asset, AssetType, baseAssets, SetupData;
+    as common show Asset, AssetType, baseAssets, FeatureHint, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<common.AssetType, common.Asset> getAssets() {
-  final wasmAssets = [common.AssetType.wasmModule, common.AssetType.wasmScript];
+Map<common.AssetType, common.Asset> getAssets([common.FeatureHint? hint]) {
+  if (hint != null) {
+    throw ArgumentError('no feature hints available for mobile assets');
+  }
+
+  final wasmAssets = [
+    common.AssetType.wasmSequentialModule,
+    common.AssetType.wasmSequentialScript,
+    common.AssetType.wasmParallelModule,
+    common.AssetType.wasmParallelScript,
+  ];
   return Map.fromEntries(common.baseAssets.entries
       .where((asset) => wasmAssets.contains(asset.key) == false));
 }
@@ -16,7 +25,11 @@ class SetupData implements common.SetupData {
   late String qambertModel;
   late String ltrModel;
 
-  SetupData(Map<common.AssetType, String> assets) {
+  SetupData(Map<common.AssetType, String> assets, [common.FeatureHint? hint]) {
+    if (hint != null) {
+      throw ArgumentError('no feature hints available for mobile assets');
+    }
+
     smbertVocab = assets[common.AssetType.smbertVocab]!;
     smbertModel = assets[common.AssetType.smbertModel]!;
     qambertVocab = assets[common.AssetType.qambertVocab]!;

--- a/bindings/dart/lib/src/mobile/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/mobile/reranker/data_provider.dart
@@ -1,12 +1,9 @@
 import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
-    as common show Asset, AssetType, baseAssets, FeatureHint, SetupData;
+    as common show Asset, AssetType, baseAssets, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<common.AssetType, common.Asset> getAssets(common.FeatureHint hint) {
-  if (hint != common.FeatureHint.mobileParallel) {
-    throw ArgumentError('unsupported feature hint for mobile: $hint');
-  }
-
+Map<common.AssetType, common.Asset> getAssets(
+    {List<String> features = const []}) {
   final wasmAssets = [
     common.AssetType.wasmSequentialModule,
     common.AssetType.wasmSequentialScript,
@@ -26,11 +23,8 @@ class SetupData implements common.SetupData {
   late String qambertModel;
   late String ltrModel;
 
-  SetupData(Map<common.AssetType, String> assets, common.FeatureHint hint) {
-    if (hint != common.FeatureHint.mobileParallel) {
-      throw ArgumentError('unsupported feature hint for mobile: $hint');
-    }
-
+  SetupData(Map<common.AssetType, String> assets,
+      {List<String> features = const []}) {
     smbertVocab = assets[common.AssetType.smbertVocab]!;
     smbertModel = assets[common.AssetType.smbertModel]!;
     qambertVocab = assets[common.AssetType.qambertVocab]!;

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -1,29 +1,23 @@
 import 'dart:typed_data' show Uint8List;
 
 import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
-    as common show Asset, AssetType, baseAssets, FeatureHint, SetupData;
+    as common show Asset, AssetType, baseAssets, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<common.AssetType, common.Asset> getAssets(common.FeatureHint hint) {
-  switch (hint) {
-    case common.FeatureHint.webSequential:
-      final wasmNonSequentialAssets = [
-        common.AssetType.wasmParallelModule,
-        common.AssetType.wasmParallelScript,
-        common.AssetType.wasmParallelSnippet,
-      ];
-      return Map.fromEntries(common.baseAssets.entries.where(
-          (asset) => wasmNonSequentialAssets.contains(asset.key) == false));
-    case common.FeatureHint.webParallel:
-      final wasmNonParallelAssets = [
-        common.AssetType.wasmSequentialModule,
-        common.AssetType.wasmSequentialScript,
-      ];
-      return Map.fromEntries(common.baseAssets.entries.where(
-          (asset) => wasmNonParallelAssets.contains(asset.key) == false));
-    default:
-      throw ArgumentError('unsupported feature hint for web: $hint');
-  }
+Map<common.AssetType, common.Asset> getAssets(
+    {List<String> features = const []}) {
+  final redundantAssets = features.contains('webParallel')
+      ? [
+          common.AssetType.wasmSequentialModule,
+          common.AssetType.wasmSequentialScript,
+        ]
+      : [
+          common.AssetType.wasmParallelModule,
+          common.AssetType.wasmParallelScript,
+          common.AssetType.wasmParallelSnippet,
+        ];
+  return Map.fromEntries(common.baseAssets.entries
+      .where((asset) => redundantAssets.contains(asset.key) == false));
 }
 
 /// Data that is required to initialize [`XaynAi`].
@@ -35,21 +29,15 @@ class SetupData implements common.SetupData {
   late Uint8List ltrModel;
   late Uint8List wasmModule;
 
-  SetupData(Map<common.AssetType, Uint8List> assets, common.FeatureHint hint) {
+  SetupData(Map<common.AssetType, Uint8List> assets,
+      {List<String> features = const []}) {
     smbertVocab = assets[common.AssetType.smbertVocab]!;
     smbertModel = assets[common.AssetType.smbertModel]!;
     qambertVocab = assets[common.AssetType.qambertVocab]!;
     qambertModel = assets[common.AssetType.qambertModel]!;
     ltrModel = assets[common.AssetType.ltrModel]!;
-    switch (hint) {
-      case common.FeatureHint.webSequential:
-        wasmModule = assets[common.AssetType.wasmSequentialModule]!;
-        break;
-      case common.FeatureHint.webParallel:
-        wasmModule = assets[common.AssetType.wasmParallelModule]!;
-        break;
-      default:
-        throw ArgumentError('unsupported feature hint for web: $hint');
-    }
+    wasmModule = features.contains('webParallel')
+        ? assets[common.AssetType.wasmParallelModule]!
+        : assets[common.AssetType.wasmSequentialModule]!;
   }
 }

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -10,6 +10,7 @@ Map<common.AssetType, common.Asset> getAssets(common.FeatureHint hint) {
       final wasmNonSequentialAssets = [
         common.AssetType.wasmParallelModule,
         common.AssetType.wasmParallelScript,
+        common.AssetType.wasmParallelSnippet,
       ];
       return Map.fromEntries(common.baseAssets.entries.where(
           (asset) => wasmNonSequentialAssets.contains(asset.key) == false));

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -1,11 +1,30 @@
 import 'dart:typed_data' show Uint8List;
 
 import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
-    as common show Asset, AssetType, baseAssets, SetupData;
+    as common show Asset, AssetType, baseAssets, FeatureHint, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<common.AssetType, common.Asset> getAssets() {
-  return common.baseAssets;
+Map<common.AssetType, common.Asset> getAssets([common.FeatureHint? hint]) {
+  if (hint == null) {
+    throw ArgumentError('requires a feature hint for web assets');
+  }
+
+  switch (hint) {
+    case common.FeatureHint.wasmSequential:
+      final wasmNonSequentialAssets = [
+        common.AssetType.wasmParallelModule,
+        common.AssetType.wasmParallelScript,
+      ];
+      return Map.fromEntries(common.baseAssets.entries.where(
+          (asset) => wasmNonSequentialAssets.contains(asset.key) == false));
+    case common.FeatureHint.wasmParallel:
+      final wasmNonParallelAssets = [
+        common.AssetType.wasmSequentialModule,
+        common.AssetType.wasmSequentialScript,
+      ];
+      return Map.fromEntries(common.baseAssets.entries.where(
+          (asset) => wasmNonParallelAssets.contains(asset.key) == false));
+  }
 }
 
 /// Data that is required to initialize [`XaynAi`].
@@ -17,12 +36,24 @@ class SetupData implements common.SetupData {
   late Uint8List ltrModel;
   late Uint8List wasmModule;
 
-  SetupData(Map<common.AssetType, Uint8List> assets) {
+  SetupData(Map<common.AssetType, Uint8List> assets,
+      [common.FeatureHint? hint]) {
+    if (hint == null) {
+      throw ArgumentError('requires a feature hint for web assets');
+    }
+
     smbertVocab = assets[common.AssetType.smbertVocab]!;
     smbertModel = assets[common.AssetType.smbertModel]!;
     qambertVocab = assets[common.AssetType.qambertVocab]!;
     qambertModel = assets[common.AssetType.qambertModel]!;
     ltrModel = assets[common.AssetType.ltrModel]!;
-    wasmModule = assets[common.AssetType.wasmModule]!;
+    switch (hint) {
+      case common.FeatureHint.wasmSequential:
+        wasmModule = assets[common.AssetType.wasmSequentialModule]!;
+        break;
+      case common.FeatureHint.wasmParallel:
+        wasmModule = assets[common.AssetType.wasmParallelModule]!;
+        break;
+    }
   }
 }

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -4,26 +4,24 @@ import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
     as common show Asset, AssetType, baseAssets, FeatureHint, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
-Map<common.AssetType, common.Asset> getAssets([common.FeatureHint? hint]) {
-  if (hint == null) {
-    throw ArgumentError('requires a feature hint for web assets');
-  }
-
+Map<common.AssetType, common.Asset> getAssets(common.FeatureHint hint) {
   switch (hint) {
-    case common.FeatureHint.wasmSequential:
+    case common.FeatureHint.webSequential:
       final wasmNonSequentialAssets = [
         common.AssetType.wasmParallelModule,
         common.AssetType.wasmParallelScript,
       ];
       return Map.fromEntries(common.baseAssets.entries.where(
           (asset) => wasmNonSequentialAssets.contains(asset.key) == false));
-    case common.FeatureHint.wasmParallel:
+    case common.FeatureHint.webParallel:
       final wasmNonParallelAssets = [
         common.AssetType.wasmSequentialModule,
         common.AssetType.wasmSequentialScript,
       ];
       return Map.fromEntries(common.baseAssets.entries.where(
           (asset) => wasmNonParallelAssets.contains(asset.key) == false));
+    default:
+      throw ArgumentError('unsupported feature hint for web: $hint');
   }
 }
 
@@ -36,24 +34,21 @@ class SetupData implements common.SetupData {
   late Uint8List ltrModel;
   late Uint8List wasmModule;
 
-  SetupData(Map<common.AssetType, Uint8List> assets,
-      [common.FeatureHint? hint]) {
-    if (hint == null) {
-      throw ArgumentError('requires a feature hint for web assets');
-    }
-
+  SetupData(Map<common.AssetType, Uint8List> assets, common.FeatureHint hint) {
     smbertVocab = assets[common.AssetType.smbertVocab]!;
     smbertModel = assets[common.AssetType.smbertModel]!;
     qambertVocab = assets[common.AssetType.qambertVocab]!;
     qambertModel = assets[common.AssetType.qambertModel]!;
     ltrModel = assets[common.AssetType.ltrModel]!;
     switch (hint) {
-      case common.FeatureHint.wasmSequential:
+      case common.FeatureHint.webSequential:
         wasmModule = assets[common.AssetType.wasmSequentialModule]!;
         break;
-      case common.FeatureHint.wasmParallel:
+      case common.FeatureHint.webParallel:
         wasmModule = assets[common.AssetType.wasmParallelModule]!;
         break;
+      default:
+        throw ArgumentError('unsupported feature hint for web: $hint');
     }
   }
 }

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -1,12 +1,12 @@
 import 'dart:typed_data' show Uint8List;
 
 import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
-    as common show Asset, AssetType, baseAssets, SetupData;
+    as common show Asset, AssetType, baseAssets, Feature, SetupData;
 
 /// Returns a map of all assets required for initializing [`XaynAi`].
 Map<common.AssetType, common.Asset> getAssets(
-    {List<String> features = const []}) {
-  final redundantAssets = features.contains('webParallel')
+    {Set<common.Feature> features = const {}}) {
+  final redundantAssets = features.contains(common.Feature.webParallel)
       ? [
           common.AssetType.wasmSequentialModule,
           common.AssetType.wasmSequentialScript,
@@ -30,13 +30,13 @@ class SetupData implements common.SetupData {
   late Uint8List wasmModule;
 
   SetupData(Map<common.AssetType, Uint8List> assets,
-      {List<String> features = const []}) {
+      {Set<common.Feature> features = const {}}) {
     smbertVocab = assets[common.AssetType.smbertVocab]!;
     smbertModel = assets[common.AssetType.smbertModel]!;
     qambertVocab = assets[common.AssetType.qambertVocab]!;
     qambertModel = assets[common.AssetType.qambertModel]!;
     ltrModel = assets[common.AssetType.ltrModel]!;
-    wasmModule = features.contains('webParallel')
+    wasmModule = features.contains(common.Feature.webParallel)
         ? assets[common.AssetType.wasmParallelModule]!
         : assets[common.AssetType.wasmSequentialModule]!;
   }

--- a/bindings/dart/test/mobile/utils.dart
+++ b/bindings/dart/test/mobile/utils.dart
@@ -6,19 +6,14 @@ import 'package:xayn_ai_ffi_dart/src/common/data/history.dart'
     show UserFeedback, History, Relevance, DayOfWeek, UserAction;
 import 'package:xayn_ai_ffi_dart/src/common/result/error.dart'
     show Code, XaynAiException;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
-    show FeatureHint;
 import 'package:xayn_ai_ffi_dart/src/mobile/reranker/data_provider.dart'
     show getAssets, SetupData;
 
 SetupData mkSetupData() {
-  return SetupData(
-    {
-      for (final asset in getAssets(FeatureHint.mobileParallel).entries)
-        asset.key: '../../data/' + asset.value.urlSuffix
-    },
-    FeatureHint.mobileParallel,
-  );
+  return SetupData({
+    for (final asset in getAssets().entries)
+      asset.key: '../../data/' + asset.value.urlSuffix
+  });
 }
 
 Document mkTestDoc(String id, String title, int rank) => Document(

--- a/bindings/dart/test/mobile/utils.dart
+++ b/bindings/dart/test/mobile/utils.dart
@@ -6,14 +6,19 @@ import 'package:xayn_ai_ffi_dart/src/common/data/history.dart'
     show UserFeedback, History, Relevance, DayOfWeek, UserAction;
 import 'package:xayn_ai_ffi_dart/src/common/result/error.dart'
     show Code, XaynAiException;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
+    show FeatureHint;
 import 'package:xayn_ai_ffi_dart/src/mobile/reranker/data_provider.dart'
     show getAssets, SetupData;
 
 SetupData mkSetupData() {
-  return SetupData({
-    for (final asset in getAssets().entries)
-      asset.key: '../../data/' + asset.value.urlSuffix
-  });
+  return SetupData(
+    {
+      for (final asset in getAssets(FeatureHint.mobileParallel).entries)
+        asset.key: '../../data/' + asset.value.urlSuffix
+    },
+    FeatureHint.mobileParallel,
+  );
 }
 
 Document mkTestDoc(String id, String title, int rank) => Document(

--- a/generate_assets_metadata.sh
+++ b/generate_assets_metadata.sh
@@ -131,12 +131,17 @@ gen_wasm_assets_metadata() {
 
     local WASM_JS_NAME="genesis.js"
     local WASM_MODULE_NAME="genesis_bg.wasm"
+    local WASM_SNIPPET_NAME="snippets/wasm-bindgen-rayon-7afa899f36665473/src/workerHelpers.no-bundler.js"
 
     local ASSET_JS_PATH=${WASM_OUT_DIR_PATH}/${WASM_VERSION}/${WASM_JS_NAME}
     local ASSET_WASM_PATH=${WASM_OUT_DIR_PATH}/${WASM_VERSION}/${WASM_MODULE_NAME}
+    local ASSET_SNIPPET_PATH=${WASM_OUT_DIR_PATH}/${WASM_VERSION}/${WASM_SNIPPET_NAME}
 
     gen_wasm_asset_metadata wasm${WASM_FEATURE}Script $WASM_VERSION $WASM_JS_NAME $ASSET_JS_PATH
     gen_wasm_asset_metadata wasm${WASM_FEATURE}Module $WASM_VERSION $WASM_MODULE_NAME $ASSET_WASM_PATH
+    if [ "${WASM_FEATURE}" = "Parallel" ]; then
+        gen_wasm_asset_metadata wasm${WASM_FEATURE}Snippet $WASM_VERSION $WASM_SNIPPET_NAME $ASSET_SNIPPET_PATH
+    fi
 }
 
 gen_assets_metadata() {

--- a/generate_assets_metadata.sh
+++ b/generate_assets_metadata.sh
@@ -154,5 +154,5 @@ gen_assets_metadata() {
     gen_wasm_assets_metadata "Parallel" $WASM_PARALLEL_VERSION $WASM_OUT_DIR_PATH
 }
 
-gen_assets_metadata $1 $2 $3 $4
+gen_assets_metadata "$1" "$2" "$3" "$4"
 generate_dart_assets_manifest

--- a/xayn-ai-ffi-wasm/Cargo.toml
+++ b/xayn-ai-ffi-wasm/Cargo.toml
@@ -19,6 +19,7 @@ xayn-ai-ffi = { path = "../xayn-ai-ffi" }
 # "cargo clippy --all-targets --all-features" and similar. Furthermore we
 # always want to use parallelism if our target supports it, which this
 # setups represents fairly well.
+# NOTE: the `generate_asset_metadata.sh` script must be updated if this version gets changed!
 [target.'cfg(all(target_arch = "wasm32", target_feature = "atomics"))'.dependencies]
 wasm-bindgen-rayon = { version = "=1.0.3", features = ["no-bundler"] }
 xayn-ai = { path = "../xayn-ai", features = ["parallel"] }


### PR DESCRIPTION
**References**

- [TY-2069]
- [TY-2066]

**Summary**

- add an optional set of  `Feature`s to select the respective assets for sequential/parallel mobile/web in dart
- update the corresponding `getAssets()`, `SetupData()` functions and pick a default in the example app
- expand the asset generation script to generate sequential/parallel web assets depending on the input
- update the makefile to generate the sequential/parallel web assets depending on `DISABLE_WASM_THREADS`
- update the release ci to build the sequential/parallel web artifacts

**Todo**

- ~rebase once #207 is merged~

**Open questions**

- testing for mobile and sequential web was successful, but when trying to test the parallel web it loads indefinitely (i tried firefox) where i'm not sure if this is related to these changes or to the `run-web` script, to reproduce:
  - build with `DISABLE_WASM_THREADS=0 cargo make build-web`(or without explicitely setting the env var)
  - select `FeatureHint.webParallel` in the dart example's `main.dart` (l. 62)
  - run `cargo make run-web`, open in a browser and check the console


[TY-2069]: https://xainag.atlassian.net/browse/TY-2069
[TY-2066]: https://xainag.atlassian.net/browse/TY-2066