### PR TITLE
Rename wasmSequentialX to wasmX

### DIFF
--- a/bindings/dart/lib/src/mobile/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/mobile/reranker/data_provider.dart
@@ -5,8 +5,8 @@ import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
 Map<common.AssetType, common.Asset> getAssets(
     {Set<common.Feature> features = const {}}) {
   final wasmAssets = [
-    common.AssetType.wasmSequentialModule,
-    common.AssetType.wasmSequentialScript,
+    common.AssetType.wasmModule,
+    common.AssetType.wasmScript,
     common.AssetType.wasmParallelModule,
     common.AssetType.wasmParallelScript,
     common.AssetType.wasmParallelSnippet,

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -8,8 +8,8 @@ Map<common.AssetType, common.Asset> getAssets(
     {Set<common.Feature> features = const {}}) {
   final redundantAssets = features.contains(common.Feature.webParallel)
       ? [
-          common.AssetType.wasmSequentialModule,
-          common.AssetType.wasmSequentialScript,
+          common.AssetType.wasmModule,
+          common.AssetType.wasmScript,
         ]
       : [
           common.AssetType.wasmParallelModule,
@@ -38,6 +38,6 @@ class SetupData implements common.SetupData {
     ltrModel = assets[common.AssetType.ltrModel]!;
     wasmModule = features.contains(common.Feature.webParallel)
         ? assets[common.AssetType.wasmParallelModule]!
-        : assets[common.AssetType.wasmSequentialModule]!;
+        : assets[common.AssetType.wasmModule]!;
   }
 }

--- a/generate_assets_metadata.sh
+++ b/generate_assets_metadata.sh
@@ -155,7 +155,7 @@ gen_assets_metadata() {
     echo "{\"assets\": []}" > $ASSETS_METADATA_PATH
 
     gen_data_assets_metadata $ASSET_MANIFEST
-    gen_wasm_assets_metadata "Sequential" $WASM_SEQUENTIAL_VERSION $WASM_OUT_DIR_PATH
+    gen_wasm_assets_metadata "" $WASM_SEQUENTIAL_VERSION $WASM_OUT_DIR_PATH
     gen_wasm_assets_metadata "Parallel" $WASM_PARALLEL_VERSION $WASM_OUT_DIR_PATH
 }
 


### PR DESCRIPTION
Rename the asset named `wasmSequentialX` to `wasmX` to keep compatibility with previous version.