### PR TITLE
Don't push tags to release repository 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -670,6 +670,4 @@ jobs:
             https://github.com/xaynetwork/xayn_ai/commit/$SRC_COMMIT
             https://github.com/xaynetwork/xayn_ai/tree/$BRANCH"
             git push -u origin HEAD:$BRANCH
-            git fetch --tags git@github.com:xaynetwork/xayn_ai.git
-            git push --tags
           fi


### PR DESCRIPTION
This needs to be backported to let the release CI work correctly. At the moment it fails because the tags are already on the release repo and they cannot be overridden.