### PR TITLE
TY-2106 fix mime type detection

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -525,7 +525,7 @@ jobs:
           for ASSET in $(cat ${{ needs.build-asset-artifacts.outputs.json-metadata }} | jq -c '.upload[]'); do
             ASSET_URL_SUFFIX=$(echo $ASSET | jq -r '.url_suffix')
             ASSET_PATH=$(echo $ASSET | jq -r '.path')
-            s3cmd sync -v --acl-public --guess-mime-type $ASSET_PATH ${BUCKET_URL}/$ASSET_URL_SUFFIX
+            s3cmd sync -v --acl-public --guess-mime-type --no-mime-magic $ASSET_PATH ${BUCKET_URL}/$ASSET_URL_SUFFIX
           done
 
   release:


### PR DESCRIPTION
Ticket: 

- [TY-2106]

Summary:

- disables the mime detection via `python-magic`
- s3cmd only uses the file extension to guess the right mime type ([Understand Content Type, Mime type guessing and Magic](https://github.com/s3tools/s3cmd/wiki/Understand-Content-Type,-Mime-type-guessing-and-Magic))
  - for wasm files the mime type is now ->  `application/wasm`
  - and for js files ->  `application/javascript`

[TY-2106]: https://xainag.atlassian.net/browse/TY-2106