### PR TITLE
TY-2085 kpe prototype [0]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kpe"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "displaydoc",
+ "ndarray",
+ "rubert-tokenizer",
+ "test-utils",
+ "thiserror",
+]
+
+[[package]]
 name = "kstring"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "dev-tool",
+    "kpe",
     "rubert",
     "rubert-tokenizer",
     "test-utils",

--- a/kpe/Cargo.toml
+++ b/kpe/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kpe"
+version = "0.1.0"
+authors = ["Xayn Engineering <engineering@xaynet.dev>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+derive_more = { version = "0.99.16", default-features = false, features = ["deref", "from"] }
+displaydoc = "0.2.3"
+# to be kept in sync with tract-core
+ndarray = "=0.15.3"
+rubert-tokenizer = { path = "../rubert-tokenizer" }
+thiserror = "1.0.29"
+
+[dev-dependencies]
+test-utils = { path = "../test-utils" }

--- a/kpe/src/lib.rs
+++ b/kpe/src/lib.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(doc, forbid(broken_intra_doc_links, private_intra_doc_links))]
+#![allow(dead_code)]
+
+mod tokenizer;
+
+#[cfg(doc)]
+pub use crate::tokenizer::{key_phrase::RankedKeyPhrases, TokenizerError};

--- a/kpe/src/tokenizer/encoding.rs
+++ b/kpe/src/tokenizer/encoding.rs
@@ -1,0 +1,402 @@
+use derive_more::{Deref, From};
+use ndarray::{Array1, Array2, Axis};
+
+use crate::tokenizer::{key_phrase::KeyPhrases, Tokenizer};
+
+/// The token ids of the encoded sequence.
+#[derive(Clone, Deref, From)]
+pub struct TokenIds(pub Array2<i64>);
+
+/// The attention mask of the encoded sequence.
+#[derive(Clone, Deref, From)]
+pub struct AttentionMask(pub Array2<i64>);
+
+/// The type ids of the encoded sequence.
+#[derive(Clone, Deref, From)]
+pub struct TypeIds(pub Array2<i64>);
+
+/// The starting tokens mask of the encoded sequence.
+#[derive(Clone, Deref, From)]
+pub struct ValidMask(pub Vec<bool>);
+
+/// The active words mask for each key phrase.
+#[derive(Clone, Deref, From)]
+pub struct ActiveMask(pub Array2<bool>);
+
+/// The encoded sequence.
+pub struct Encoding {
+    pub token_ids: TokenIds,
+    pub attention_mask: AttentionMask,
+    pub type_ids: TypeIds,
+    pub valid_mask: ValidMask,
+    pub active_mask: ActiveMask,
+}
+
+impl Tokenizer {
+    /// Encodes the sequence.
+    ///
+    /// The encoding is in correct shape for the models.
+    pub fn encode(&self, sequence: impl AsRef<str>) -> (Encoding, KeyPhrases) {
+        let encoding = self.tokenizer.encode(sequence);
+        let (token_ids, type_ids, tokens, word_indices, _, _, attention_mask, overflowing) =
+            encoding.into();
+
+        let token_ids = Array1::from(token_ids).insert_axis(Axis(0)).into();
+        let attention_mask = Array1::from(attention_mask).insert_axis(Axis(0)).into();
+        let type_ids = Array1::from(type_ids).insert_axis(Axis(0)).into();
+
+        let valid_mask = valid_mask(&word_indices);
+        let words = decode_words(tokens, word_indices, overflowing);
+        let key_phrases = KeyPhrases::collect(&words, self.key_phrase_size);
+        let active_mask = key_phrases.active_mask();
+
+        (
+            Encoding {
+                token_ids,
+                attention_mask,
+                type_ids,
+                valid_mask,
+                active_mask,
+            },
+            key_phrases,
+        )
+    }
+}
+
+/// Joins starting tokens with their continuing tokens to decode the tokenized words.
+fn decode_words(
+    tokens: Vec<String>,
+    word_indices: Vec<Option<i64>>,
+    overflowing: Option<Vec<rubert_tokenizer::Encoding<i64>>>,
+) -> Vec<String> {
+    let mut words = Vec::<String>::with_capacity(word_indices.len());
+    let last_idx = word_indices.into_iter().zip(tokens.into_iter()).fold(
+        None,
+        |previous, (current, token)| {
+            if current.is_some() {
+                if previous == current {
+                    words.last_mut().unwrap().push_str(&token[2..]);
+                } else {
+                    words.push(token);
+                }
+                current
+            } else {
+                previous
+            }
+        },
+    );
+    // subtokens of the last word might have been truncated during tokenization, but we can
+    // still use the whole word for the keyphrase because the model only pays attention to the
+    // starting token
+    if let Some(overflowing) = overflowing {
+        if !overflowing.is_empty() {
+            for (idx, token) in overflowing[0]
+                .word_indices()
+                .iter()
+                .zip(overflowing[0].tokens().iter())
+            {
+                if idx.is_some() {
+                    if idx == &last_idx {
+                        words.last_mut().unwrap().push_str(&token[2..]);
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    words.shrink_to_fit();
+
+    words
+}
+
+/// Creates the mask of starting tokens.
+fn valid_mask(word_indices: &[Option<i64>]) -> ValidMask {
+    word_indices
+        .iter()
+        .scan(None, |previous, current| {
+            if current == previous {
+                Some(false)
+            } else {
+                *previous = *current;
+                if current.is_some() {
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .into()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, io::BufReader};
+
+    use ndarray::ArrayView2;
+
+    use super::*;
+    use test_utils::smbert::vocab;
+
+    const EXACT_SEQUENCE: &str = "This embedding fits perfectly.";
+    const SHORT_SEQUENCE: &str = "This is an embedding.";
+    const LONG_SEQUENCE: &str = "This embedding is way too long.";
+
+    fn tokenizer(token_size: usize) -> Tokenizer {
+        let vocab = BufReader::new(File::open(vocab().unwrap()).unwrap());
+        let accents = false;
+        let lowercase = true;
+        let key_phrase_size = 3;
+
+        Tokenizer::new(vocab, accents, lowercase, token_size, key_phrase_size).unwrap()
+    }
+
+    #[test]
+    fn test_encode_exact() {
+        let shape = (1, 10);
+        let tokenizer = tokenizer(shape.1);
+        let (encoding, _) = tokenizer.encode(EXACT_SEQUENCE);
+        assert_eq!(
+            encoding.token_ids.0,
+            ArrayView2::from_shape(
+                shape,
+                &[2, 2584, 69469, 1599, 13891, 1046, 18992, 1838, 5, 3],
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            encoding.attention_mask.0,
+            ArrayView2::from_shape(shape, &[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]).unwrap(),
+        );
+        assert_eq!(
+            encoding.type_ids.0,
+            ArrayView2::from_shape(shape, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
+        );
+        assert_eq!(
+            encoding.valid_mask.0,
+            [false, true, true, false, true, false, true, false, true, false],
+        );
+        assert_eq!(
+            encoding.active_mask.0,
+            ArrayView2::from_shape(
+                (12, 12),
+                &[
+                    true, false, false, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, true, false, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, true, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, true, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, true, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, true, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, true, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, true, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, true, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, true, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, false, true,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    true, //
+                ],
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_encode_padded() {
+        let shape = (1, 10);
+        let tokenizer = tokenizer(shape.1);
+        let (encoding, _) = tokenizer.encode(SHORT_SEQUENCE);
+        assert_eq!(
+            encoding.token_ids.0,
+            ArrayView2::from_shape(shape, &[2, 2584, 1693, 1624, 69469, 1599, 5, 3, 0, 0]).unwrap(),
+        );
+        assert_eq!(
+            encoding.attention_mask.0,
+            ArrayView2::from_shape(shape, &[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]).unwrap(),
+        );
+        assert_eq!(
+            encoding.type_ids.0,
+            ArrayView2::from_shape(shape, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
+        );
+        assert_eq!(
+            encoding.valid_mask.0,
+            [false, true, true, true, true, false, true, false, false, false],
+        );
+        assert_eq!(
+            encoding.active_mask.0,
+            ArrayView2::from_shape(
+                (12, 12),
+                &[
+                    true, false, false, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, true, false, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, true, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, true, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, true, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, true, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, true, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, true, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, true, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, true, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, false, true,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    true, //
+                ],
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_encode_truncated() {
+        let shape = (1, 8);
+        let tokenizer = tokenizer(shape.1);
+        let (encoding, _) = tokenizer.encode(LONG_SEQUENCE);
+        assert_eq!(
+            encoding.token_ids.0,
+            ArrayView2::from_shape(shape, &[2, 2584, 69469, 1599, 1693, 5331, 11700, 3]).unwrap(),
+        );
+        assert_eq!(
+            encoding.attention_mask.0,
+            ArrayView2::from_shape(shape, &[1, 1, 1, 1, 1, 1, 1, 1]).unwrap(),
+        );
+        assert_eq!(
+            encoding.type_ids.0,
+            ArrayView2::from_shape(shape, &[0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
+        );
+        assert_eq!(
+            encoding.valid_mask.0,
+            [false, true, true, false, true, true, true, false],
+        );
+        assert_eq!(
+            encoding.active_mask.0,
+            ArrayView2::from_shape(
+                (12, 12),
+                &[
+                    true, false, false, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, true, false, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, true, false, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, true, false, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, true, false, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, true, false, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, true, false, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, true, false, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, true, false, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, true, false,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, false, true,
+                    false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    true, //
+                ],
+            )
+            .unwrap(),
+        );
+    }
+
+    const EXACT_WORDS: [&str; 5] = ["this", "embedding", "fits", "perfectly", "."];
+    const SHORT_WORDS: [&str; 5] = ["this", "is", "an", "embedding", "."];
+    const LONG_WORDS: [&str; 7] = ["this", "embedding", "is", "way", "too", "long", "."];
+
+    #[test]
+    fn test_decode_words_exact() {
+        let (_, _, tokens, word_indices, _, _, _, overflowing) =
+            tokenizer(10).tokenizer.encode(EXACT_SEQUENCE).into();
+        let words = decode_words(tokens, word_indices, overflowing);
+        assert_eq!(words, EXACT_WORDS);
+    }
+
+    #[test]
+    fn test_decode_words_padded() {
+        let (_, _, tokens, word_indices, _, _, _, overflowing) =
+            tokenizer(10).tokenizer.encode(SHORT_SEQUENCE).into();
+        let words = decode_words(tokens, word_indices, overflowing);
+        assert_eq!(words, SHORT_WORDS);
+    }
+
+    #[test]
+    fn test_decode_words_truncated_between() {
+        let (_, _, tokens, word_indices, _, _, _, overflowing) =
+            tokenizer(8).tokenizer.encode(LONG_SEQUENCE).into();
+        let words = decode_words(tokens, word_indices, overflowing);
+        assert_eq!(words, LONG_WORDS[..5]);
+    }
+
+    #[test]
+    fn test_decode_words_truncated_within() {
+        let (_, _, tokens, word_indices, _, _, _, overflowing) =
+            tokenizer(4).tokenizer.encode(LONG_SEQUENCE).into();
+        let words = decode_words(tokens, word_indices, overflowing);
+        assert_eq!(words, LONG_WORDS[..2]);
+    }
+
+    #[test]
+    fn test_decode_words_truncated_empty() {
+        let (_, _, tokens, word_indices, _, _, _, overflowing) =
+            tokenizer(2).tokenizer.encode(LONG_SEQUENCE).into();
+        let words = decode_words(tokens, word_indices, overflowing);
+        assert!(words.is_empty());
+    }
+
+    #[test]
+    fn test_decode_words_empty() {
+        let (_, _, tokens, word_indices, _, _, _, overflowing) =
+            tokenizer(5).tokenizer.encode("").into();
+        let words = decode_words(tokens, word_indices, overflowing);
+        assert!(words.is_empty());
+    }
+
+    #[test]
+    fn test_valid_mask_full() {
+        let word_indices = vec![
+            None,
+            Some(0),
+            Some(1),
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(3),
+            Some(4),
+            None,
+        ];
+        assert_eq!(
+            valid_mask(&word_indices).0,
+            [false, true, true, false, true, true, false, true, false],
+        );
+    }
+
+    #[test]
+    fn test_valid_mask_empty() {
+        assert_eq!(valid_mask(&[]).0, [] as [bool; 0]);
+    }
+}

--- a/kpe/src/tokenizer/key_phrase.rs
+++ b/kpe/src/tokenizer/key_phrase.rs
@@ -1,0 +1,284 @@
+use std::{borrow::Borrow, collections::HashMap};
+
+use derive_more::{Deref, From};
+use ndarray::Array2;
+
+use crate::tokenizer::encoding::ActiveMask;
+
+/// The collection of all potential key phrases.
+pub struct KeyPhrases {
+    choices: Vec<String>,
+    mentions: Vec<i64>,
+}
+
+/// The ranked key phrases in descending order.
+#[derive(Clone, Debug, Deref, From)]
+pub struct RankedKeyPhrases(Vec<String>);
+
+impl KeyPhrases {
+    /// Collects all potential key phrases from the words.
+    ///
+    /// Each key phrase contains at most `size` words.
+    pub fn collect(words: &[impl Borrow<str>], size: usize) -> Self {
+        if words.is_empty() {
+            return Self {
+                choices: Vec::new(),
+                mentions: Vec::new(),
+            };
+        }
+
+        let num_words = words.len();
+        let size = size.min(num_words);
+        let max_key_phrases = (0..size).into_iter().fold(0, |max, n| max + num_words - n);
+
+        let mut choices = Vec::with_capacity(max_key_phrases);
+        let mut mentions = Vec::with_capacity(max_key_phrases);
+        for n in 0..size {
+            let max_key_phrases = num_words - n;
+            let mut key_phrase_idx = HashMap::with_capacity(max_key_phrases);
+            for i in 0..max_key_phrases {
+                let key_phrase = words[i..i + n + 1].join(" ");
+                let idx = *key_phrase_idx.entry(key_phrase.clone()).or_insert_with(|| {
+                    choices.push(key_phrase);
+                    choices.len() as i64 - 1
+                });
+                mentions.push(idx);
+            }
+        }
+        choices.shrink_to_fit();
+
+        debug_assert_eq!(choices.len() as i64 - 1, *mentions.iter().max().unwrap());
+        debug_assert_eq!(mentions.len(), max_key_phrases);
+        debug_assert!(choices.len() <= mentions.len());
+
+        Self { choices, mentions }
+    }
+
+    /// Creates the mask of active/mentioned key phrases for each unique keyphrase.
+    pub fn active_mask(&self) -> ActiveMask {
+        Array2::from_shape_fn((self.choices.len(), self.mentions.len()), |(i, j)| {
+            i as i64 == self.mentions[j]
+        })
+        .into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ndarray::ArrayView2;
+
+    use super::*;
+
+    const UNIQUE_WORDS: [&str; 4] = ["this", "embedding", "fits", "perfectly"];
+    const DUPLICATE_WORDS: [&str; 9] = [
+        "this",
+        "embedding",
+        "fits",
+        "perfectly",
+        "and",
+        "this",
+        "embedding",
+        "fits",
+        "well",
+    ];
+    const FEW_WORDS: [&str; 2] = ["this", "embedding"];
+
+    #[test]
+    fn test_collect_unique() {
+        let size = 3;
+        let key_phrases = KeyPhrases::collect(&UNIQUE_WORDS, size);
+        assert_eq!(
+            key_phrases.choices,
+            [
+                "this",
+                "embedding",
+                "fits",
+                "perfectly",
+                "this embedding",
+                "embedding fits",
+                "fits perfectly",
+                "this embedding fits",
+                "embedding fits perfectly",
+            ],
+        );
+        assert_eq!(
+            key_phrases.mentions,
+            [
+                0, 1, 2, 3, //
+                4, 5, 6, //
+                7, 8, //
+            ],
+        );
+    }
+
+    #[test]
+    fn test_collect_duplicate() {
+        let size = 3;
+        let key_phrases = KeyPhrases::collect(&DUPLICATE_WORDS, size);
+        assert_eq!(
+            key_phrases.choices,
+            [
+                "this",
+                "embedding",
+                "fits",
+                "perfectly",
+                "and",
+                "well",
+                "this embedding",
+                "embedding fits",
+                "fits perfectly",
+                "perfectly and",
+                "and this",
+                "fits well",
+                "this embedding fits",
+                "embedding fits perfectly",
+                "fits perfectly and",
+                "perfectly and this",
+                "and this embedding",
+                "embedding fits well",
+            ],
+        );
+        assert_eq!(
+            key_phrases.mentions,
+            [
+                0, 1, 2, 3, 4, 0, 1, 2, 5, //
+                6, 7, 8, 9, 10, 6, 7, 11, //
+                12, 13, 14, 15, 16, 12, 17, //
+            ],
+        );
+    }
+
+    #[test]
+    fn test_collect_few() {
+        let size = 3;
+        let key_phrases = KeyPhrases::collect(&FEW_WORDS, size);
+        assert_eq!(key_phrases.choices, ["this", "embedding", "this embedding"]);
+        assert_eq!(
+            key_phrases.mentions,
+            [
+                0, 1, //
+                2, //
+            ],
+        );
+    }
+
+    #[test]
+    fn test_collect_empty() {
+        let key_phrases = KeyPhrases::collect(&[] as &[&str], 3);
+        assert!(key_phrases.choices.is_empty());
+        assert!(key_phrases.mentions.is_empty());
+    }
+
+    #[test]
+    fn test_mask_unique() {
+        assert_eq!(
+            KeyPhrases::collect(&UNIQUE_WORDS, 3).active_mask().0,
+            ArrayView2::from_shape(
+                (9, 9),
+                &[
+                    true, false, false, false, false, false, false, false, false, //
+                    false, true, false, false, false, false, false, false, false, //
+                    false, false, true, false, false, false, false, false, false, //
+                    false, false, false, true, false, false, false, false, false, //
+                    false, false, false, false, true, false, false, false, false, //
+                    false, false, false, false, false, true, false, false, false, //
+                    false, false, false, false, false, false, true, false, false, //
+                    false, false, false, false, false, false, false, true, false, //
+                    false, false, false, false, false, false, false, false, true, //
+                ],
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_mask_duplicate() {
+        assert_eq!(
+            KeyPhrases::collect(&DUPLICATE_WORDS, 3).active_mask().0,
+            ArrayView2::from_shape(
+                (18, 24),
+                &[
+                    true, false, false, false, false, true, false, false, false, false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, true, false, false, false, false, true, false, false, false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, true, false, false, false, false, true, false, false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, true, false, false, false, false, false, false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, true, false, false, false, false, false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, true, false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, true, false,
+                    false, false, false, true, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, true,
+                    false, false, false, false, true, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    true, false, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, true, false, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, true, false, false, false, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, false, false, false, true, false, false, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, false, false, false, false, true, false, false, false, false,
+                    true, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, false, false, false, false, false, true, false, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, false, false, false, false, false, false, true, false, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, false, false, false, false, false, false, false, true, false,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, false, false, false, false, false, false, false, false, true,
+                    false, false, //
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, false, false, false, false, false, false, false, false, false, false,
+                    false, true, //
+                ],
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_mask_few() {
+        assert_eq!(
+            KeyPhrases::collect(&FEW_WORDS, 3).active_mask().0,
+            ArrayView2::from_shape(
+                (3, 3),
+                &[
+                    true, false, false, //
+                    false, true, false, //
+                    false, false, true, //
+                ],
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_mask_empty() {
+        assert_eq!(
+            KeyPhrases::collect(&[] as &[&str], 3).active_mask().0,
+            ArrayView2::from_shape((0, 0), &[] as &[bool]).unwrap(),
+        );
+    }
+}

--- a/kpe/src/tokenizer/mod.rs
+++ b/kpe/src/tokenizer/mod.rs
@@ -1,0 +1,52 @@
+pub mod encoding;
+pub mod key_phrase;
+
+use std::io::BufRead;
+
+use displaydoc::Display;
+use rubert_tokenizer::{Builder, BuilderError, Padding, Tokenizer as BertTokenizer, Truncation};
+use thiserror::Error;
+
+/// A pre-configured Bert tokenizer for key phrase extraction.
+#[derive(Debug)]
+pub struct Tokenizer {
+    tokenizer: BertTokenizer<i64>,
+    token_size: usize,
+    key_phrase_size: usize,
+}
+
+/// The potential errors of the tokenizer.
+#[derive(Debug, Display, Error, PartialEq)]
+pub enum TokenizerError {
+    /// Failed to build the tokenizer: {0}
+    Builder(#[from] BuilderError),
+}
+
+impl Tokenizer {
+    /// Creates a tokenizer from a vocabulary.
+    ///
+    /// Can be set to keep accents and to lowercase the sequences. Requires the maximum number of
+    /// tokens per tokenized sequence, which applies to padding and truncation and includes special
+    /// tokens as well. Also requires the maximum number of words per key phrase.
+    pub fn new(
+        vocab: impl BufRead,
+        accents: bool,
+        lowercase: bool,
+        token_size: usize,
+        key_phrase_size: usize,
+    ) -> Result<Self, TokenizerError> {
+        let tokenizer = Builder::new(vocab)?
+            .with_normalizer(true, false, accents, lowercase)
+            .with_model("[UNK]", "##", 100)
+            .with_post_tokenizer("[CLS]", "[SEP]")
+            .with_truncation(Truncation::fixed(token_size, 0))
+            .with_padding(Padding::fixed(token_size, "[PAD]"))
+            .build()?;
+
+        Ok(Tokenizer {
+            tokenizer,
+            token_size,
+            key_phrase_size,
+        })
+    }
+}

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde = "1.0.130"
+serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"


### PR DESCRIPTION
**References**

- [TY-2085]

**Summary**

the original python source uses a lot of different names in various modules for the very same things, i'll try to link the important parts of the code to make it easier to review.

part [0] adds the tokenizer, the `token_ids`, `attention_mask` and `type_ids` are the same as for rubert, new additions are:
- `KeyPhrases` collector (cf. https://github.com/xaynetwork/xayn_ai_research/blob/main/experiments/preference_modeling/keyphrase_extraction/bert2joint/util.py#L44-L88)
- `valid_mask` and `active_mask` which come with the corresponding key phrase collector (cf. [python source](https://github.com/xaynetwork/xayn_ai_research/blob/main/experiments/preference_modeling/keyphrase_extraction/bert2joint/util.py#L91-L177))
