### PR TITLE
Add new methods to create AI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
-## 2.1 - 2021/09/15
+## 3.0 - 2021/10/21
 
 ### Added
 
 - AI data is synchronizable between devices via the new functions `syncdata_bytes` and `synchronize`.
 - Add multi-threading support: Parallelism is always enabled for mobile targets and can optionally be enabled for web targets. An optional set of `Feature`s is introduced to pick the assets for the chosen target during the setup (see `getInputData()`). Currently the only available `Feature` is `webParallel` (if not specified, the AI will run sequentially). The asset generation and publishing has been updated accordingly. For the AI to run in parallel on the web it is required that it runs on a WebWorker.
+- Add methods to instantiate the AI from a state: `restore`.
+
+### Changed
+- The method `create` does not accept anymore a serialized state and it can only be used to create a clean AI.
 
 ## 2.0.1 - 2021/09/07
 

--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -1,4 +1,5 @@
 import 'dart:convert' show jsonDecode;
+import 'dart:typed_data' show Uint8List;
 
 import 'package:flutter/material.dart' show debugPrint;
 import 'package:flutter/services.dart' show AssetBundle;
@@ -77,7 +78,7 @@ class Logic {
 
     final setupData = await getInputData(features: features);
 
-    final currentAi = await XaynAi.create(
+    final currentAi = await initAi(
         setupData, availableCallData[currentCallDataKey]?.serializedState);
 
     return Logic._(currentAi, setupData, availableCallData, currentCallDataKey);
@@ -95,8 +96,7 @@ class Logic {
 
   Future<void> resetXaynAiState() async {
     _currentAi.free();
-    _currentAi =
-        await XaynAi.create(_setupData, _currentCallData.serializedState);
+    _currentAi = await initAi(_setupData, _currentCallData.serializedState);
   }
 
   List<Outcome> run() {
@@ -112,6 +112,14 @@ class Logic {
     _currentAi
         .faults()
         .forEach((fault) => debugPrint('AI FAULT: $fault', wrapWidth: 1000));
+  }
+
+  static Future<XaynAi> initAi(SetupData setupData, Uint8List? serialized) {
+    if (serialized == null) {
+      return XaynAi.create(setupData);
+    } else {
+      return XaynAi.restore(setupData, serialized);
+    }
   }
 
   Stats benchmark() {

--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -40,11 +40,18 @@ extension RerankModeToInt on RerankMode {
 
 /// The Xayn AI.
 class XaynAi {
+  /// Creates and initializes the Xayn AI from a given state.
+  ///
+  /// Requires the vocabulary and model of the tokenizer/embedder and the state.
+  /// It will throw an error if the provided state is empty.
+  static Future<XaynAi> restore(SetupData data, Uint8List serialized) async {
+    throw UnsupportedError('Unsupported platform.');
+  }
+
   /// Creates and initializes the Xayn AI.
   ///
-  /// Requires the data to setup the AI, e.g. the vocabulary and model of the tokenizer/embedder.
-  /// Optionally accepts the serialized reranker database, otherwise creates a new one.
-  static Future<XaynAi> create(SetupData data, [Uint8List? serialized]) async {
+  /// Requires the vocabulary and model of the tokenizer/embedder.
+  static Future<XaynAi> create(SetupData data) async {
     throw UnsupportedError('Unsupported platform.');
   }
 

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -64,15 +64,25 @@ class _XaynAi {
 class XaynAi implements common.XaynAi {
   late _XaynAi? _ai;
 
+  /// Creates and initializes the Xayn AI from a given state and initializes the WASM module.
+  ///
+  /// Requires the vocabulary and model of the tokenizer/embedder and the state.
+  /// It will throw an error if the provided state is empty.
+  static Future<XaynAi> restore(SetupData data, Uint8List serialized) async {
+    await init(data.wasmModule);
+    return XaynAi._(data.smbertVocab, data.smbertModel, data.qambertVocab,
+        data.qambertModel, data.ltrModel, serialized);
+  }
+
   /// Creates and initializes the Xayn AI and initializes the WASM module.
   ///
   /// Requires the vocabulary and model of the tokenizer/embedder and the WASM
   /// module. Optionally accepts the serialized reranker database, otherwise
   /// creates a new one.
-  static Future<XaynAi> create(SetupData data, [Uint8List? serialized]) async {
+  static Future<XaynAi> create(SetupData data) async {
     await init(data.wasmModule);
     return XaynAi._(data.smbertVocab, data.smbertModel, data.qambertVocab,
-        data.qambertModel, data.ltrModel, serialized);
+        data.qambertModel, data.ltrModel, null);
   }
 
   /// Creates and initializes the Xayn AI.

--- a/bindings/dart/test/mobile/reranker/ai_test.dart
+++ b/bindings/dart/test/mobile/reranker/ai_test.dart
@@ -1,7 +1,16 @@
 import 'dart:typed_data' show Uint8List;
 
 import 'package:flutter_test/flutter_test.dart'
-    show contains, equals, expect, group, isEmpty, isNot, test;
+    show
+        contains,
+        equals,
+        expect,
+        group,
+        isEmpty,
+        isNot,
+        test,
+        throwsA,
+        TypeMatcher;
 
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/common/result/error.dart' show Code;
@@ -103,15 +112,16 @@ void main() {
     });
 
     test('empty serialized', () async {
-      final serialized = Uint8List(0);
-      final ai = await XaynAi.create(mkSetupData(), serialized);
-      ai.free();
+      expect(
+        () async => await XaynAi.restore(mkSetupData(), Uint8List(0)),
+        throwsA(TypeMatcher<ArgumentError>()),
+      );
     });
 
     test('invalid serialized', () {
       expect(
         () async =>
-            await XaynAi.create(mkSetupData(), Uint8List.fromList([255])),
+            await XaynAi.restore(mkSetupData(), Uint8List.fromList([255])),
         throwsXaynAiException(Code.rerankerDeserialization),
       );
     });


### PR DESCRIPTION
Add `createWithState` and `createEmpty` to create the AI. `create` has been deprecated.
This is to try to catch errors when we want to restore from a state but the serialized data is empty.

This PR target `staging`.