### PR TITLE
TY-2135 move ffi layer into separate file

### DIFF
--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -42,7 +42,7 @@ extension RerankModeToInt on RerankMode {
 class XaynAi {
   /// Creates and initializes the Xayn AI from a given state.
   ///
-  /// Requires the vocabulary and model of the tokenizer/embedder and the state.
+  /// Requires the necessary [SetupData] and the state.
   /// It will throw an error if the provided state is empty.
   static Future<XaynAi> restore(SetupData data, Uint8List serialized) async {
     throw UnsupportedError('Unsupported platform.');
@@ -50,7 +50,7 @@ class XaynAi {
 
   /// Creates and initializes the Xayn AI.
   ///
-  /// Requires the vocabulary and model of the tokenizer/embedder.
+  /// Requires the necessary [SetupData] for the AI.
   static Future<XaynAi> create(SetupData data) async {
     throw UnsupportedError('Unsupported platform.');
   }
@@ -58,8 +58,11 @@ class XaynAi {
   /// Reranks the documents.
   ///
   /// The list of ranks is in the same order as the documents.
-  Future<RerankingOutcomes> rerank(RerankMode mode, List<History> histories,
-          List<Document> documents) async =>
+  Future<RerankingOutcomes> rerank(
+    RerankMode mode,
+    List<History> histories,
+    List<Document> documents,
+  ) async =>
       throw UnsupportedError('Unsupported platform.');
 
   /// Serializes the current state of the reranker.

--- a/bindings/dart/lib/src/web/ffi/ai.dart
+++ b/bindings/dart/lib/src/web/ffi/ai.dart
@@ -66,25 +66,36 @@ class XaynAi implements common.XaynAi {
 
   /// Creates and initializes the Xayn AI and initializes the WASM module.
   ///
-  /// Requires the vocabulary and model of the tokenizer/embedder and the WASM
-  /// module. Optionally accepts the serialized reranker database, otherwise
-  /// creates a new one.
+  /// Requires the necessary [SetupData] for the AI. Optionally accepts the
+  /// serialized reranker database, otherwise creates a new one.
   static Future<XaynAi> create(SetupData data, [Uint8List? serialized]) async {
     await init(data.wasmModule);
-    return XaynAi._(data.smbertVocab, data.smbertModel, data.qambertVocab,
-        data.qambertModel, data.ltrModel, serialized);
+    return XaynAi._(
+      data.smbertVocab,
+      data.smbertModel,
+      data.qambertVocab,
+      data.qambertModel,
+      data.ltrModel,
+      serialized,
+    );
   }
 
   /// Creates and initializes the Xayn AI.
   ///
-  /// Requires the vocabulary and model of the tokenizer/embedder. Optionally accepts the serialized
-  /// reranker database, otherwise creates a new one.
+  /// Requires the vocabulary and model of the tokenizer/embedder and the LTR model.
+  /// Optionally accepts the serialized reranker database, otherwise creates a new one.
   XaynAi._(Uint8List smbertVocab, Uint8List smbertModel, Uint8List qambertVocab,
       Uint8List qambertModel, Uint8List ltrModel,
       [Uint8List? serialized]) {
     try {
-      _ai = _XaynAi(smbertVocab, smbertModel, qambertVocab, qambertModel,
-          ltrModel, serialized);
+      _ai = _XaynAi(
+        smbertVocab,
+        smbertModel,
+        qambertVocab,
+        qambertModel,
+        ltrModel,
+        serialized,
+      );
     } on XaynAiError catch (error) {
       throw error.toException();
     } on RuntimeError catch (error) {
@@ -96,20 +107,26 @@ class XaynAi implements common.XaynAi {
   ///
   /// The list of ranks is in the same order as the documents.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
-  Future<RerankingOutcomes> rerank(RerankMode mode, List<History> histories,
-      List<Document> documents) async {
+  Future<RerankingOutcomes> rerank(
+    RerankMode mode,
+    List<History> histories,
+    List<Document> documents,
+  ) async {
     if (_ai == null) {
       throw StateError('XaynAi was already freed');
     }
 
     try {
       return _ai!
-          .rerank(mode.toInt(), histories.toJsHistories(),
-              documents.toJsDocuments())
+          .rerank(
+            mode.toInt(),
+            histories.toJsHistories(),
+            documents.toJsDocuments(),
+          )
           .toRerankingOutcomes();
     } on XaynAiError catch (error) {
       throw error.toException();
@@ -123,9 +140,9 @@ class XaynAi implements common.XaynAi {
 
   /// Serializes the current state of the reranker.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<Uint8List> serialize() async {
     if (_ai == null) {
@@ -146,9 +163,9 @@ class XaynAi implements common.XaynAi {
   ///
   /// Faults can range from warnings to errors which are handled in some default way internally.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<List<String>> faults() async {
     if (_ai == null) {
@@ -165,9 +182,9 @@ class XaynAi implements common.XaynAi {
 
   /// Retrieves the analytics which were collected in the penultimate reranking.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<Analytics?> analytics() async {
     if (_ai == null) {
@@ -184,9 +201,9 @@ class XaynAi implements common.XaynAi {
 
   /// Serializes the synchronizable data of the reranker.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<Uint8List> syncdataBytes() async {
     if (_ai == null) {
@@ -205,9 +222,9 @@ class XaynAi implements common.XaynAi {
 
   /// Synchronizes the internal data of the reranker with another.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<void> synchronize(Uint8List serialized) async {
     if (_ai == null) {

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -22,19 +22,18 @@ import 'package:xayn_ai_ffi_dart/src/web/reranker/data_provider.dart'
 class XaynAi implements common.XaynAi {
   final ffi.XaynAi _ai;
 
-  /// Creates and initializes the Xayn AI from a given state and initializes the WASM module.
+  /// Creates and initializes the Xayn AI from a given state.
   ///
-  /// Requires the vocabulary and model of the tokenizer/embedder and the state.
+  /// Requires the necessary [SetupData] and the state.
   /// It will throw an error if the provided state is empty.
   static Future<XaynAi> restore(SetupData data, Uint8List serialized) async {
     final ai = await ffi.XaynAi.create(data, serialized);
     return XaynAi._(ai);
   }
 
-  /// Creates and initializes the Xayn AI and initializes the WASM module.
+  /// Creates and initializes the Xayn AI.
   ///
-  /// Requires the necessary [SetupData] for the AI. Optionally accepts the serialized reranker database, otherwise
-  /// creates a new one.
+  /// Requires the necessary [SetupData] for the AI.
   static Future<XaynAi> create(SetupData data) async {
     final ai = await ffi.XaynAi.create(data, null);
     return XaynAi._(ai);
@@ -42,28 +41,31 @@ class XaynAi implements common.XaynAi {
 
   /// Creates and initializes the Xayn AI.
   ///
-  /// Requires the vocabulary and model of the tokenizer/embedder. Optionally accepts the serialized
-  /// reranker database, otherwise creates a new one.
+  /// Requires the vocabulary and model of the tokenizer/embedder and the LTR model.
+  /// Optionally accepts the serialized reranker database, otherwise creates a new one.
   XaynAi._(this._ai);
 
   /// Reranks the documents.
   ///
   /// The list of ranks is in the same order as the documents.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
-  Future<RerankingOutcomes> rerank(RerankMode mode, List<History> histories,
-      List<Document> documents) async {
+  Future<RerankingOutcomes> rerank(
+    RerankMode mode,
+    List<History> histories,
+    List<Document> documents,
+  ) async {
     return await _ai.rerank(mode, histories, documents);
   }
 
   /// Serializes the current state of the reranker.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<Uint8List> serialize() async {
     return await _ai.serialize();
@@ -73,9 +75,9 @@ class XaynAi implements common.XaynAi {
   ///
   /// Faults can range from warnings to errors which are handled in some default way internally.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<List<String>> faults() async {
     return await _ai.faults();
@@ -83,9 +85,9 @@ class XaynAi implements common.XaynAi {
 
   /// Retrieves the analytics which were collected in the penultimate reranking.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<Analytics?> analytics() async {
     return await _ai.analytics();
@@ -93,9 +95,9 @@ class XaynAi implements common.XaynAi {
 
   /// Serializes the synchronizable data of the reranker.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<Uint8List> syncdataBytes() async {
     return await _ai.syncdataBytes();
@@ -103,9 +105,9 @@ class XaynAi implements common.XaynAi {
 
   /// Synchronizes the internal data of the reranker with another.
   ///
-  /// In case of a [`Code.panic`], the ai is dropped and its pointer invalidated. The last known
+  /// In case of a `Code.panic`, the ai is dropped and its pointer invalidated. The last known
   /// valid state can be restored with a previously serialized reranker database obtained from
-  /// [`serialize()`].
+  /// [XaynAi.serialize].
   @override
   Future<void> synchronize(Uint8List serialized) async {
     await _ai.synchronize(serialized);


### PR DESCRIPTION
Ticket:
- [TY-2135]

Summary:
- moved the ffi layer into separate file
- in the next PRs the ffi layer will be used in the web worker 

[TY-2135]: https://xainag.atlassian.net/browse/TY-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ