### PR TITLE
Revert dart and flutter version

### DIFF
--- a/bindings/dart/pubspec.yaml
+++ b/bindings/dart/pubspec.yaml
@@ -2,8 +2,8 @@ name: 'xayn_ai_ffi_dart'
 version: '2.0.1'
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
-  flutter: '>=2.5.0 <3.0.0'
+  sdk: '>=2.14.0-0 <3.0.0'
+  flutter: '>=2.3.0-0.pre <3.0.0'
 
 dependencies:
   async: '^2.8.1'


### PR DESCRIPTION
* App cannot use flutter 2.5 yet.
* Adjust dart version to allow `pre` versions.

I think we can keep 2.5 in the CI. We are not really using any flutter feature here.