### PR TITLE
TY 2079 [1] System takes documents as immutable 

### DIFF
--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -158,11 +158,11 @@ impl CoiSystem {
 impl systems::CoiSystem for CoiSystem {
     fn compute_coi(
         &self,
-        documents: Vec<DocumentDataWithSMBert>,
+        documents: &[DocumentDataWithSMBert],
         user_interests: &UserInterests,
     ) -> Result<Vec<DocumentDataWithCoi>, Error> {
         documents
-            .into_iter()
+            .iter()
             .map(|document| {
                 self.compute_coi_for_embedding(&document.smbert.embedding, user_interests)
                     .map(|coi| DocumentDataWithCoi::from_document(document, coi))
@@ -207,11 +207,11 @@ impl NeutralCoiSystem {
 impl systems::CoiSystem for NeutralCoiSystem {
     fn compute_coi(
         &self,
-        documents: Vec<DocumentDataWithSMBert>,
+        documents: &[DocumentDataWithSMBert],
         _user_interests: &UserInterests,
     ) -> Result<Vec<DocumentDataWithCoi>, Error> {
         Ok(documents
-            .into_iter()
+            .iter()
             .map(|document| DocumentDataWithCoi::from_document(document, Self::COI))
             .collect())
     }
@@ -466,7 +466,7 @@ mod tests {
         let documents = create_data_with_embeddings(&[[1., 4., 4.], [3., 6., 6.]]);
 
         let documents_coi = CoiSystem::default()
-            .compute_coi(documents, &user_interests)
+            .compute_coi(&documents, &user_interests)
             .unwrap();
 
         assert_eq!(documents_coi[0].coi.id, CoiId::mocked(1));
@@ -485,7 +485,7 @@ mod tests {
         let negative = create_neg_cois(&[[4., 5., 6.]]);
         let user_interests = UserInterests { positive, negative };
         let documents = create_data_with_embeddings(&[[NAN, NAN, NAN]]);
-        let _ = CoiSystem::default().compute_coi(documents, &user_interests);
+        let _ = CoiSystem::default().compute_coi(&documents, &user_interests);
     }
 
     #[test]
@@ -495,7 +495,7 @@ mod tests {
         let negative = create_neg_cois(&[[4., 5., 6.]]);
         let user_interests = UserInterests { positive, negative };
         let documents = create_data_with_embeddings(&[[1., NAN, 2.]]);
-        let _ = CoiSystem::default().compute_coi(documents, &user_interests);
+        let _ = CoiSystem::default().compute_coi(&documents, &user_interests);
     }
 
     #[test]

--- a/xayn-ai/src/data/document_data.rs
+++ b/xayn-ai/src/data/document_data.rs
@@ -7,15 +7,15 @@ use crate::{
     reranker::systems::CoiSystemData,
 };
 
-#[cfg_attr(test, derive(Debug, PartialEq, Clone))]
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct DocumentBaseComponent {
     pub(crate) id: DocumentId,
     pub(crate) initial_ranking: usize,
 }
 
-#[cfg_attr(test, derive(Debug, PartialEq, Clone, Default))]
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(Debug, PartialEq, Default))]
+#[derive(Clone, Serialize, Deserialize)]
 pub(crate) struct DocumentContentComponent {
     pub(crate) title: String,
     pub(crate) snippet: String,
@@ -28,15 +28,15 @@ pub(crate) struct DocumentContentComponent {
 }
 
 // TODO: the test-derived impls are temporarily available from rubert::utils::test_utils
-#[cfg_attr(test, derive(Debug, PartialEq, Clone))]
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Clone, Serialize, Deserialize)]
 #[allow(clippy::upper_case_acronyms)]
 pub(crate) struct SMBertComponent {
     pub(crate) embedding: Embedding,
 }
 
-#[cfg_attr(test, derive(Debug, PartialEq, Clone))]
-#[derive(Serialize, Deserialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Clone, Serialize, Deserialize)]
 #[allow(clippy::upper_case_acronyms)]
 pub(crate) struct QAMBertComponent {
     pub(crate) similarity: f32,
@@ -137,12 +137,12 @@ pub(crate) struct DocumentDataWithSMBert {
 
 impl DocumentDataWithSMBert {
     pub(crate) fn from_document(
-        document: DocumentDataWithDocument,
+        document: &DocumentDataWithDocument,
         smbert: SMBertComponent,
     ) -> Self {
         Self {
-            document_base: document.document_base,
-            document_content: document.document_content,
+            document_base: document.document_base.clone(),
+            document_content: document.document_content.clone(),
             smbert,
         }
     }
@@ -162,12 +162,12 @@ pub(crate) struct DocumentDataWithQAMBert {
 }
 
 impl DocumentDataWithQAMBert {
-    pub(crate) fn from_document(document: DocumentDataWithCoi, qambert: QAMBertComponent) -> Self {
+    pub(crate) fn from_document(document: &DocumentDataWithCoi, qambert: QAMBertComponent) -> Self {
         Self {
-            document_base: document.document_base,
-            document_content: document.document_content,
-            smbert: document.smbert,
-            coi: document.coi,
+            document_base: document.document_base.clone(),
+            document_content: document.document_content.clone(),
+            smbert: document.smbert.clone(),
+            coi: document.coi.clone(),
             qambert,
         }
     }
@@ -181,11 +181,11 @@ pub(crate) struct DocumentDataWithCoi {
 }
 
 impl DocumentDataWithCoi {
-    pub(crate) fn from_document(document: DocumentDataWithSMBert, coi: CoiComponent) -> Self {
+    pub(crate) fn from_document(document: &DocumentDataWithSMBert, coi: CoiComponent) -> Self {
         Self {
-            document_base: document.document_base,
-            document_content: document.document_content,
-            smbert: document.smbert,
+            document_base: document.document_base.clone(),
+            document_content: document.document_content.clone(),
+            smbert: document.smbert.clone(),
             coi,
         }
     }
@@ -201,12 +201,12 @@ pub(crate) struct DocumentDataWithLtr {
 }
 
 impl DocumentDataWithLtr {
-    pub(crate) fn from_document(document: DocumentDataWithQAMBert, ltr: LtrComponent) -> Self {
+    pub(crate) fn from_document(document: &DocumentDataWithQAMBert, ltr: LtrComponent) -> Self {
         Self {
-            document_base: document.document_base,
-            smbert: document.smbert,
-            qambert: document.qambert,
-            coi: document.coi,
+            document_base: document.document_base.clone(),
+            smbert: document.smbert.clone(),
+            qambert: document.qambert.clone(),
+            coi: document.coi.clone(),
             ltr,
         }
     }
@@ -303,7 +303,8 @@ mod tests {
         let embedding = SMBertComponent {
             embedding: arr1(&[1., 2., 3., 4.]).into(),
         };
-        let document_data = DocumentDataWithSMBert::from_document(document_data, embedding.clone());
+        let document_data =
+            DocumentDataWithSMBert::from_document(&document_data, embedding.clone());
         assert_eq!(document_data.document_base, document_id);
         assert_eq!(document_data.smbert, embedding);
 
@@ -313,19 +314,19 @@ mod tests {
             neg_distance: 0.2,
         };
 
-        let document_data = DocumentDataWithCoi::from_document(document_data, coi.clone());
+        let document_data = DocumentDataWithCoi::from_document(&document_data, coi.clone());
         assert_eq!(document_data.document_base, document_id);
         assert_eq!(document_data.smbert, embedding);
         assert_eq!(document_data.coi, coi);
 
         let qambert = QAMBertComponent { similarity: 0.5 };
-        let document_data = DocumentDataWithQAMBert::from_document(document_data, qambert.clone());
+        let document_data = DocumentDataWithQAMBert::from_document(&document_data, qambert.clone());
         assert_eq!(document_data.document_base, document_id);
         assert_eq!(document_data.smbert, embedding);
         assert_eq!(document_data.qambert, qambert);
 
         let ltr = LtrComponent { ltr_score: 0.3 };
-        let document_data = DocumentDataWithLtr::from_document(document_data, ltr.clone());
+        let document_data = DocumentDataWithLtr::from_document(&document_data, ltr.clone());
         assert_eq!(document_data.document_base, document_id);
         assert_eq!(document_data.smbert, embedding);
         assert_eq!(document_data.qambert, qambert);

--- a/xayn-ai/src/embedding/smbert.rs
+++ b/xayn-ai/src/embedding/smbert.rs
@@ -12,10 +12,10 @@ use rubert::SMBert;
 impl SMBertSystem for SMBert {
     fn compute_embedding(
         &self,
-        documents: Vec<DocumentDataWithDocument>,
+        documents: &[DocumentDataWithDocument],
     ) -> Result<Vec<DocumentDataWithSMBert>, Error> {
         #[cfg(not(feature = "multithreaded"))]
-        let documents = documents.into_iter();
+        let documents = documents.iter();
         #[cfg(feature = "multithreaded")]
         let documents = documents.into_par_iter();
 
@@ -42,10 +42,10 @@ pub struct NeutralSMBert;
 impl SMBertSystem for NeutralSMBert {
     fn compute_embedding(
         &self,
-        documents: Vec<DocumentDataWithDocument>,
+        documents: &[DocumentDataWithDocument],
     ) -> Result<Vec<DocumentDataWithSMBert>, Error> {
         Ok(documents
-            .into_iter()
+            .iter()
             .map(|document| {
                 DocumentDataWithSMBert::from_document(
                     document,

--- a/xayn-ai/src/ltr/mod.rs
+++ b/xayn-ai/src/ltr/mod.rs
@@ -32,7 +32,7 @@ impl LtrSystem for DomainReranker {
     fn compute_ltr(
         &self,
         history: &[DocumentHistory],
-        documents: Vec<DocumentDataWithQAMBert>,
+        documents: &[DocumentDataWithQAMBert],
     ) -> Result<Vec<DocumentDataWithLtr>, Error> {
         let hists = history.iter().map_into().collect_vec();
         let docs = documents.iter().map_into().collect_vec();
@@ -96,11 +96,11 @@ impl LtrSystem for ConstLtr {
     fn compute_ltr(
         &self,
         _history: &[DocumentHistory],
-        documents: Vec<DocumentDataWithQAMBert>,
+        documents: &[DocumentDataWithQAMBert],
     ) -> Result<Vec<DocumentDataWithLtr>, Error> {
         let ltr_score = Self::SCORE;
         Ok(documents
-            .into_iter()
+            .iter()
             .map(|doc| DocumentDataWithLtr::from_document(doc, LtrComponent { ltr_score }))
             .collect())
     }
@@ -247,7 +247,7 @@ mod tests {
             coi,
         };
 
-        let res = ConstLtr.compute_ltr(&[], vec![doc1, doc2]);
+        let res = ConstLtr.compute_ltr(&[], &vec![doc1, doc2]);
         assert!(res.is_ok());
         let ltr_docs = res.unwrap();
         assert_eq!(ltr_docs.len(), 2);

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -199,7 +199,7 @@ where
                 let prev_documents = self
                     .common_systems
                     .smbert()
-                    .compute_embedding(prev_documents)
+                    .compute_embedding(&prev_documents)
                     .unwrap_or_default();
                 self.data.prev_documents = PreviousDocuments::Embedding(prev_documents);
             } else {
@@ -243,11 +243,11 @@ where
         documents: &[Document],
     ) -> Result<Vec<DocumentDataWithRank>, Error> {
         let documents = make_documents(documents);
-        let documents = NeutralSMBert.compute_embedding(documents)?;
+        let documents = NeutralSMBert.compute_embedding(&documents)?;
         let documents =
-            NeutralCoiSystem.compute_coi(documents, &self.data.sync_data.user_interests)?;
-        let documents = NeutralQAMBert.compute_similarity(documents)?;
-        let documents = ConstLtr.compute_ltr(history, documents)?;
+            NeutralCoiSystem.compute_coi(&documents, &self.data.sync_data.user_interests)?;
+        let documents = NeutralQAMBert.compute_similarity(&documents)?;
+        let documents = ConstLtr.compute_ltr(history, &documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_identity(documents); // stable order needed
 
@@ -261,13 +261,13 @@ where
         documents: &[Document],
     ) -> Result<Vec<DocumentDataWithRank>, Error> {
         let documents = make_documents(documents);
-        let documents = self.common_systems.smbert().compute_embedding(documents)?;
+        let documents = self.common_systems.smbert().compute_embedding(&documents)?;
         let documents = self
             .common_systems
             .coi()
-            .compute_coi(documents, &self.data.sync_data.user_interests)?;
-        let documents = NeutralQAMBert.compute_similarity(documents)?;
-        let documents = self.common_systems.ltr().compute_ltr(history, documents)?;
+            .compute_coi(&documents, &self.data.sync_data.user_interests)?;
+        let documents = NeutralQAMBert.compute_similarity(&documents)?;
+        let documents = self.common_systems.ltr().compute_ltr(history, &documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_context(documents);
 
@@ -281,14 +281,14 @@ where
         documents: &[Document],
     ) -> Result<Vec<DocumentDataWithRank>, Error> {
         let documents = make_documents(documents);
-        let documents = NeutralSMBert.compute_embedding(documents)?;
+        let documents = NeutralSMBert.compute_embedding(&documents)?;
         let documents =
-            NeutralCoiSystem.compute_coi(documents, &self.data.sync_data.user_interests)?;
+            NeutralCoiSystem.compute_coi(&documents, &self.data.sync_data.user_interests)?;
         let documents = self
             .common_systems
             .qambert()
-            .compute_similarity(documents)?;
-        let documents = ConstLtr.compute_ltr(history, documents)?;
+            .compute_similarity(&documents)?;
+        let documents = ConstLtr.compute_ltr(history, &documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_context(documents);
 
@@ -302,16 +302,16 @@ where
         documents: &[Document],
     ) -> Result<Vec<DocumentDataWithRank>, Error> {
         let documents = make_documents(documents);
-        let documents = self.common_systems.smbert().compute_embedding(documents)?;
+        let documents = self.common_systems.smbert().compute_embedding(&documents)?;
         let documents = self
             .common_systems
             .coi()
-            .compute_coi(documents, &self.data.sync_data.user_interests)?;
+            .compute_coi(&documents, &self.data.sync_data.user_interests)?;
         let documents = self
             .common_systems
             .qambert()
-            .compute_similarity(documents)?;
-        let documents = self.common_systems.ltr().compute_ltr(history, documents)?;
+            .compute_similarity(&documents)?;
+        let documents = self.common_systems.ltr().compute_ltr(history, &documents)?;
         let documents = self.common_systems.context().compute_context(documents)?;
         let documents = rank_by_context(documents);
 

--- a/xayn-ai/src/reranker/systems.rs
+++ b/xayn-ai/src/reranker/systems.rs
@@ -27,7 +27,7 @@ use mockall::automock;
 pub(crate) trait SMBertSystem {
     fn compute_embedding(
         &self,
-        documents: Vec<DocumentDataWithDocument>,
+        documents: &[DocumentDataWithDocument],
     ) -> Result<Vec<DocumentDataWithSMBert>, Error>;
 }
 
@@ -36,7 +36,7 @@ pub(crate) trait SMBertSystem {
 pub(crate) trait QAMBertSystem {
     fn compute_similarity(
         &self,
-        documents: Vec<DocumentDataWithCoi>,
+        documents: &[DocumentDataWithCoi],
     ) -> Result<Vec<DocumentDataWithQAMBert>, Error>;
 }
 
@@ -51,7 +51,7 @@ pub(crate) trait CoiSystem {
     /// Add centre of interest information to a document
     fn compute_coi(
         &self,
-        documents: Vec<DocumentDataWithSMBert>,
+        documents: &[DocumentDataWithSMBert],
         user_interests: &UserInterests,
     ) -> Result<Vec<DocumentDataWithCoi>, Error>;
 
@@ -69,7 +69,7 @@ pub(crate) trait LtrSystem {
     fn compute_ltr(
         &self,
         history: &[DocumentHistory],
-        documents: Vec<DocumentDataWithQAMBert>,
+        documents: &[DocumentDataWithQAMBert],
     ) -> Result<Vec<DocumentDataWithLtr>, Error>;
 }
 

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -30,7 +30,7 @@ pub(crate) fn mocked_smbert_system() -> MockSMBertSystem {
     let mut mock_smbert = MockSMBertSystem::new();
     mock_smbert.expect_compute_embedding().returning(|docs| {
         Ok(docs
-            .into_iter()
+            .iter()
             .map(|doc| {
                 let mut embedding: Vec<f32> = doc
                     .document_content
@@ -43,8 +43,8 @@ pub(crate) fn mocked_smbert_system() -> MockSMBertSystem {
                 embedding.resize(128, 0.);
 
                 DocumentDataWithSMBert {
-                    document_base: doc.document_base,
-                    document_content: doc.document_content,
+                    document_base: doc.document_base.clone(),
+                    document_content: doc.document_content.clone(),
                     smbert: SMBertComponent {
                         embedding: arr1(&embedding).into(),
                     },
@@ -59,12 +59,12 @@ pub(crate) fn mocked_qambert_system() -> MockQAMBertSystem {
     let mut mock_qambert = MockQAMBertSystem::new();
     mock_qambert.expect_compute_similarity().returning(|docs| {
         Ok(docs
-            .into_iter()
+            .iter()
             .map(|doc| DocumentDataWithQAMBert {
-                document_base: doc.document_base,
-                document_content: doc.document_content,
-                smbert: doc.smbert,
-                coi: doc.coi,
+                document_base: doc.document_base.clone(),
+                document_content: doc.document_content.clone(),
+                smbert: doc.smbert.clone(),
+                coi: doc.coi.clone(),
                 qambert: QAMBertComponent { similarity: 0.5 },
             })
             .collect())

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -89,10 +89,10 @@ fn cois_from_words<CP: CoiPoint>(
                 ..Default::default()
             },
         })
-        .collect();
+        .collect::<Vec<_>>();
 
     smbert
-        .compute_embedding(documents)
+        .compute_embedding(&documents)
         .unwrap()
         .into_iter()
         .enumerate()


### PR DESCRIPTION
Since now we want to have fallback strategies we cannot take ownership of the documents in the systems.
Systems are now taking a slice.

I didn't do it for the context system because it is the last one that gets the data and there is not fallback for it.

This is based on #265, only the last commit belongs to this PR.