### PR TITLE
[Merged by Bors] - TY-2136 impl kpe models manually [1]

### DIFF
--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -261,7 +261,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "not implemented: ATen/native/")]
+    #[should_panic(expected = "not implemented: ATen/native/cpu/Unfold2d")]
     fn test_conv1d_padding_with_nonsingleton_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "not implemented: ATen/native/")]
+    #[should_panic(expected = "not implemented: ATen/native/cpu/Unfold2d")]
     fn test_conv1d_padding_with_singleton_kernel() {
         let weights = Array1::range(0., 6., 1.).into_shape((2, 3, 1)).unwrap();
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
@@ -305,7 +305,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "not implemented: ATen/native/")]
+    #[should_panic(expected = "not implemented: ATen/native/NaiveDilatedConvolution")]
     fn test_conv1d_dilation() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
@@ -318,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "not implemented: ATen/native/")]
+    #[should_panic(expected = "not implemented: ATen/native/Convolution")]
     fn test_conv1d_groups() {
         let weights = Array1::range(0., 24., 1.).into_shape((2, 4, 3)).unwrap();
         let input = Array1::range(0., 80., 1.).into_shape((2, 8, 5)).unwrap();

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -1,0 +1,204 @@
+use ndarray::{Array1, Array3, ArrayBase, Data, Ix3, s};
+
+use crate::utils::IncompatibleMatrices;
+
+// not transposed, zero output padding
+pub struct Conv1D {
+    weights: Array3<f32>,
+    bias: Option<Array1<f32>>,
+
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+    groups: usize,
+}
+
+impl Conv1D {
+    pub fn new(
+        weights: Array3<f32>,
+        bias: Option<Array1<f32>>,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<Self, IncompatibleMatrices> {
+        assert!(!weights.is_empty());
+        assert!(stride > 0, "non-positive stride is not supported");
+        assert!(dilation > 0, "non-positive dilation is not supported");
+        assert!(groups > 0, "non-positive groups is not supported");
+        let weights_shape = weights.shape();
+        assert!(
+            groups <= weights_shape[0],
+            "Given groups={}, expected weight to be at least {} at dimension 0, but got weight of size {:?} instead",
+            groups,
+            groups,
+            weights_shape,
+        );
+        assert_eq!(
+            weights_shape[0] % groups,
+            0,
+            "Given groups={}, expected weight to be divisible by {} at dimension 0, but got weight of size {:?} instead",
+            groups,
+            groups, 
+            weights_shape,
+        );
+        if let Some(ref bias) = bias {
+            assert!(!bias.is_empty());
+            let bias_shape = bias.shape();
+            assert_eq!(
+                bias_shape[0],
+                weights_shape[0],
+                "Given weight of size {:?}, expected bias to be 1-dimensional with {} elements, but got bias of size {:?} instead",
+                weights_shape,
+                weights_shape[0],
+                bias_shape,
+            );
+        }
+
+        Ok(Self {
+            weights,
+            bias,
+            stride,
+            padding,
+            dilation,
+            groups,
+        })
+    }
+
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L820
+    pub fn run<S>(&self, input: ArrayBase<S, Ix3>) -> Array3<f32>
+    where
+        S: Data<Elem = f32>,
+    {
+        let input_shape = input.shape();
+        let weights_shape = self.weights.shape();
+        assert_eq!(
+            input_shape[1],
+            weights_shape[1] * self.groups,
+            "Given groups={}, weight of size {:?}, expected input {:?} to have {} channels, but got {} channels instead",
+            self.groups,
+            weights_shape,
+            input_shape, 
+            weights_shape[1] * self.groups,
+            input_shape[1],
+        );
+        let input_size = input_shape[2] + 2 * self.padding;
+        let kernel_size = self.dilation * (weights_shape[2] - 1) + 1;
+        // d * (s2 - 1) + 1 - s2 = (d - 1) * s2 - d + 1 = (d - 1) * s2 - (d - 1) = (d - 1) * (s2 - 1) >= 0
+        // => input_size >= kernel_size >= weights_shape[2]
+        assert!(
+            input_size >= kernel_size,
+            "Calculated padded input size per channel: {}. Kernel size: {}. Kernel size can't be greater than actual input size.",
+            input_size,
+            kernel_size,
+        );
+
+        let output_size = (input_size - kernel_size) / self.stride + 1;
+        if input.is_empty() {
+            return Array3::zeros([0, self.weights.shape()[0], output_size]);
+        }
+
+        // view weights and input as 4D via reshape(shape0, shape1, 1, shape2)
+
+        if self.groups > 1 {
+            unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1032-L1041");
+        }
+
+        // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1070
+        if self.dilation > 1 {
+            unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/NaiveDilatedConvolution.cpp#L434");
+        } else {
+            let _kernel_height = 1;
+            let kernel_width = weights_shape[2];
+            let _pad_height = 0;
+            let pad_width = self.padding;
+            let _stride_height = 1;
+            let stride_width = self.stride;
+
+            let n_input_plane = input_shape[1];
+            let _input_height = 1;
+            let input_width = input_shape[2];
+            let n_output_plane = weights_shape[0];
+            let _output_height = 1;
+            let output_width = output_size;
+            let batch_size = input_shape[0];
+
+            // TODO: reshape only once in `new`
+            let weights = self.weights.view().into_shape((weights_shape[0], weights_shape[1] * weights_shape[2])).unwrap();
+
+            // TODO: move this into batch_size loop
+            let mut finput = if kernel_width == 1 && stride_width == 1 && pad_width == 0 {
+                // output_width == input_shape[2]
+                input.to_owned().into_shape((input_shape[0], input_shape[1], output_width)).unwrap()
+            } else {
+                Array3::zeros((input_shape[0], input_shape[1] * kernel_width, output_width))
+            };
+            
+            // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/ConvolutionMM2d.cpp#L140
+            let mut output = Array3::<f32>::zeros([
+                batch_size,
+                n_output_plane, /* ws0 */
+                output_width,   /* is2 - ws2 + 1 */
+            ]);
+            for i in 0..batch_size {
+                let input = input.slice(s![i, .., ..]);
+                let mut finput = finput.slice_mut(s![i, .., ..]);
+                let mut output = output.slice_mut(s![i, .., ..]);
+                if kernel_width != 1 || stride_width != 1 || pad_width != 0 {
+                    let input = input.as_slice().unwrap();
+                    let finput = finput.as_slice_mut().unwrap();
+
+                    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160
+                    for k in 0..n_input_plane * kernel_width {
+                        let nip = k / kernel_width;
+                        let rest = k % kernel_width;
+                        let kh = rest / kernel_width;
+                        let kw = rest % kernel_width;
+    
+                        if pad_width > 0 {
+                            unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160");
+                        } else if stride_width == 1 {
+                            let src = nip*input_width + kh*input_width + kw;
+                            let dst = nip * kernel_width * output_width + kh * kernel_width * output_width + kw * output_width;
+                            finput[dst..dst+output_width].copy_from_slice(&input[src..src+output_width]);
+                        } else {
+                            unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160");
+                        }
+                    }
+                }
+                // multiply weights with input[i, ..] and assign to output[i, ..]
+                // weights: (ws0, ws1 * ws2), input: (is0, is1 * ws2, is2 - ws2 + 1) => ws1 == is1 is guaranteed above
+                output.assign(&weights.dot(&finput));
+            }
+
+            if let Some(ref bias) = self.bias {
+                // view 1D bias as 3D via reshape(1, shape0, 1)
+                output = output + bias.view().into_shape((1, bias.len(), 1)).unwrap();
+            }
+
+            output
+        }
+
+
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ndarray::arr3;
+
+    use test_utils::assert_approx_eq;
+    use super::*;
+
+    #[test]
+    fn test_conv1d() {
+        let weights = (0..18).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 3)).unwrap();
+        let input = (0..30).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 5)).unwrap();
+        let output = Conv1D::new(weights, None, 1, 0, 1, 1).unwrap().run(input);
+        let expected = arr3(&[[[ 312.,  348.,  384.],
+            [ 798.,  915., 1032.]],
+           [[ 852.,  888.,  924.],
+            [2553., 2670., 2787.]]]);
+        assert_approx_eq!(f32, output, expected);
+    }
+}

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -242,7 +242,7 @@ mod tests {
             [[312., 384.], [798., 1032.]],
             [[852., 924.], [2553., 2787.]],
         ]);
-        assert_approx_eq!(f32, dbg!(output), expected);
+        assert_approx_eq!(f32, output, expected);
     }
 
     #[test]
@@ -257,7 +257,7 @@ mod tests {
             [[25., 31., 37.], [70., 94., 118.]],
             [[70., 76., 82.], [250., 274., 298.]],
         ]);
-        assert_approx_eq!(f32, dbg!(output), expected);
+        assert_approx_eq!(f32, output, expected);
     }
 
     #[test]

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -14,6 +14,7 @@ pub struct Conv1D {
 }
 
 impl Conv1D {
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L515
     pub fn new(
         weights: Array3<f32>,
         bias: Option<Array1<f32>>,
@@ -84,8 +85,6 @@ impl Conv1D {
         );
         let input_size = input_shape[2] + 2 * self.padding;
         let kernel_size = self.dilation * (weights_shape[2] - 1) + 1;
-        // d * (s2 - 1) + 1 - s2 = (d - 1) * s2 - d + 1 = (d - 1) * s2 - (d - 1) = (d - 1) * (s2 - 1) >= 0
-        // => input_size >= kernel_size >= weights_shape[2]
         assert!(
             input_size >= kernel_size,
             "Calculated padded input size per channel: {}. Kernel size: {}. Kernel size can't be greater than actual input size.",
@@ -98,88 +97,82 @@ impl Conv1D {
             return Array3::zeros([0, self.weights.shape()[0], output_size]);
         }
 
-        // view weights and input as 4D via reshape(shape0, shape1, 1, shape2)
-
         if self.groups > 1 {
             unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1032-L1041");
         }
 
-        // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1070
         if self.dilation > 1 {
             unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/NaiveDilatedConvolution.cpp#L434");
-        } else {
-            let _kernel_height = 1;
-            let kernel_width = weights_shape[2];
-            let _pad_height = 0;
-            let pad_width = self.padding;
-            let _stride_height = 1;
-            let stride_width = self.stride;
-
-            let n_input_plane = input_shape[1];
-            let _input_height = 1;
-            let input_width = input_shape[2];
-            let n_output_plane = weights_shape[0];
-            let _output_height = 1;
-            let output_width = output_size;
-            let batch_size = input_shape[0];
-
-            // TODO: reshape only once in `new`
-            let weights = self.weights.view().into_shape((weights_shape[0], weights_shape[1] * weights_shape[2])).unwrap();
-
-            // TODO: move this into batch_size loop
-            let mut finput = if kernel_width == 1 && stride_width == 1 && pad_width == 0 {
-                // output_width == input_shape[2]
-                input.to_owned().into_shape((input_shape[0], input_shape[1], output_width)).unwrap()
-            } else {
-                Array3::zeros((input_shape[0], input_shape[1] * kernel_width, output_width))
-            };
-            
-            // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/ConvolutionMM2d.cpp#L140
-            let mut output = Array3::<f32>::zeros([
-                batch_size,
-                n_output_plane, /* ws0 */
-                output_width,   /* is2 - ws2 + 1 */
-            ]);
-            for i in 0..batch_size {
-                let input = input.slice(s![i, .., ..]);
-                let mut finput = finput.slice_mut(s![i, .., ..]);
-                let mut output = output.slice_mut(s![i, .., ..]);
-                if kernel_width != 1 || stride_width != 1 || pad_width != 0 {
-                    let input = input.as_slice().unwrap();
-                    let finput = finput.as_slice_mut().unwrap();
-
-                    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160
-                    for k in 0..n_input_plane * kernel_width {
-                        let nip = k / kernel_width;
-                        let rest = k % kernel_width;
-                        let kh = rest / kernel_width;
-                        let kw = rest % kernel_width;
-    
-                        if pad_width > 0 {
-                            unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160");
-                        } else if stride_width == 1 {
-                            let src = nip*input_width + kh*input_width + kw;
-                            let dst = nip * kernel_width * output_width + kh * kernel_width * output_width + kw * output_width;
-                            finput[dst..dst+output_width].copy_from_slice(&input[src..src+output_width]);
-                        } else {
-                            unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160");
-                        }
-                    }
-                }
-                // multiply weights with input[i, ..] and assign to output[i, ..]
-                // weights: (ws0, ws1 * ws2), input: (is0, is1 * ws2, is2 - ws2 + 1) => ws1 == is1 is guaranteed above
-                output.assign(&weights.dot(&finput));
-            }
-
-            if let Some(ref bias) = self.bias {
-                // view 1D bias as 3D via reshape(1, shape0, 1)
-                output = output + bias.view().into_shape((1, bias.len(), 1)).unwrap();
-            }
-
-            output
         }
 
+        // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1070
+        let _kernel_height = 1;
+        let kernel_width = weights_shape[2];
+        let _pad_height = 0;
+        let pad_width = self.padding;
+        let _stride_height = 1;
+        let stride_width = self.stride;
 
+        let n_input_plane = input_shape[1];
+        let _input_height = 1;
+        let input_width = input_shape[2];
+        let n_output_plane = weights_shape[0];
+        let _output_height = 1;
+        let output_width = output_size;
+        let batch_size = input_shape[0];
+
+        // TODO: reshape only once in `new`
+        let weights = self.weights.view().into_shape((weights_shape[0], weights_shape[1] * weights_shape[2])).unwrap();
+
+        // TODO: move this into batch_size loop
+        let mut finput = if kernel_width == 1 && stride_width == 1 && pad_width == 0 {
+            // output_width == input_shape[2]
+            input.to_owned().into_shape((input_shape[0], input_shape[1], output_width)).unwrap()
+        } else {
+            Array3::zeros((input_shape[0], input_shape[1] * kernel_width, output_width))
+        };
+        
+        // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/ConvolutionMM2d.cpp#L140
+        let mut output = Array3::<f32>::zeros([
+            batch_size,
+            n_output_plane, /* ws0 */
+            output_width,   /* is2 - ws2 + 1 */
+        ]);
+        for i in 0..batch_size {
+            let input = input.slice(s![i, .., ..]);
+            let mut finput = finput.slice_mut(s![i, .., ..]);
+            let mut output = output.slice_mut(s![i, .., ..]);
+            if kernel_width != 1 || stride_width != 1 || pad_width != 0 {
+                let input = input.as_slice().unwrap();
+                let finput = finput.as_slice_mut().unwrap();
+
+                // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160
+                for k in 0..n_input_plane * kernel_width {
+                    let nip = k / kernel_width;
+                    let rest = k % kernel_width;
+                    let kh = rest / kernel_width;
+                    let kw = rest % kernel_width;
+
+                    if pad_width > 0 || stride_width > 1 {
+                        unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160");
+                    } else {
+                        let src = nip*input_width + kh*input_width + kw;
+                        let dst = nip * kernel_width * output_width + kh * kernel_width * output_width + kw * output_width;
+                        finput[dst..dst+output_width].copy_from_slice(&input[src..src+output_width]);
+                    }
+                }
+            }
+            // multiply weights with input[i, ..] and assign to output[i, ..]
+            // weights: (ws0, ws1 * ws2), input: (is0, is1 * ws2, is2 - ws2 + 1) => ws1 == is1 is guaranteed above
+            output.assign(&weights.dot(&finput));
+        }
+
+        if let Some(ref bias) = self.bias {
+            // view 1D bias as 3D via reshape(1, shape0, 1)
+            output = output + bias.view().into_shape((1, bias.len(), 1)).unwrap();
+        }
+
+        output
     }
 }
 
@@ -190,8 +183,9 @@ mod tests {
     use test_utils::assert_approx_eq;
     use super::*;
 
+    // https://github.com/pytorch/pytorch/blob/master/test/cpp/api/functional.cpp#L13
     #[test]
-    fn test_conv1d() {
+    fn test_conv1d_wide_kernel() {
         let weights = (0..18).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 3)).unwrap();
         let input = (0..30).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, None, 1, 0, 1, 1).unwrap().run(input);
@@ -199,6 +193,83 @@ mod tests {
             [ 798.,  915., 1032.]],
            [[ 852.,  888.,  924.],
             [2553., 2670., 2787.]]]);
+        assert_approx_eq!(f32, output, expected);
+    }
+
+    #[test]
+    fn test_conv1d_single_kernel() {
+        let weights = (0..6).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 1)).unwrap();
+        let input = (0..30).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 5)).unwrap();
+        let output = Conv1D::new(weights, None, 1, 0, 1, 1).unwrap().run(input);
+        let expected = arr3(&[[[ 25.,  28.,  31.,  34.,  37.],
+            [ 70.,  82.,  94., 106., 118.]],
+           [[ 70.,  73.,  76.,  79.,  82.],
+            [250., 262., 274., 286., 298.]]]);
+        assert_approx_eq!(f32, output, expected);
+    }
+
+    #[test]
+    #[ignore = "unimplemented"]
+    fn test_conv1d_stride() {
+        let weights = (0..18).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 3)).unwrap();
+        let input = (0..30).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 5)).unwrap();
+        let output = Conv1D::new(weights, None, 2, 0, 1, 1).unwrap().run(input);
+        let expected = arr3(&[[[ 312.,  384.],
+            [ 798., 1032.]],
+           [[ 852.,  924.],
+            [2553., 2787.]]]);
+        assert_approx_eq!(f32, output, expected);
+    }
+
+    #[test]
+    #[ignore = "unimplemented"]
+    fn test_conv1d_pad() {
+        let weights = (0..18).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 3)).unwrap();
+        let input = (0..30).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 5)).unwrap();
+        let output = Conv1D::new(weights, None, 1, 1, 1, 1).unwrap().run(input);
+        let expected = arr3(&[[[ 210.,  312.,  348.,  384.,  240.],
+            [ 507.,  798.,  915., 1032.,  699.]],
+           [[ 615.,  852.,  888.,  924.,  555.],
+            [1722., 2553., 2670., 2787., 1824.]]]);
+        assert_approx_eq!(f32, output, expected);
+    }
+
+    #[test]
+    #[ignore = "unimplemented"]
+    fn test_conv1d_dilation() {
+        let weights = (0..18).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 3)).unwrap();
+        let input = (0..30).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 5)).unwrap();
+        let output = Conv1D::new(weights, None, 1, 0, 2, 1).unwrap().run(input);
+        let expected = arr3(&[[[ 354.],
+            [ 921.]],
+           [[ 894.],
+            [2676.]]]);
+        assert_approx_eq!(f32, output, expected);
+    }
+
+    #[test]
+    #[ignore = "unimplemented"]
+    fn test_conv1d_groups() {
+        let weights = (0..24).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 4, 3)).unwrap();
+        let input = (0..80).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 8, 5)).unwrap();
+        let output = Conv1D::new(weights, None, 1, 0, 1, 2).unwrap().run(input);
+        let expected = arr3(&[[[  794.,   860.,   926.],
+            [ 6218.,  6428.,  6638.]],
+           [[ 3434.,  3500.,  3566.],
+            [14618., 14828., 15038.]]]);
+        assert_approx_eq!(f32, output, expected);
+    }
+
+    #[test]
+    fn test_conv1d_bias() {
+        let weights = (0..18).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 3)).unwrap();
+        let bias = (0..2).map(|e| e as f32).collect::<Array1<f32>>();
+        let input = (0..30).map(|e| e as f32).collect::<Array1<f32>>().into_shape((2, 3, 5)).unwrap();
+        let output = Conv1D::new(weights, Some(bias), 1, 0, 1, 1).unwrap().run(input);
+        let expected = arr3(&[[[ 312.,  348.,  384.],
+            [ 799.,  916., 1033.]],
+           [[ 852.,  888.,  924.],
+            [2554., 2671., 2788.]]]);
         assert_approx_eq!(f32, output, expected);
     }
 }

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -1,15 +1,25 @@
-use ndarray::{s, Array1, Array3, ArrayBase, Data, Ix3};
+// TODO: refactor looped assignments as iterator collections
+
+use ndarray::{s, Array1, Array2, Array3, ArrayBase, ArrayView2, Data, Ix3};
 
 use crate::utils::IncompatibleMatrices;
 
 pub struct Conv1D {
-    weights: Array3<f32>,
-    bias: Option<Array1<f32>>,
+    // params
+    weights: Array2<f32>,
+    bias: Option<Array3<f32>>,
 
+    // configs
     stride: usize,
     padding: usize,
     dilation: usize,
     groups: usize,
+
+    // shapes
+    channel_out_size: usize,
+    channel_grouped_size: usize,
+    kernel_size: usize,
+    dilated_kernel_size: usize,
 }
 
 impl Conv1D {
@@ -26,159 +36,158 @@ impl Conv1D {
         assert!(stride > 0, "non-positive stride is not supported");
         assert!(dilation > 0, "non-positive dilation is not supported");
         assert!(groups > 0, "non-positive groups is not supported");
+
         let weights_shape = weights.shape();
+        let channel_out_size = weights_shape[0];
+        let channel_grouped_size = weights_shape[1];
+        let kernel_size = weights_shape[2];
+        let dilated_kernel_size = dilation * (kernel_size - 1) + 1;
+
         assert!(
-            groups <= weights_shape[0],
+            groups <= channel_out_size,
             "Given groups={}, expected weight to be at least {} at dimension 0, but got weight of size {:?} instead",
             groups,
             groups,
             weights_shape,
         );
         assert_eq!(
-            weights_shape[0] % groups,
+            channel_out_size % groups,
             0,
             "Given groups={}, expected weight to be divisible by {} at dimension 0, but got weight of size {:?} instead",
             groups,
             groups,
             weights_shape,
         );
-        if let Some(ref bias) = bias {
+        let bias = bias.map(|bias| {
             assert!(!bias.is_empty());
-            let bias_shape = bias.shape();
+            let bias_size = bias.len();
             assert_eq!(
-                bias_shape[0],
-                weights_shape[0],
+                bias_size,
+                channel_out_size,
                 "Given weight of size {:?}, expected bias to be 1-dimensional with {} elements, but got bias of size {:?} instead",
                 weights_shape,
-                weights_shape[0],
-                bias_shape,
+                channel_out_size,
+                bias_size,
             );
-        }
+            bias.into_shape((1, bias_size, 1)).unwrap()
+        });
+        let weights = weights
+            .into_shape((channel_out_size, channel_grouped_size * kernel_size))
+            .unwrap();
 
         Ok(Self {
             weights,
             bias,
+
             stride,
             padding,
             dilation,
             groups,
+
+            channel_out_size,
+            channel_grouped_size,
+            kernel_size,
+            dilated_kernel_size,
         })
     }
 
     // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L820
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1070
     pub fn run<S>(&self, input: ArrayBase<S, Ix3>) -> Array3<f32>
     where
         S: Data<Elem = f32>,
     {
         let input_shape = input.shape();
-        let weights_shape = self.weights.shape();
+        let batch_size = input_shape[0];
+        let channel_in_size = input_shape[1];
+        let input_size = input_shape[2];
+
         assert_eq!(
-            input_shape[1],
-            weights_shape[1] * self.groups,
+            channel_in_size,
+            self.channel_grouped_size * self.groups,
             "Given groups={}, weight of size {:?}, expected input {:?} to have {} channels, but got {} channels instead",
             self.groups,
-            weights_shape,
+            [self.channel_out_size, self.channel_grouped_size, self.kernel_size],
             input_shape,
-            weights_shape[1] * self.groups,
-            input_shape[1],
+            self.channel_grouped_size * self.groups,
+            channel_in_size,
         );
-        let input_size = input_shape[2] + 2 * self.padding;
-        let kernel_size = self.dilation * (weights_shape[2] - 1) + 1;
+        let padded_input_size = input_size + 2 * self.padding;
         assert!(
-            input_size >= kernel_size,
+            padded_input_size >= self.dilated_kernel_size,
             "Calculated padded input size per channel: {}. Kernel size: {}. Kernel size can't be greater than actual input size.",
-            input_size,
-            kernel_size,
+            padded_input_size,
+            self.dilated_kernel_size,
         );
 
-        let output_size = (input_size - kernel_size) / self.stride + 1;
+        let output_size = (padded_input_size - self.dilated_kernel_size) / self.stride + 1;
         if input.is_empty() {
-            return Array3::zeros([0, self.weights.shape()[0], output_size]);
+            return Array3::zeros([0, self.channel_out_size, output_size]);
         }
 
         if self.groups > 1 {
             unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1032-L1041");
         }
-
         if self.dilation > 1 {
             unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/NaiveDilatedConvolution.cpp#L434");
         }
 
-        // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/Convolution.cpp#L1070
-        let _kernel_height = 1;
-        let kernel_width = weights_shape[2];
-        let _pad_height = 0;
-        let pad_width = self.padding;
-        let _stride_height = 1;
-        let stride_width = self.stride;
-
-        let n_input_plane = input_shape[1];
-        let _input_height = 1;
-        let input_width = input_shape[2];
-        let n_output_plane = weights_shape[0];
-        let _output_height = 1;
-        let output_width = output_size;
-        let batch_size = input_shape[0];
-
-        // TODO: reshape only once in `new`
-        let weights = self
-            .weights
-            .view()
-            .into_shape((weights_shape[0], weights_shape[1] * weights_shape[2]))
-            .unwrap();
-
-        let mut finput = if kernel_width == 1 && stride_width == 1 && pad_width == 0 {
-            // output_width == input_shape[2]
-            input
-                .to_owned()
-                .into_shape((input_shape[0], input_shape[1], output_width))
-                .unwrap()
-        } else {
-            Array3::zeros((input_shape[0], input_shape[1] * kernel_width, output_width))
-        };
-
         // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/ConvolutionMM2d.cpp#L140
-        let mut output = Array3::<f32>::zeros([
-            batch_size,
-            n_output_plane, /* ws0 */
-            output_width,   /* is2 - ws2 + 1 */
-        ]);
+        let mut output = Array3::zeros([batch_size, self.channel_out_size, output_size]);
         for i in 0..batch_size {
             let input = input.slice(s![i, .., ..]);
-            let mut finput = finput.slice_mut(s![i, .., ..]);
             let mut output = output.slice_mut(s![i, .., ..]);
-            if kernel_width != 1 || stride_width != 1 || pad_width != 0 {
-                let input = input.as_slice().unwrap();
-                let finput = finput.as_slice_mut().unwrap();
-
-                // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160
-                for k in 0..n_input_plane * kernel_width {
-                    let nip = k / kernel_width;
-                    let rest = k % kernel_width;
-                    let kh = rest / kernel_width;
-                    let kw = rest % kernel_width;
-
-                    if pad_width > 0 || stride_width > 1 {
-                        unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160");
-                    } else {
-                        let src = nip * input_width + kh * input_width + kw;
-                        let dst = nip * kernel_width * output_width
-                            + kh * kernel_width * output_width
-                            + kw * output_width;
-                        finput[dst..dst + output_width]
-                            .copy_from_slice(&input[src..src + output_width]);
-                    }
-                }
+            if self.kernel_size == 1 && self.stride == 1 && self.padding == 0 {
+                output.assign(&self.weights.dot(&input));
+            } else {
+                let input = self.unfold(input, output_size);
+                output.assign(&self.weights.dot(&input));
             }
-
-            output.assign(&weights.dot(&finput));
         }
 
         if let Some(ref bias) = self.bias {
-            output = output + bias.view().into_shape((1, bias.len(), 1)).unwrap();
+            output + bias
+        } else {
+            output
+        }
+    }
+
+    // https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L160
+    fn unfold(&self, input: ArrayView2<f32>, output_size: usize) -> Array2<f32> {
+        if self.padding > 0 {
+            unimplemented!("https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cpu/Unfold2d.cpp#L191-L243");
         }
 
-        output
+        let channel_in_size = input.shape()[0];
+        let input_size = input.shape()[1];
+        let input = input.as_slice().unwrap();
+
+        let mut unfolded = Array2::zeros((channel_in_size * self.kernel_size, output_size));
+        {
+            let unfolded = unfolded.as_slice_mut().unwrap();
+            for k in 0..channel_in_size * self.kernel_size {
+                let nip = k / self.kernel_size;
+                let rest = k % self.kernel_size;
+                let kh = rest / self.kernel_size;
+                let kw = rest % self.kernel_size;
+
+                let src = nip * input_size + kh * input_size + kw;
+                let dst = nip * self.kernel_size * output_size
+                    + kh * self.kernel_size * output_size
+                    + kw * output_size;
+
+                if self.stride > 1 {
+                    for j in 0..output_size {
+                        unfolded[dst + j] = input[src + j * self.stride];
+                    }
+                } else {
+                    unfolded[dst..dst + output_size]
+                        .copy_from_slice(&input[src..src + output_size]);
+                }
+            }
+        }
+
+        unfolded
     }
 }
 
@@ -189,7 +198,7 @@ mod tests {
     use super::*;
     use test_utils::assert_approx_eq;
 
-    // https://github.com/pytorch/pytorch/blob/master/test/cpp/api/functional.cpp#L13
+    // https://github.com/pytorch/pytorch/blob/master/test/cpp/api/functional.cpp#L13-L26
     #[test]
     fn test_conv1d_wide_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
@@ -215,7 +224,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "not implemented: https://github.com/pytorch")]
     fn test_conv1d_stride() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
@@ -224,12 +232,12 @@ mod tests {
             [[312., 384.], [798., 1032.]],
             [[852., 924.], [2553., 2787.]],
         ]);
-        assert_approx_eq!(f32, output, expected);
+        assert_approx_eq!(f32, dbg!(output), expected);
     }
 
     #[test]
     #[should_panic(expected = "not implemented: https://github.com/pytorch")]
-    fn test_conv1d_pad() {
+    fn test_conv1d_padding() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, None, 1, 1, 1, 1).unwrap().run(input);

--- a/layer/src/lib.rs
+++ b/layer/src/lib.rs
@@ -1,6 +1,7 @@
 //! AI model building blocks.
 
 pub mod activation;
+pub mod conv;
 pub mod dense;
 pub mod io;
 pub mod utils;

--- a/layer/src/utils.rs
+++ b/layer/src/utils.rs
@@ -1,5 +1,6 @@
 use std::f32::consts::SQRT_2;
 
+use displaydoc::Display;
 use ndarray::{
     Array2,
     ArrayBase,
@@ -10,11 +11,41 @@ use ndarray::{
     Dimension,
     IntoDimension,
     Ix2,
+    IxDyn,
     NdFloat,
     RemoveAxis,
 };
 use rand::Rng;
 use rand_distr::{Distribution, Normal};
+use thiserror::Error;
+
+/// Can't combine {name_left}({shape_left:?}) with {name_right}({shape_right:?}): {hint}
+#[derive(Debug, Display, Error)]
+pub struct IncompatibleMatrices {
+    name_left: &'static str,
+    shape_left: IxDyn,
+    name_right: &'static str,
+    shape_right: IxDyn,
+    hint: &'static str,
+}
+
+impl IncompatibleMatrices {
+    pub fn new(
+        name_left: &'static str,
+        shape_left: impl IntoDimension,
+        name_right: &'static str,
+        shape_right: impl IntoDimension,
+        hint: &'static str,
+    ) -> Self {
+        Self {
+            name_left,
+            shape_left: shape_left.into_dimension().into_dyn(),
+            name_right,
+            shape_right: shape_right.into_dimension().into_dyn(),
+            hint,
+        }
+    }
+}
 
 /// Computes softmax along specified axis.
 ///

--- a/xayn-ai/src/ltr/list_net/model.rs
+++ b/xayn-ai/src/ltr/list_net/model.rs
@@ -27,9 +27,9 @@ use crate::ltr::list_net::data::{
 };
 use layer::{
     activation::{Linear, Relu, Softmax},
-    dense::{Dense, DenseGradientSet, IncompatibleMatrices, LoadingDenseFailed},
+    dense::{Dense, DenseGradientSet, LoadingDenseFailed},
     io::{BinParams, LoadingBinParamsFailed},
-    utils::{he_normal_weights_init, kl_divergence},
+    utils::{he_normal_weights_init, kl_divergence, IncompatibleMatrices},
 };
 
 /// ListNet load failure.


### PR DESCRIPTION
**References**

- [TY-2136]

**Summary**

i'd suggest to look at the [commit of the raw impl](https://github.com/xaynetwork/xayn_ai/blob/b692b68714776f3ddcaee70cd48f8e64875c28b8/layer/src/conv.rs) to check correctness wrt the original C++ version and then at the last commit to check if this was rustified correctly:
- add a 1D convolutional layer and implement the paths needed from the [C++ torch source](https://pytorch.org/docs/stable/generated/torch.nn.functional.conv1d.html) for the chosen configuration in the [KPE prototype](https://github.com/xaynetwork/xayn_ai_research/blob/main/experiments/preference_modeling/keyphrase_extraction/bert2joint/model.py#L193-L195)
- add tests, the original only had one test and i created more from running the original

**Todo**

- ~refactor the looped assignments as iterator collections whereever possible~


[TY-2136]: https://xainag.atlassian.net/browse/TY-2136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ