### PR TITLE
TY-2068 limit max threads

### DIFF
--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -1,3 +1,4 @@
+import 'dart:math' show min;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:json_annotation/json_annotation.dart' show JsonValue;
@@ -76,15 +77,14 @@ class XaynAi {
   void free() => throw UnsupportedError('Unsupported platform.');
 }
 
+/// Maximum number of threads to be used for parallel features.
+const int maxNumberOfThreads = 16;
+
 /// Selects the number of threads used by the [`XaynAi`] thread pool.
 ///
 /// On a single core system the thread pool consists of only one thread.
 /// On a multicore system the thread pool consists of
-/// (the number of logical cores - 1) threads.
-int selectThreadPoolSize(int numberOfProcessors) {
-  if (numberOfProcessors > 1) {
-    return numberOfProcessors - 1;
-  } else {
-    return numberOfProcessors;
-  }
-}
+/// (the number of logical cores - 1) threads, but at most [`maxNumberOfThreads`] threads.
+int selectThreadPoolSize(int numberOfProcessors) => (numberOfProcessors > 1)
+    ? min(numberOfProcessors - 1, maxNumberOfThreads)
+    : 1;

--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -1,4 +1,4 @@
-import 'dart:math' show min;
+import 'dart:math' show max, min;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:json_annotation/json_annotation.dart' show JsonValue;
@@ -84,7 +84,7 @@ const int maxNumberOfThreads = 16;
 ///
 /// On a single core system the thread pool consists of only one thread.
 /// On a multicore system the thread pool consists of
-/// (the number of logical cores - 1) threads, but at most [`maxNumberOfThreads`] threads.
-int selectThreadPoolSize(int numberOfProcessors) => (numberOfProcessors > 1)
-    ? min(numberOfProcessors - 1, maxNumberOfThreads)
-    : 1;
+/// (the number of logical cores - 1) threads, but at most [`maxNumberOfThreads`]
+/// threads and at least one thread.
+int selectThreadPoolSize(int numberOfProcessors) =>
+    min(max(numberOfProcessors - 1, 1), maxNumberOfThreads);


### PR DESCRIPTION
**References**

- [TY-2068]

**Summary**

- introduce a `maxNumberOfThreads` constant to limit the maximum number of threads to be used, it's currently set to 16 which is somewhat arbitrary


[TY-2068]: https://xainag.atlassian.net/browse/TY-2068