### PR TITLE
[Merged by Bors] - TY-2128 add web worker asset type

### DIFF
--- a/.ci/copy-headers/action.yml
+++ b/.ci/copy-headers/action.yml
@@ -1,0 +1,20 @@
+name: 'copy ffi header files'
+description: 'Copies ffi header files'
+inputs:
+  working-directory:
+    description: 'The working directory'
+    required: true
+  dart-ws:
+    description: 'The Dart workspace'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        cp ios/Classes/XaynAiFfiCommon.h ${{ inputs.dart-ws }}/ios/Classes
+        cp ios/Classes/XaynAiFfiDart.h ${{ inputs.dart-ws }}/ios/Classes
+        cp lib/src/common/ffi/genesis.dart ${{ inputs.dart-ws }}/lib/src/common/ffi
+        cp lib/src/mobile/ffi/genesis.dart ${{ inputs.dart-ws }}/lib/src/mobile/ffi
+        find lib/ -type f -regex ".*\.g\.dart" -exec cp --parents '{}' ${{ inputs.dart-ws }}/ \;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -323,14 +323,10 @@ jobs:
           path: ${{ runner.temp }}/headers
 
       - name: Copy headers
-        shell: bash
-        working-directory: ${{ runner.temp }}/headers
-        run: |
-          cp ios/Classes/XaynAiFfiCommon.h ${{ env.DART_WORKSPACE }}/ios/Classes
-          cp ios/Classes/XaynAiFfiDart.h ${{ env.DART_WORKSPACE }}/ios/Classes
-          cp lib/src/common/ffi/genesis.dart ${{ env.DART_WORKSPACE }}/lib/src/common/ffi
-          cp lib/src/mobile/ffi/genesis.dart ${{ env.DART_WORKSPACE }}/lib/src/mobile/ffi
-          find lib/ -type f -regex ".*\.g\.dart" -exec cp --parents '{}' ${{ env.DART_WORKSPACE }}/ \;
+        uses: ./.ci/copy-headers
+        with:
+          working-directory: ${{ runner.temp }}/headers
+          dart-ws: ${{ env.DART_WORKSPACE }}
 
       - id: out-dir
         run: echo "::set-output name=path::$(echo ${{ env.OUT_DIR }}/web_worker)"
@@ -600,14 +596,10 @@ jobs:
           cp -r ios-*/* ${{ env.DART_WORKSPACE }}/ios
 
       - name: Copy headers
-        shell: bash
-        run: |
-          cd /tmp/artifacts/headers-${{ github.sha }}
-          cp ios/Classes/XaynAiFfiCommon.h ${{ env.DART_WORKSPACE }}/ios/Classes
-          cp ios/Classes/XaynAiFfiDart.h ${{ env.DART_WORKSPACE }}/ios/Classes
-          cp lib/src/common/ffi/genesis.dart ${{ env.DART_WORKSPACE }}/lib/src/common/ffi
-          cp lib/src/mobile/ffi/genesis.dart ${{ env.DART_WORKSPACE }}/lib/src/mobile/ffi
-          find lib/ -type f -regex ".*\.g\.dart" -exec cp --parents '{}' ${{ env.DART_WORKSPACE }}/ \;
+        uses: ./.ci/copy-headers
+        with:
+          working-directory: /tmp/artifacts/headers-${{ github.sha }}
+          dart-ws: ${{ env.DART_WORKSPACE }}
 
       - name: Download asset artifacts
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,7 +120,6 @@ jobs:
         with:
           profile: minimal
           toolchain: ${{ env.RUST_STABLE }}
-          target: ${{ matrix.target }}
           default: true
 
       - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
@@ -294,9 +293,69 @@ jobs:
           if-no-files-found: error
           path: target/${{ matrix.target}}/release/libxayn_ai_ffi_c_${{ matrix.target }}.a
 
+  build-web-worker-asset:
+    name: build-web-worker-asset
+    runs-on: ubuntu-20.04
+    needs: build-release-headers
+    timeout-minutes: 20
+    env:
+      OUT_DIR: ${{ github.workspace }}/out
+    outputs:
+      upload-name: ${{ steps.upload.outputs.name }}
+      upload-path: ${{ steps.out-dir.outputs.path }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # v2.3.5
+
+      - name: Install flutter
+        uses: subosito/flutter-action@4389e6cbc6cb8a4b18c628ff96ff90be0e926aa8 # v1.5.3
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: Install flutter dependencies
+        working-directory: ${{ env.DART_WORKSPACE }}
+        run: flutter pub get
+
+      - name: Download headers
+        uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
+        with:
+          name: headers-${{ github.sha }}
+          path: ${{ runner.temp }}/headers
+
+      - name: Copy headers
+        shell: bash
+        working-directory: ${{ runner.temp }}/headers
+        run: |
+          cp ios/Classes/XaynAiFfiCommon.h ${{ env.DART_WORKSPACE }}/ios/Classes
+          cp ios/Classes/XaynAiFfiDart.h ${{ env.DART_WORKSPACE }}/ios/Classes
+          cp lib/src/common/ffi/genesis.dart ${{ env.DART_WORKSPACE }}/lib/src/common/ffi
+          cp lib/src/mobile/ffi/genesis.dart ${{ env.DART_WORKSPACE }}/lib/src/mobile/ffi
+          find lib/ -type f -regex ".*\.g\.dart" -exec cp --parents '{}' ${{ env.DART_WORKSPACE }}/ \;
+
+      - id: out-dir
+        run: echo "::set-output name=path::$(echo ${{ env.OUT_DIR }}/web_worker)"
+
+      - name: Compile Dart web worker
+        run: |
+          mkdir -p ${{ steps.out-dir.outputs.path }}
+          dart compile js ${{ env.DART_WORKSPACE }}/lib/src/web/worker/worker.dart -m --no-source-maps -o ${{ steps.out-dir.outputs.path }}/worker.js
+          cd ${{ steps.out-dir.outputs.path }}
+          rm ${{ steps.out-dir.outputs.path }}/worker.js.deps
+
+      - id: upload
+        run: echo "::set-output name=name::$(echo build-worker-release)"
+
+      - name: Upload web worker artifact
+        uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
+        with:
+          name: ${{ steps.upload.outputs.name }}
+          retention-days: 1
+          if-no-files-found: error
+          path: ${{ steps.out-dir.outputs.path }}
+
   build-release-wasm-libs:
     name: build-release-wasm-libs
-    needs: cargo-registry-cache
+    needs: [cargo-registry-cache, build-web-worker-asset]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
@@ -332,6 +391,9 @@ jobs:
       - name: Install wasm-pack
         uses: ./.ci/install-wasm-pack
 
+      - name: Install webpack
+        run: yarn --cwd data/bundler_config
+
       - name: Restore ${{ needs.cargo-registry-cache.outputs.cache-key }} cache
         uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # v2.1.6
         with:
@@ -348,14 +410,23 @@ jobs:
           key: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.wasm_feature }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-${{ steps.rust-toolchain.outputs.rustc }}-${{ github.job }}-${{ matrix.wasm_feature }}-${{ needs.cargo-registry-cache.outputs.cache-date }}-
 
-      - name: Install webpack
-        run: yarn --cwd data/bundler_config
-
       - name: Build WASM library
         env:
           RUSTFLAGS: ${{ matrix.RUSTFLAGS }}
           RUSTC_BOOTSTRAP: ${{ matrix.RUSTC_BOOTSTRAP }}
         run: ./build_wasm.sh ${{ env.OUT_DIR }}/wasm ${{ matrix.wasm_feature }} ${{ matrix.cargo_args }}
+
+      - name: Download web worker artifact
+        uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
+        with:
+          name: ${{ needs.build-web-worker-asset.outputs.upload-name }}
+          path: ${{ needs.build-web-worker-asset.outputs.upload-path }}
+
+      - name: Add web worker to WASM artifact
+        # https://github.com/xaynetwork/xayn_ai/pull/272 explains the reason for following step.
+        run: |
+          mv ${{ needs.build-web-worker-asset.outputs.upload-path }}/* ${{ env.OUT_DIR }}/wasm/
+          rm -r ${{ needs.build-web-worker-asset.outputs.upload-path }}
 
       - name: Generate WASM library version key
         id: wasm-lib
@@ -398,11 +469,11 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
-          path: ${{ runner.temp }}/wasm_assets
+          path: ${{ runner.temp }}/wasm_artifacts
 
-      - run: |
+      - working-directory: ${{ runner.temp }}/wasm_artifacts
+        run: |
           mkdir -p ${{ needs.build-release-wasm-libs.outputs.out-dir }}
-          cd ${{ runner.temp }}/wasm_assets
           cp -R build-wasm-*/* ${{ needs.build-release-wasm-libs.outputs.out-dir }}
 
       - name: Download data
@@ -449,11 +520,11 @@ jobs:
       - name: Download WASM artifacts
         uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
-          path: ${{ runner.temp }}/wasm_assets
+          path: ${{ runner.temp }}/wasm_artifacts
 
-      - run: |
+      - working-directory: ${{ runner.temp }}/wasm_artifacts
+        run: |
           mkdir -p ${{ needs.build-release-wasm-libs.outputs.out-dir }}
-          cd ${{ runner.temp }}/wasm_assets
           cp -R build-wasm-*/* ${{ needs.build-release-wasm-libs.outputs.out-dir }}
 
       - name: Download data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [unreleased]
 
+### Added
+
+- A new `webWorkerScript` asset type that points to the web worker script. The complete URL (base URL + URL suffix) needs to be passed as a `String` via the assets map to the `SetupData`.
+
 ### Changed
 
 - `wasmScript` is no longer a javascript module.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -84,7 +84,7 @@ script = ["""
 
 [tasks.generate_assets_metadata]
 script = ["""
-  ./generate_assets_metadata.sh assets_manifest.json "$WASM_OUT_DIR_PATH"
+  ./generate_assets_metadata.sh assets_manifest.json "$EXAMPLE_ASSETS_DIR"
 """]
 
 [tasks.serve-web]
@@ -94,8 +94,8 @@ script = ["""
 
 [tasks.build-web]
 # This will run build-local "unnecessarily". This will be fixed in a later PR.
-env = { WASM_VERSION = "wasm_bindings", WASM_OUT_DIR_PATH = "bindings/dart/example/assets", DISABLE_WASM_THREADS = { value = "1", condition = { env_not_set = ["DISABLE_WASM_THREADS"] } } }
-run_task = { name = ["build-dart", "build-wasm", "generate_assets_metadata"] }
+env = { EXAMPLE_ASSETS_DIR = "bindings/dart/example/assets", WASM_VERSION = "wasm_bindings", DISABLE_WASM_THREADS = { value = "1", condition = { env_not_set = ["DISABLE_WASM_THREADS"] } } }
+run_task = { name = ["build-dart", "build-wasm", "compile-dart-worker", "generate_assets_metadata"] }
 
 [tasks.build-wasm]
 dependencies = ["install-webpack", "build-wasm-multithreaded", "build-wasm-sequential"]
@@ -110,24 +110,29 @@ script = ["""
     exit 1
   fi
   RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
-  ./build_wasm.sh "$CARGO_MAKE_WORKING_DIRECTORY/$WASM_OUT_DIR_PATH/$WASM_VERSION" multithreaded -Z build-std=panic_abort,std
+  ./build_wasm.sh "$CARGO_MAKE_WORKING_DIRECTORY/$EXAMPLE_ASSETS_DIR/$WASM_VERSION" multithreaded -Z build-std=panic_abort,std
   # Webpack removes the entire wasm output folder along with the `.gitkeep` file.
   # We add the `.gitkeep` back so it doesn't show up as a change in git.
-  touch "$CARGO_MAKE_WORKING_DIRECTORY/$WASM_OUT_DIR_PATH/$WASM_VERSION/.gitkeep"
+  touch "$CARGO_MAKE_WORKING_DIRECTORY/$EXAMPLE_ASSETS_DIR/$WASM_VERSION/.gitkeep"
 """]
 
 [tasks.build-wasm-sequential]
 condition = { env_true = ["DISABLE_WASM_THREADS"] }
 script = ["""
-  ./build_wasm.sh "$CARGO_MAKE_WORKING_DIRECTORY/$WASM_OUT_DIR_PATH/$WASM_VERSION" sequential
+  ./build_wasm.sh "$CARGO_MAKE_WORKING_DIRECTORY/$EXAMPLE_ASSETS_DIR/$WASM_VERSION" sequential
   # Webpack removes the entire wasm output folder along with the `.gitkeep` file.
   # We add the `.gitkeep` back so it doesn't show up as a change in git.
-  touch "$CARGO_MAKE_WORKING_DIRECTORY/$WASM_OUT_DIR_PATH/$WASM_VERSION/.gitkeep"
+  touch "$CARGO_MAKE_WORKING_DIRECTORY/$EXAMPLE_ASSETS_DIR/$WASM_VERSION/.gitkeep"
 """]
 
 [tasks.install-webpack]
 script = ["""
   yarn --cwd data/bundler_config
+"""]
+
+[tasks.compile-dart-worker]
+script = ["""
+  dart compile js "${DART_WORKSPACE}/lib/src/web/worker/worker.dart" -m -o "$CARGO_MAKE_WORKING_DIRECTORY/$EXAMPLE_ASSETS_DIR/$WASM_VERSION/worker.js"
 """]
 
 [tasks.test-wasm]

--- a/bindings/dart/example/lib/data_provider/web.dart
+++ b/bindings/dart/example/lib/data_provider/web.dart
@@ -12,7 +12,7 @@ const _baseAssetUrl = './assets/assets';
 
 /// Prepares and returns the data that is needed to init [`XaynAi`].
 Future<SetupData> getInputData() async {
-  final fetched = <AssetType, Uint8List>{};
+  final fetched = <AssetType, dynamic>{};
   final features = <WebFeature>{};
 
   // uncomment the following section to load the multithreaded version
@@ -24,12 +24,14 @@ Future<SetupData> getInputData() async {
 
   for (var asset in getAssets(features: features).entries) {
     final path = joinPaths([_baseAssetUrl, asset.value.urlSuffix]);
-    // We also load the wasm script here in order to check its integrity/checksum.
+    // We also load the wasm/worker script here in order to check its integrity/checksum.
     // The browser keeps it in cache so `injectWasmScript` does not download it again.
     final data = await _fetchAsset(path, asset.value.checksum.checksumSri);
 
     if (asset.key == AssetType.wasmScript) {
       await injectWasmScript(path);
+    } else if (asset.key == AssetType.webWorkerScript) {
+      fetched.putIfAbsent(asset.key, () => path);
     } else {
       fetched.putIfAbsent(asset.key, () => data);
     }

--- a/bindings/dart/example/pubspec.yaml
+++ b/bindings/dart/example/pubspec.yaml
@@ -50,4 +50,3 @@ flutter:
     - 'assets/ltr_v0000/'
     - 'assets/call_data/'
     - 'assets/wasm_bindings/'
-

--- a/bindings/dart/lib/package.dart
+++ b/bindings/dart/lib/package.dart
@@ -1,7 +1,6 @@
 export 'src/common/data/document.dart' show Document;
 export 'src/common/data/history.dart'
     show UserFeedback, History, Relevance, DayOfWeek, UserAction;
-export 'src/common/reranker/ai.dart' show RerankMode;
 export 'src/common/reranker/ai.dart'
     if (dart.library.io) 'src/mobile/reranker/ai.dart'
     if (dart.library.js) 'src/web/reranker/ai.dart' show XaynAi;
@@ -13,4 +12,5 @@ export 'src/common/reranker/data_provider.dart'
     if (dart.library.js) 'src/web/reranker/data_provider.dart'
     show getAssets, SetupData;
 export 'src/common/reranker/debug.dart' show RerankDebugCallData;
+export 'src/common/reranker/mode.dart' show RerankMode;
 export 'src/common/result/outcomes.dart' show RerankingOutcomes;

--- a/bindings/dart/lib/src/common/reranker/ai.dart
+++ b/bindings/dart/lib/src/common/reranker/ai.dart
@@ -1,50 +1,14 @@
-import 'dart:math' show max, min;
 import 'dart:typed_data' show Uint8List;
 
-import 'package:json_annotation/json_annotation.dart' show JsonValue;
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
-import 'package:xayn_ai_ffi_dart/src/common/ffi/genesis.dart' as ffi
-    show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
     show Analytics;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/data_provider.dart'
     show SetupData;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart' show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
-
-/// Rerank mode
-enum RerankMode {
-  @JsonValue(ffi.RerankMode.StandardNews)
-  standardNews,
-  @JsonValue(ffi.RerankMode.PersonalizedNews)
-  personalizedNews,
-  @JsonValue(ffi.RerankMode.StandardSearch)
-  standardSearch,
-  @JsonValue(ffi.RerankMode.PersonalizedSearch)
-  personalizedSearch,
-}
-
-extension RerankModeToInt on RerankMode {
-  /// Gets the discriminant.
-  int toInt() {
-    // We can't use `_$RerankModeEnumMap` as it only gets generated for
-    // files which have a `@JsonSerializable` type containing the enum.
-    // You can't make enums `@JsonSerializable`. Given that `RerankMode`
-    // has only few variants and rarely changes we just write this switch
-    // statement by hand.
-    switch (this) {
-      case RerankMode.standardNews:
-        return ffi.RerankMode.StandardNews;
-      case RerankMode.personalizedNews:
-        return ffi.RerankMode.PersonalizedNews;
-      case RerankMode.standardSearch:
-        return ffi.RerankMode.StandardSearch;
-      case RerankMode.personalizedSearch:
-        return ffi.RerankMode.PersonalizedSearch;
-    }
-  }
-}
 
 /// The Xayn AI.
 class XaynAi {
@@ -98,15 +62,3 @@ class XaynAi {
   /// Frees the memory.
   Future<void> free() async => throw UnsupportedError('Unsupported platform.');
 }
-
-/// Maximum number of threads to be used for multithreaded features.
-const int maxNumberOfThreads = 16;
-
-/// Selects the number of threads used by the [`XaynAi`] thread pool.
-///
-/// On a single core system the thread pool consists of only one thread.
-/// On a multicore system the thread pool consists of
-/// (the number of logical cores - 1) threads, but at most [`maxNumberOfThreads`]
-/// threads and at least one thread.
-int selectThreadPoolSize(int numberOfProcessors) =>
-    min(max(numberOfProcessors - 1, 1), maxNumberOfThreads);

--- a/bindings/dart/lib/src/common/reranker/debug.dart
+++ b/bindings/dart/lib/src/common/reranker/debug.dart
@@ -6,7 +6,7 @@ import 'package:json_annotation/json_annotation.dart'
 
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart' show RerankMode;
 
 part 'debug.g.dart';
 

--- a/bindings/dart/lib/src/common/reranker/mode.dart
+++ b/bindings/dart/lib/src/common/reranker/mode.dart
@@ -1,0 +1,37 @@
+import 'package:json_annotation/json_annotation.dart' show JsonValue;
+
+import 'package:xayn_ai_ffi_dart/src/common/ffi/genesis.dart' as ffi
+    show RerankMode;
+
+/// Rerank mode
+enum RerankMode {
+  @JsonValue(ffi.RerankMode.StandardNews)
+  standardNews,
+  @JsonValue(ffi.RerankMode.PersonalizedNews)
+  personalizedNews,
+  @JsonValue(ffi.RerankMode.StandardSearch)
+  standardSearch,
+  @JsonValue(ffi.RerankMode.PersonalizedSearch)
+  personalizedSearch,
+}
+
+extension RerankModeToInt on RerankMode {
+  /// Gets the discriminant.
+  int toInt() {
+    // We can't use `_$RerankModeEnumMap` as it only gets generated for
+    // files which have a `@JsonSerializable` type containing the enum.
+    // You can't make enums `@JsonSerializable`. Given that `RerankMode`
+    // has only few variants and rarely changes we just write this switch
+    // statement by hand.
+    switch (this) {
+      case RerankMode.standardNews:
+        return ffi.RerankMode.StandardNews;
+      case RerankMode.personalizedNews:
+        return ffi.RerankMode.PersonalizedNews;
+      case RerankMode.standardSearch:
+        return ffi.RerankMode.StandardSearch;
+      case RerankMode.personalizedSearch:
+        return ffi.RerankMode.PersonalizedSearch;
+    }
+  }
+}

--- a/bindings/dart/lib/src/common/reranker/utils.dart
+++ b/bindings/dart/lib/src/common/reranker/utils.dart
@@ -1,0 +1,13 @@
+import 'dart:math' show min, max;
+
+/// Maximum number of threads to be used for multithreaded features.
+const int maxNumberOfThreads = 16;
+
+/// Selects the number of threads used by the [`XaynAi`] thread pool.
+///
+/// On a single core system the thread pool consists of only one thread.
+/// On a multicore system the thread pool consists of
+/// (the number of logical cores - 1) threads, but at most [`maxNumberOfThreads`]
+/// threads and at least one thread.
+int selectThreadPoolSize(int numberOfProcessors) =>
+    min(max(numberOfProcessors - 1, 1), maxNumberOfThreads);

--- a/bindings/dart/lib/src/common/reranker/utils.dart
+++ b/bindings/dart/lib/src/common/reranker/utils.dart
@@ -1,4 +1,4 @@
-import 'dart:math' show min, max;
+import 'dart:math' show max, min;
 
 /// Maximum number of threads to be used for multithreaded features.
 const int maxNumberOfThreads = 16;

--- a/bindings/dart/lib/src/mobile/reranker/ai.dart
+++ b/bindings/dart/lib/src/mobile/reranker/ai.dart
@@ -6,12 +6,14 @@ import 'package:ffi/ffi.dart' show malloc, StringUtf8Pointer;
 
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart'
-    show RerankMode, RerankModeToInt, selectThreadPoolSize;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' as common
     show XaynAi;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
     show Analytics;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart'
+    show RerankMode, RerankModeToInt;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/utils.dart'
+    show selectThreadPoolSize;
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
 import 'package:xayn_ai_ffi_dart/src/common/utils.dart' show assertNeq;

--- a/bindings/dart/lib/src/web/ffi/ai.dart
+++ b/bindings/dart/lib/src/web/ffi/ai.dart
@@ -7,10 +7,10 @@ import 'package:js/js.dart' show JS;
 
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart'
-    show RerankMode, RerankModeToInt;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
     show Analytics;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart'
+    show RerankMode, RerankModeToInt;
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
 import 'package:xayn_ai_ffi_dart/src/web/data/document.dart'
@@ -62,7 +62,8 @@ class XaynAi {
 
   /// Creates and initializes the Xayn AI and initializes the WASM module.
   ///
-  /// Requires the necessary [SetupData] for the AI. Optionally accepts the
+  /// Requires the path to the vocabulary and model of the tokenizer/embedder,
+  /// the path of the LTR model and the WASM module. Optionally accepts the
   /// serialized reranker database, otherwise creates a new one.
   static Future<XaynAi> create(
       Uint8List smbertVocab,

--- a/bindings/dart/lib/src/web/ffi/library.dart
+++ b/bindings/dart/lib/src/web/ffi/library.dart
@@ -2,9 +2,11 @@
 library library;
 
 import 'dart:html' show WorkerGlobalScope;
+
 import 'package:js/js.dart' show JS;
 import 'package:js/js_util.dart' show promiseToFuture;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart'
+
+import 'package:xayn_ai_ffi_dart/src/common/reranker/utils.dart'
     show selectThreadPoolSize;
 
 @JS('Promise')

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -7,11 +7,11 @@ import 'package:js/js.dart' show JS;
 
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' as common
     show XaynAi;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
     show Analytics;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart' show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/common/result/outcomes.dart'
     show RerankingOutcomes;
 import 'package:xayn_ai_ffi_dart/src/web/ffi/ai.dart' as ffi show XaynAi;

--- a/bindings/dart/lib/src/web/reranker/data_provider.dart
+++ b/bindings/dart/lib/src/web/reranker/data_provider.dart
@@ -33,13 +33,15 @@ class SetupData implements common.SetupData {
   late Uint8List qambertModel;
   late Uint8List ltrModel;
   late Uint8List wasmModule;
+  late String webWorkerScript;
 
-  SetupData(Map<common.AssetType, Uint8List> assets) {
-    smbertVocab = assets[common.AssetType.smbertVocab]!;
-    smbertModel = assets[common.AssetType.smbertModel]!;
-    qambertVocab = assets[common.AssetType.qambertVocab]!;
-    qambertModel = assets[common.AssetType.qambertModel]!;
-    ltrModel = assets[common.AssetType.ltrModel]!;
-    wasmModule = assets[common.AssetType.wasmModule]!;
+  SetupData(Map<common.AssetType, dynamic> assets) {
+    smbertVocab = assets[common.AssetType.smbertVocab]! as Uint8List;
+    smbertModel = assets[common.AssetType.smbertModel]! as Uint8List;
+    qambertVocab = assets[common.AssetType.qambertVocab]! as Uint8List;
+    qambertModel = assets[common.AssetType.qambertModel]! as Uint8List;
+    ltrModel = assets[common.AssetType.ltrModel]! as Uint8List;
+    wasmModule = assets[common.AssetType.wasmModule]! as Uint8List;
+    webWorkerScript = assets[common.AssetType.webWorkerScript]! as String;
   }
 }

--- a/bindings/dart/lib/src/web/worker/message/request.dart
+++ b/bindings/dart/lib/src/web/worker/message/request.dart
@@ -1,9 +1,10 @@
 import 'dart:typed_data' show Uint8List;
 
 import 'package:json_annotation/json_annotation.dart' show JsonSerializable;
+
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart' show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/common/utils.dart' show ToJson;
 import 'package:xayn_ai_ffi_dart/src/web/worker/message/utils.dart'
     show Uint8ListConverter, Uint8ListMaybeNullConverter;

--- a/bindings/dart/lib/src/web/worker/message/response.dart
+++ b/bindings/dart/lib/src/web/worker/message/response.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data' show Uint8List;
 
 import 'package:json_annotation/json_annotation.dart' show JsonSerializable;
+
 import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
     show Analytics;
 import 'package:xayn_ai_ffi_dart/src/common/utils.dart' show ToJson;

--- a/bindings/dart/lib/src/web/worker/oneshot.dart
+++ b/bindings/dart/lib/src/web/worker/oneshot.dart
@@ -1,6 +1,7 @@
 import 'dart:html' show MessageChannel, MessageEvent, MessagePort;
 
 import 'package:json_annotation/json_annotation.dart' show JsonSerializable;
+
 import 'package:xayn_ai_ffi_dart/src/common/utils.dart' show ToJson;
 import 'package:xayn_ai_ffi_dart/src/web/worker/message/utils.dart'
     show MessagePortConverter;

--- a/bindings/dart/test/common/reranker/debug_test.dart
+++ b/bindings/dart/test/common/reranker/debug_test.dart
@@ -7,10 +7,10 @@ import 'package:flutter_test/flutter_test.dart'
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart'
     show History, Relevance, UserFeedback, UserAction, DayOfWeek;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart'
-    show RerankMode, RerankModeToInt;
 import 'package:xayn_ai_ffi_dart/src/common/reranker/debug.dart'
     show RerankDebugCallData;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart'
+    show RerankMode, RerankModeToInt;
 
 String encodeJson(Map<String, dynamic> object) => JsonEncoder().convert(object);
 

--- a/bindings/dart/test/mobile/reranker/ai_test.dart
+++ b/bindings/dart/test/mobile/reranker/ai_test.dart
@@ -12,7 +12,7 @@ import 'package:flutter_test/flutter_test.dart'
         throwsA,
         TypeMatcher;
 
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart' show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/common/result/error.dart' show Code;
 import 'package:xayn_ai_ffi_dart/src/mobile/reranker/ai.dart' show XaynAi;
 import '../utils.dart'

--- a/bindings/dart/test/mobile/reranker/analytics_test.dart
+++ b/bindings/dart/test/mobile/reranker/analytics_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart'
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart'
     show History, Relevance, UserAction, UserFeedback, DayOfWeek;
-import 'package:xayn_ai_ffi_dart/src/common/reranker/ai.dart' show RerankMode;
+import 'package:xayn_ai_ffi_dart/src/common/reranker/mode.dart' show RerankMode;
 import 'package:xayn_ai_ffi_dart/src/mobile/ffi/genesis.dart' show CAnalytics;
 import 'package:xayn_ai_ffi_dart/src/mobile/reranker/ai.dart' show XaynAi;
 import 'package:xayn_ai_ffi_dart/src/mobile/reranker/analytics.dart'

--- a/data/asset_templates/base_assets.dart.tmpl
+++ b/data/asset_templates/base_assets.dart.tmpl
@@ -22,4 +22,5 @@ enum AssetType {
   {{- end}}
   wasmModule,
   wasmScript,
+  webWorkerScript,
 }

--- a/data/asset_templates/web_assets.dart.tmpl
+++ b/data/asset_templates/web_assets.dart.tmpl
@@ -6,6 +6,7 @@ part of 'data_provider.dart';
 final _{{ print "wasm " $key | strings.CamelCase}} = <common.AssetType, common.Asset>{
   common.AssetType.wasmModule: common.Asset('{{$value.module.url_suffix}}', common.Checksum('{{$value.module.checksum}}'), []),
   common.AssetType.wasmScript: common.Asset('{{$value.script.url_suffix}}', common.Checksum('{{$value.script.checksum}}'), []),
+  common.AssetType.webWorkerScript: common.Asset('{{$value.web_worker.url_suffix}}', common.Checksum('{{$value.web_worker.checksum}}'), []),
 };
 {{- end }}
 

--- a/generate_assets_metadata.sh
+++ b/generate_assets_metadata.sh
@@ -8,7 +8,7 @@
 # The script needs to be executed in the root of the repository.
 #
 # Usage:
-# ./generate_assets_metadata <path of assets_manifest.json> [<path of the wasm output directory>] [<path of the web worker output directory>] [<version of the web worker file>]
+# ./generate_assets_metadata <path of assets_manifest.json> [<path of the wasm output directory>]
 
 set -e
 

--- a/generate_assets_metadata.sh
+++ b/generate_assets_metadata.sh
@@ -8,12 +8,15 @@
 # The script needs to be executed in the root of the repository.
 #
 # Usage:
-# ./generate_assets_metadata <path of assets_manifest.json> [<path of the wasm output directory>]
+# ./generate_assets_metadata <path of assets_manifest.json> [<path of the wasm output directory>] [<path of the web worker output directory>] [<version of the web worker file>]
 
 set -e
 
 OUT_DIR="out"
 ASSETS_METADATA_PATH="$OUT_DIR/assets_metadata.json"
+WASM_SCRIPT_NAME="genesis.js"
+WASM_MODULE_NAME="genesis_bg.wasm"
+WEB_WORKER_NAME="worker.js"
 
 if [[ "$OSTYPE" == "darwin"*  || $RUNNER_OS == "macOS" ]]; then
     if [ -x "$(command -v gsplit)" ]; then
@@ -106,19 +109,30 @@ gen_data_assets_metadata() {
     done
 }
 
-gen_wasm_asset_metadata() {
-    local WASM_VERSION=$1
-    local ASSET_PATH=$2
+gen_web_asset_metadata() {
+    local ASSET_PATH=$1
+    local WASM_VERSION=$2
 
     local ASSET="{}"
-
     local ASSET_CHECKSUM=$(calc_checksum "$ASSET_PATH")
     local ASSET_WITH_CHECKSUM=$(echo $ASSET | jq -c --arg checksum $ASSET_CHECKSUM '. |= .+ {"checksum": $checksum}')
     local ASSET_FILENAME=$(basename "$ASSET_PATH")
-    local ASSET_URL_SUFFIX="${WASM_VERSION}/${ASSET_FILENAME}"
+    local ASSET_URL_SUFFIX="$WASM_VERSION/$ASSET_FILENAME"
     ASSET=$(echo $ASSET_WITH_CHECKSUM | jq -c --arg url_suffix $ASSET_URL_SUFFIX '. |= .+ {"url_suffix": $url_suffix}')
 
     echo $ASSET
+}
+
+gen_web_worker_asset_metadata() {
+    local WEB_WORKER_OUT_DIR_PATH=$1
+    local WASM_VERSION=$2
+
+    local ASSET_WEB_WORKER_PATH="$WEB_WORKER_OUT_DIR_PATH/$WEB_WORKER_NAME"
+    local ASSET_WEB_WORKER=$(gen_web_asset_metadata "$ASSET_WEB_WORKER_PATH" "$WASM_VERSION")
+
+    add_to_upload_list "$ASSET_WEB_WORKER_PATH" "$ASSET_WEB_WORKER"
+
+    echo $ASSET_WEB_WORKER
 }
 
 # Generates and adds the following object to the `wasm_assets` object.
@@ -133,21 +147,27 @@ gen_wasm_asset_metadata() {
 #   "module": {
 #     "checksum": "<checksum>",
 #     "url_suffix": "<version>/<filename>"
+#   },
+#   "web_worker": {
+#     "checksum": "<checksum>",
+#     "url_suffix": "<version>/<filename>"
 #   }
 # },
 gen_wasm_assets_metadata() {
     local WASM_OUT_DIR_PATH=$1
     local WASM_VERSION=$2
     local WASM_FEATURE=$3
+    local ASSET_WEB_WORKER=$4
 
-    local ASSET_JS_PATH="${WASM_OUT_DIR_PATH}/${WASM_VERSION}/genesis.js"
-    local ASSET_WASM_PATH="${WASM_OUT_DIR_PATH}/${WASM_VERSION}/genesis_bg.wasm"
+    local ASSET_JS_PATH="$WASM_OUT_DIR_PATH/$WASM_VERSION/$WASM_SCRIPT_NAME"
+    local ASSET_WASM_PATH="$WASM_OUT_DIR_PATH/$WASM_VERSION/$WASM_MODULE_NAME"
 
     local WASM_PACKAGE="{}"
-    local ASSET_JS=$(gen_wasm_asset_metadata "$WASM_VERSION" "$ASSET_JS_PATH")
+    local ASSET_JS=$(gen_web_asset_metadata "$ASSET_JS_PATH" "$WASM_VERSION")
     WASM_PACKAGE=$(echo $WASM_PACKAGE | jq -c --argjson wasm_script $ASSET_JS '. |= .+ {"script": $wasm_script}')
-    local ASSET_WASM=$(gen_wasm_asset_metadata "$WASM_VERSION" "$ASSET_WASM_PATH")
+    local ASSET_WASM=$(gen_web_asset_metadata "$ASSET_WASM_PATH" "$WASM_VERSION")
     WASM_PACKAGE=$(echo $WASM_PACKAGE | jq -c --argjson wasm_module $ASSET_WASM '. |= .+ {"module": $wasm_module}')
+    WASM_PACKAGE=$(echo $WASM_PACKAGE | jq -c --argjson web_worker_script $ASSET_WEB_WORKER '. |= .+ {"web_worker": $web_worker_script}')
 
     local TMP_FILE=$(mktemp)
     jq --argjson wasm_asset $WASM_PACKAGE --arg feature "$WASM_FEATURE" '.wasm_assets |= .+ {($feature): $wasm_asset}' "$ASSETS_METADATA_PATH" > "$TMP_FILE"
@@ -156,7 +176,7 @@ gen_wasm_assets_metadata() {
     add_to_upload_list "$ASSET_JS_PATH" "$ASSET_JS"
     add_to_upload_list "$ASSET_WASM_PATH" "$ASSET_WASM"
 
-    for ASSET_PATH in $(find "${WASM_OUT_DIR_PATH}/${WASM_VERSION}" -type f -name '*.js' ! -name genesis.js); do
+    for ASSET_PATH in $(find "${WASM_OUT_DIR_PATH}/${WASM_VERSION}" -type f -name '*.js' ! -name $WASM_SCRIPT_NAME ! -name $WEB_WORKER_NAME); do
         local ASSET_FILENAME=$(basename "$ASSET_PATH")
         local ASSET_URL_SUFFIX="${WASM_VERSION}/${ASSET_FILENAME}"
         add_to_upload_list "$ASSET_PATH" "{\"url_suffix\": \"$ASSET_URL_SUFFIX\"}"
@@ -202,7 +222,8 @@ gen_assets_metadata() {
         for WASM_VERSION in $(find "$WASM_OUT_DIR_PATH" -type f -maxdepth 2 -name 'package.json' -exec sh -c "dirname {} | xargs basename" \;); do
             local PACKAGE="$WASM_OUT_DIR_PATH/$WASM_VERSION/package.json"
             local WASM_FEATURE=$(cat "$PACKAGE" | jq -r '.feature')
-            gen_wasm_assets_metadata "$WASM_OUT_DIR_PATH" "$WASM_VERSION" "$WASM_FEATURE"
+            local ASSET_WEB_WORKER=$(gen_web_worker_asset_metadata "$WASM_OUT_DIR_PATH/$WASM_VERSION" "$WASM_VERSION")
+            gen_wasm_assets_metadata "$WASM_OUT_DIR_PATH" "$WASM_VERSION" "$WASM_FEATURE" "$ASSET_WEB_WORKER"
         done
     fi
 }


### PR DESCRIPTION
Tickets:
- [TY-2128]
- [TY-2127]

Summary:

- moved `RerankMode` and `selectThreadPoolSize` into a separate file. That change was necessary as `RerankMode` or `selectThreadPoolSize` would pull in the code of `SetupData` when compiling the worker. `SetupData` uses the generated `AssetType` which cannot exist in that moment as we first need to compile the worker because it is an asset as well. 
- added a new `webWorkerScript` asset type that points to the url of the web worker script
- added a release ci job for compiling the dart worker
- updated the changelog

Note why we move the worker into the respective WASM artefact folders:

My first idea that I had was simply adding a separate folder for the web worker and upload it on S3:
```
<base>/wasm_<feature>_<hash>/genesis.js
<base>/web_worker_<hash>/worker.js
```

However, this didn't work as the path of `genesis.js`, that is imported via `importScripts`, needs to be relative to the path of `worker.js`.

My second idea was then to put the WASM artefacts into the web worker folder:
```
<base>/web_worker_<hash>/worker.js
<base>/web_worker_<hash>/wasm_<feature>_<hash>/genesis.js
```

Here, the import of `genesis.js` works but the import of the snippet (in case of the multithread version) does not.
When webpack bundles the multithread version it creates 3 files:

```
genesis.js
<1>_genesis.js <- snippet
<2>_genesis.js <- relative import of genesis.js
```

Because webpack does not know anything about our later folder structure it simply uses `self.location + ''` as a base path. `self.location + ''` resolves to the path of `worker.js`. Once `genesis.js` tries to load `<1>_genesis.js` it uses the URL `<base>/web_worker_<hash>/<1>_genesis.js` instead of `<base>/web_worker_<hash>/wasm_<feature>_<hash>/<1>_genesis.js`. Webpack offers an option [output.publicpath](https://webpack.js.org/configuration/output/#outputpublicpath) to add a prefix to the relative url however it does not work with the relative import of `genesis.js` because webpack also adds the prefix there. So when `<1>_genesis.js` loads `<2>_genesis.js` will load `<base>/web_worker_<hash>/wasm_<feature>_<hash>/wasm_<feature>_<hash>/<2>_genesis.js`.

In the end, I decided to move the worker file into the respective WASM artefact folders. That works well but comes with the downside that we upload the worker multiple times (depending on the number of feature). However the size of the worker is currently at 115kb, so I don't see it as huge issue. 

[TY-2128]: https://xainag.atlassian.net/browse/TY-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2127]: https://xainag.atlassian.net/browse/TY-2127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ