### PR TITLE
[Merged by Bors] - Fix _baseAssetUrl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,7 @@ If that happens run `cargo make clean-non-rust`.
 
 ```diff
 - const _baseAssetUrl = 'assets';
-+ const _baseAssetUrl =
-+   'https://ai-assets.xaynet.dev'
++ const _baseAssetUrl = 'https://ai-assets.xaynet.dev';
 ```
 
 Then use `cargo make build-web` and `cargo make serve-web` like above.


### PR DESCRIPTION
Summary:

- made the line easier to copy 
- added a missing semicolon at the end 