### PR TITLE
TY-2079 [0] Keep smbert and coi together

### DIFF
--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -11,7 +11,7 @@ use crate::{
         utils::{classify_documents_based_on_user_feedback, collect_matching_documents},
         CoiId,
     },
-    data::document_data::{CoiComponent, DocumentDataWithCoi, DocumentDataWithQAMBert},
+    data::document_data::{CoiComponent, DocumentDataWithCoi, DocumentDataWithSMBert},
     embedding::utils::{l2_distance, Embedding},
     reranker::systems::{self, CoiSystemData},
     DocumentHistory,
@@ -158,7 +158,7 @@ impl CoiSystem {
 impl systems::CoiSystem for CoiSystem {
     fn compute_coi(
         &self,
-        documents: Vec<DocumentDataWithQAMBert>,
+        documents: Vec<DocumentDataWithSMBert>,
         user_interests: &UserInterests,
     ) -> Result<Vec<DocumentDataWithCoi>, Error> {
         documents
@@ -207,7 +207,7 @@ impl NeutralCoiSystem {
 impl systems::CoiSystem for NeutralCoiSystem {
     fn compute_coi(
         &self,
-        documents: Vec<DocumentDataWithQAMBert>,
+        documents: Vec<DocumentDataWithSMBert>,
         _user_interests: &UserInterests,
     ) -> Result<Vec<DocumentDataWithCoi>, Error> {
         Ok(documents

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -73,8 +73,7 @@ pub(super) mod tests {
             CoiComponent,
             DocumentBaseComponent,
             DocumentContentComponent,
-            DocumentDataWithQAMBert,
-            QAMBertComponent,
+            DocumentDataWithSMBert,
             SMBertComponent,
         },
         utils::to_vec_of_ref_of,
@@ -122,7 +121,7 @@ pub(super) mod tests {
 
     pub(crate) fn create_data_with_embeddings(
         embeddings: &[impl FixedInitializer<Elem = f32>],
-    ) -> Vec<DocumentDataWithQAMBert> {
+    ) -> Vec<DocumentDataWithSMBert> {
         embeddings
             .iter()
             .enumerate()
@@ -136,8 +135,8 @@ pub(super) mod tests {
         id: u128,
         initial_ranking: usize,
         embedding: &[f32],
-    ) -> DocumentDataWithQAMBert {
-        DocumentDataWithQAMBert {
+    ) -> DocumentDataWithSMBert {
+        DocumentDataWithSMBert {
             document_base: DocumentBaseComponent {
                 id: DocumentId::from_u128(id),
                 initial_ranking,
@@ -148,7 +147,6 @@ pub(super) mod tests {
             smbert: SMBertComponent {
                 embedding: arr1(embedding).into(),
             },
-            qambert: QAMBertComponent { similarity: 0.5 },
         }
     }
 

--- a/xayn-ai/src/embedding/qambert.rs
+++ b/xayn-ai/src/embedding/qambert.rs
@@ -1,7 +1,7 @@
 use rubert::QAMBert;
 
 use crate::{
-    data::document_data::{DocumentDataWithQAMBert, DocumentDataWithSMBert, QAMBertComponent},
+    data::document_data::{DocumentDataWithCoi, DocumentDataWithQAMBert, QAMBertComponent},
     embedding::utils::l2_distance,
     error::Error,
     reranker::systems::QAMBertSystem,
@@ -13,7 +13,7 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 impl QAMBertSystem for QAMBert {
     fn compute_similarity(
         &self,
-        documents: Vec<DocumentDataWithSMBert>,
+        documents: Vec<DocumentDataWithCoi>,
     ) -> Result<Vec<DocumentDataWithQAMBert>, Error> {
         if let Some(document) = documents.first() {
             let query = &document.document_content.query_words;
@@ -62,7 +62,7 @@ impl NeutralQAMBert {
 impl QAMBertSystem for NeutralQAMBert {
     fn compute_similarity(
         &self,
-        documents: Vec<DocumentDataWithSMBert>,
+        documents: Vec<DocumentDataWithCoi>,
     ) -> Result<Vec<DocumentDataWithQAMBert>, Error> {
         Ok(documents
             .into_iter()

--- a/xayn-ai/src/ltr/features/mod.rs
+++ b/xayn-ai/src/ltr/features/mod.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 use crate::{
-    data::document_data::DocumentDataWithCoi,
+    data::document_data::DocumentDataWithQAMBert,
     DayOfWeek,
     DocumentHistory,
     QueryId,
@@ -90,8 +90,8 @@ pub struct DocSearchResult {
     pub(crate) initial_rank: Rank,
 }
 
-impl From<&DocumentDataWithCoi> for DocSearchResult {
-    fn from(doc_data: &DocumentDataWithCoi) -> Self {
+impl From<&DocumentDataWithQAMBert> for DocSearchResult {
+    fn from(doc_data: &DocumentDataWithQAMBert) -> Self {
         let initial_rank = doc_data.document_base.initial_ranking.into();
         let content = &doc_data.document_content;
         let query_words = content.query_words.split_whitespace().map_into().collect();

--- a/xayn-ai/src/ltr/mod.rs
+++ b/xayn-ai/src/ltr/mod.rs
@@ -15,7 +15,7 @@ use ndarray::{Array1, Array2};
 use crate::{
     data::{
         document::DocumentHistory,
-        document_data::{DocumentDataWithCoi, DocumentDataWithLtr, LtrComponent},
+        document_data::{DocumentDataWithLtr, DocumentDataWithQAMBert, LtrComponent},
     },
     error::Error,
     reranker::systems::LtrSystem,
@@ -35,7 +35,7 @@ impl LtrSystem for DomainReranker {
     fn compute_ltr(
         &self,
         history: &[DocumentHistory],
-        documents: Vec<DocumentDataWithCoi>,
+        documents: Vec<DocumentDataWithQAMBert>,
     ) -> Result<Vec<DocumentDataWithLtr>, Error> {
         let hists = history.iter().map_into().collect_vec();
         let docs = documents.iter().map_into().collect_vec();
@@ -99,7 +99,7 @@ impl LtrSystem for ConstLtr {
     fn compute_ltr(
         &self,
         _history: &[DocumentHistory],
-        documents: Vec<DocumentDataWithCoi>,
+        documents: Vec<DocumentDataWithQAMBert>,
     ) -> Result<Vec<DocumentDataWithLtr>, Error> {
         let ltr_score = Self::SCORE;
         Ok(documents
@@ -217,7 +217,7 @@ mod tests {
             pos_distance: 0.7,
             neg_distance: 0.2,
         };
-        let doc1 = DocumentDataWithCoi {
+        let doc1 = DocumentDataWithQAMBert {
             document_base: DocumentBaseComponent {
                 id,
                 initial_ranking: 24,
@@ -237,7 +237,7 @@ mod tests {
             pos_distance: 0.3,
             neg_distance: 0.9,
         };
-        let doc2 = DocumentDataWithCoi {
+        let doc2 = DocumentDataWithQAMBert {
             document_base: DocumentBaseComponent {
                 id,
                 initial_ranking: 42,

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -244,9 +244,9 @@ where
     ) -> Result<Vec<DocumentDataWithRank>, Error> {
         let documents = make_documents(documents);
         let documents = NeutralSMBert.compute_embedding(documents)?;
-        let documents = NeutralQAMBert.compute_similarity(documents)?;
         let documents =
             NeutralCoiSystem.compute_coi(documents, &self.data.sync_data.user_interests)?;
+        let documents = NeutralQAMBert.compute_similarity(documents)?;
         let documents = ConstLtr.compute_ltr(history, documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_identity(documents); // stable order needed
@@ -262,11 +262,11 @@ where
     ) -> Result<Vec<DocumentDataWithRank>, Error> {
         let documents = make_documents(documents);
         let documents = self.common_systems.smbert().compute_embedding(documents)?;
-        let documents = NeutralQAMBert.compute_similarity(documents)?;
         let documents = self
             .common_systems
             .coi()
             .compute_coi(documents, &self.data.sync_data.user_interests)?;
+        let documents = NeutralQAMBert.compute_similarity(documents)?;
         let documents = self.common_systems.ltr().compute_ltr(history, documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_context(documents);
@@ -282,12 +282,12 @@ where
     ) -> Result<Vec<DocumentDataWithRank>, Error> {
         let documents = make_documents(documents);
         let documents = NeutralSMBert.compute_embedding(documents)?;
+        let documents =
+            NeutralCoiSystem.compute_coi(documents, &self.data.sync_data.user_interests)?;
         let documents = self
             .common_systems
             .qambert()
             .compute_similarity(documents)?;
-        let documents =
-            NeutralCoiSystem.compute_coi(documents, &self.data.sync_data.user_interests)?;
         let documents = ConstLtr.compute_ltr(history, documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_context(documents);
@@ -305,12 +305,12 @@ where
         let documents = self.common_systems.smbert().compute_embedding(documents)?;
         let documents = self
             .common_systems
-            .qambert()
-            .compute_similarity(documents)?;
-        let documents = self
-            .common_systems
             .coi()
             .compute_coi(documents, &self.data.sync_data.user_interests)?;
+        let documents = self
+            .common_systems
+            .qambert()
+            .compute_similarity(documents)?;
         let documents = self.common_systems.ltr().compute_ltr(history, documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_context(documents);

--- a/xayn-ai/src/reranker/systems.rs
+++ b/xayn-ai/src/reranker/systems.rs
@@ -36,7 +36,7 @@ pub(crate) trait SMBertSystem {
 pub(crate) trait QAMBertSystem {
     fn compute_similarity(
         &self,
-        documents: Vec<DocumentDataWithSMBert>,
+        documents: Vec<DocumentDataWithCoi>,
     ) -> Result<Vec<DocumentDataWithQAMBert>, Error>;
 }
 
@@ -51,7 +51,7 @@ pub(crate) trait CoiSystem {
     /// Add centre of interest information to a document
     fn compute_coi(
         &self,
-        documents: Vec<DocumentDataWithQAMBert>,
+        documents: Vec<DocumentDataWithSMBert>,
         user_interests: &UserInterests,
     ) -> Result<Vec<DocumentDataWithCoi>, Error>;
 
@@ -69,7 +69,7 @@ pub(crate) trait LtrSystem {
     fn compute_ltr(
         &self,
         history: &[DocumentHistory],
-        documents: Vec<DocumentDataWithCoi>,
+        documents: Vec<DocumentDataWithQAMBert>,
     ) -> Result<Vec<DocumentDataWithLtr>, Error>;
 }
 

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -64,6 +64,7 @@ pub(crate) fn mocked_qambert_system() -> MockQAMBertSystem {
                 document_base: doc.document_base,
                 document_content: doc.document_content,
                 smbert: doc.smbert,
+                coi: doc.coi,
                 qambert: QAMBertComponent { similarity: 0.5 },
             })
             .collect())

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -15,6 +15,7 @@ use crate::{
             ContextComponent,
             DocumentBaseComponent,
             DocumentContentComponent,
+            DocumentDataWithCoi,
             DocumentDataWithDocument,
             DocumentDataWithRank,
             DocumentDataWithSMBert,
@@ -197,9 +198,9 @@ pub(crate) fn documents_with_embeddings_from_ids(ids: Range<u32>) -> Vec<Documen
 pub(crate) fn documents_with_embeddings_from_snippet_and_query(
     query: &str,
     snippets: &[&str],
-) -> Vec<DocumentDataWithSMBert> {
+) -> Vec<DocumentDataWithCoi> {
     from_ids(0..snippets.len() as u32)
-        .map(|(id, initial_ranking, embedding)| DocumentDataWithSMBert {
+        .map(|(id, initial_ranking, embedding)| DocumentDataWithCoi {
             document_base: DocumentBaseComponent {
                 id,
                 initial_ranking,
@@ -211,6 +212,11 @@ pub(crate) fn documents_with_embeddings_from_snippet_and_query(
                 ..Default::default()
             },
             smbert: SMBertComponent { embedding },
+            coi: CoiComponent {
+                id: CoiId::mocked(1),
+                pos_distance: 0.,
+                neg_distance: 0.,
+            },
         })
         .collect()
 }


### PR DESCRIPTION
The coi system depends on the smbert, keeping them in sequence helps in have cleaner code when we have to skip coi if smbert failed.

This mainly change DocumentData to have the order smbert, coi, qambert.
Who was taking in input:
`DocumentDataWithSMBert` now needs `DocumentDataWithCoi`,
`DocumentDataWithQAMBert` now needs `DocumentDataWithSMBert`,
`DocumentDataWithCoi` now needs `DocumentDataWithQAMBert`.
