### PR TITLE
Increase andorid build timeout, decrease push to release repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,7 @@ jobs:
     name: build-release-android-libs
     needs: [cargo-registry-cache, install-cargo-ndk]
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       matrix:
         target: [aarch64-linux-android, armv7-linux-androideabi, i686-linux-android, x86_64-linux-android]
@@ -501,7 +501,7 @@ jobs:
       - build-release-ios-libs
       - build-asset-artifacts
       - publish-asset-artifacts
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@3c9b0fc6f2d223b8450b02a0445f526350fc73e0 # v2.3.1


### PR DESCRIPTION
Building android on the release CI is failing.
Pushing to the release repo takes only a couple of minutes.