### PR TITLE
[Merged by Bors] - TY-2168 impl error handling in web worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - A new `webWorkerScript` asset type that points to the web worker script. The complete URL (base URL + URL suffix) needs to be passed as a `String` via the assets map to the `SetupData`.
 - The version of XaynAI runs in a web-worker.
-- Every method/static function of `XaynAI` throws a `TimeoutException` if the web worker does not respond after 15 seconds. (see [#290](https://github.com/xaynetwork/xayn_ai/pull/290))
+- Every method/static function of `XaynAI` throws a `TimeoutException` if the web worker does not respond within 15 seconds. (see [#290](https://github.com/xaynetwork/xayn_ai/pull/290))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - A new `webWorkerScript` asset type that points to the web worker script. The complete URL (base URL + URL suffix) needs to be passed as a `String` via the assets map to the `SetupData`.
 - The version of XaynAI runs in a web-worker.
+- Every method/static function of `XaynAI` throws a `TimeoutException` if the web worker does not respond after 15 seconds. (see [#290](https://github.com/xaynetwork/xayn_ai/pull/290))
 
 ### Changed
 

--- a/bindings/dart/lib/src/common/result/error.dart
+++ b/bindings/dart/lib/src/common/result/error.dart
@@ -1,6 +1,9 @@
+import 'package:json_annotation/json_annotation.dart' show JsonSerializable;
 import 'package:meta/meta.dart' show immutable;
 
 import 'package:xayn_ai_ffi_dart/src/common/ffi/genesis.dart' show CCode;
+
+part 'error.g.dart';
 
 /// The Xayn AI error codes.
 enum Code {
@@ -272,6 +275,7 @@ extension IntToCode on int {
 
 /// A Xayn AI exception.
 @immutable
+@JsonSerializable()
 class XaynAiException implements Exception {
   final Code code;
   final String message;
@@ -281,4 +285,8 @@ class XaynAiException implements Exception {
 
   @override
   String toString() => message;
+
+  factory XaynAiException.fromJson(Map json) => _$XaynAiExceptionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$XaynAiExceptionToJson(this);
 }

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -230,8 +230,9 @@ Future<Response> _call<P extends ToJson>(Worker worker, Method method,
 
   MessageEvent? msg;
   try {
-    msg =
-        await receiver.recv().timeout(Duration(seconds: kReceiveTimeoutInSec));
+    msg = await receiver
+        .recv()
+        .timeout(Duration(seconds: kReceiveTimeoutSeconds));
   } on TimeoutException {
     receiver.close();
     rethrow;

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -25,7 +25,7 @@ import 'package:xayn_ai_ffi_dart/src/web/worker/message/response.dart'
     show AnalyticsResponse, FaultsResponse, Response, Uint8ListResponse;
 import 'package:xayn_ai_ffi_dart/src/web/worker/oneshot.dart' show Oneshot;
 
-const int kReceiveTimeoutInSec = 10;
+const int kReceiveTimeoutInSec = 20;
 
 /// The Xayn AI.
 class XaynAi implements common.XaynAi {

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -25,7 +25,7 @@ import 'package:xayn_ai_ffi_dart/src/web/worker/message/response.dart'
     show AnalyticsResponse, FaultsResponse, Response, Uint8ListResponse;
 import 'package:xayn_ai_ffi_dart/src/web/worker/oneshot.dart' show Oneshot;
 
-const int kReceiveTimeoutInSec = 15;
+const int kReceiveTimeoutSeconds = 15;
 
 /// The Xayn AI.
 ///

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -78,7 +78,7 @@ class XaynAi implements common.XaynAi {
     try {
       final response = await _call(worker, Method.create, params: params);
       if (response.isException()) {
-        throw response.exception!;
+        throw response.result!;
       }
     } catch (_) {
       worker.terminate();
@@ -114,7 +114,7 @@ class XaynAi implements common.XaynAi {
     );
 
     if (response.isException()) {
-      throw response.exception!;
+      throw response.result!;
     }
 
     return RerankingOutcomes.fromJson(response.result!);
@@ -130,7 +130,7 @@ class XaynAi implements common.XaynAi {
     final response = await _call(_worker!, Method.serialize);
 
     if (response.isException()) {
-      throw response.exception!;
+      throw response.result!;
     }
 
     return Uint8ListResponse.fromJson(response.result!).data;
@@ -148,7 +148,7 @@ class XaynAi implements common.XaynAi {
     final response = await _call(_worker!, Method.faults);
 
     if (response.isException()) {
-      throw response.exception!;
+      throw response.result!;
     }
 
     return FaultsResponse.fromJson(response.result!).faults;
@@ -164,7 +164,7 @@ class XaynAi implements common.XaynAi {
     final response = await _call(_worker!, Method.analytics);
 
     if (response.isException()) {
-      throw response.exception!;
+      throw response.result!;
     }
 
     return AnalyticsResponse.fromJson(response.result!).analytics;
@@ -180,7 +180,7 @@ class XaynAi implements common.XaynAi {
     final response = await _call(_worker!, Method.syncdataBytes);
 
     if (response.isException()) {
-      throw response.exception!;
+      throw response.result!;
     }
 
     return Uint8ListResponse.fromJson(response.result!).data;
@@ -200,7 +200,7 @@ class XaynAi implements common.XaynAi {
     );
 
     if (response.isException()) {
-      throw response.exception!;
+      throw response.result!;
     }
   }
 
@@ -210,7 +210,7 @@ class XaynAi implements common.XaynAi {
     try {
       final response = await _call(_worker!, Method.free);
       if (response.isException()) {
-        throw response.exception!;
+        throw response.result!;
       }
     } catch (_) {
       rethrow;

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -25,9 +25,21 @@ import 'package:xayn_ai_ffi_dart/src/web/worker/message/response.dart'
     show AnalyticsResponse, FaultsResponse, Response, Uint8ListResponse;
 import 'package:xayn_ai_ffi_dart/src/web/worker/oneshot.dart' show Oneshot;
 
-const int kReceiveTimeoutInSec = 20;
+const int kReceiveTimeoutInSec = 15;
 
 /// The Xayn AI.
+///
+/// Web worker exception handling
+///
+/// Exceptions other than [XaynAiException] that are thrown on the web worker
+/// side are not sent back, but caught and their error message is logged in
+/// the console. In this case, the called method/static function of [XaynAi]
+/// throws a [TimeoutException]. The timeout is set to 15 seconds.
+///
+/// After a [TimeoutException] was thrown, the instance must be disposed by
+/// calling [XaynAi.free]. The instance must not be used afterwards.
+/// Note: Calling [XaynAi.free] can also throw a [XaynAiException] or a
+/// [TimeoutException].
 class XaynAi implements common.XaynAi {
   final Worker? _worker;
 

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -34,7 +34,7 @@ const int kReceiveTimeoutSeconds = 15;
 /// Exceptions other than [XaynAiException] that are thrown on the web worker
 /// side are not sent back, but caught and their error message is logged in
 /// the console. In this case, the called method/static function of [XaynAi]
-/// throws a [TimeoutException]. The timeout is set to [kReceiveTimeoutInSec] seconds.
+/// throws a [TimeoutException]. The timeout is set to [kReceiveTimeoutSeconds].
 ///
 /// After a [TimeoutException] was thrown, the instance must be disposed by
 /// calling [XaynAi.free]. The instance must not be used afterwards.

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -34,7 +34,7 @@ const int kReceiveTimeoutInSec = 15;
 /// Exceptions other than [XaynAiException] that are thrown on the web worker
 /// side are not sent back, but caught and their error message is logged in
 /// the console. In this case, the called method/static function of [XaynAi]
-/// throws a [TimeoutException]. The timeout is set to 15 seconds.
+/// throws a [TimeoutException]. The timeout is set to [kReceiveTimeoutInSec] seconds.
 ///
 /// After a [TimeoutException] was thrown, the instance must be disposed by
 /// calling [XaynAi.free]. The instance must not be used afterwards.

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -1,7 +1,7 @@
 @JS()
 library ai;
 
-import 'dart:async';
+import 'dart:async' show TimeoutException;
 import 'dart:html' show MessageEvent, Worker;
 import 'dart:typed_data' show Uint8List;
 

--- a/bindings/dart/lib/src/web/worker/message/response.dart
+++ b/bindings/dart/lib/src/web/worker/message/response.dart
@@ -4,6 +4,8 @@ import 'package:json_annotation/json_annotation.dart' show JsonSerializable;
 
 import 'package:xayn_ai_ffi_dart/src/common/reranker/analytics.dart'
     show Analytics;
+import 'package:xayn_ai_ffi_dart/src/common/result/error.dart'
+    show XaynAiException;
 import 'package:xayn_ai_ffi_dart/src/common/utils.dart' show ToJson;
 import 'package:xayn_ai_ffi_dart/src/web/worker/message/utils.dart'
     show Uint8ListConverter;
@@ -14,13 +16,17 @@ part 'response.g.dart';
 @JsonSerializable()
 class Response implements ToJson {
   final Map<String, dynamic>? result;
+  final XaynAiException? exception;
 
   static Response fromResult<R extends ToJson>(R result) =>
-      Response(result.toJson());
+      Response(result.toJson(), null);
+  static Response fromError(XaynAiException error) => Response(null, error);
 
-  static const ok = Response(null);
+  static const ok = Response(null, null);
 
-  const Response(this.result);
+  const Response(this.result, this.exception);
+
+  bool isException() => exception != null ? true : false;
 
   factory Response.fromJson(Map json) => _$ResponseFromJson(json);
 
@@ -34,9 +40,7 @@ class Uint8ListResponse implements ToJson {
   @Uint8ListConverter()
   final Uint8List data;
 
-  Uint8ListResponse(
-    this.data,
-  );
+  Uint8ListResponse(this.data);
 
   factory Uint8ListResponse.fromJson(Map json) =>
       _$Uint8ListResponseFromJson(json);
@@ -50,9 +54,7 @@ class Uint8ListResponse implements ToJson {
 class FaultsResponse implements ToJson {
   final List<String> faults;
 
-  FaultsResponse(
-    this.faults,
-  );
+  FaultsResponse(this.faults);
 
   factory FaultsResponse.fromJson(Map json) => _$FaultsResponseFromJson(json);
 
@@ -65,9 +67,7 @@ class FaultsResponse implements ToJson {
 class AnalyticsResponse implements ToJson {
   Analytics? analytics;
 
-  AnalyticsResponse(
-    this.analytics,
-  );
+  AnalyticsResponse(this.analytics);
 
   factory AnalyticsResponse.fromJson(Map json) =>
       _$AnalyticsResponseFromJson(json);

--- a/bindings/dart/lib/src/web/worker/message/response.dart
+++ b/bindings/dart/lib/src/web/worker/message/response.dart
@@ -12,22 +12,28 @@ import 'package:xayn_ai_ffi_dart/src/web/worker/message/utils.dart'
 
 part 'response.g.dart';
 
+/// The kind of the [Response].
+enum Result {
+  ok,
+  exception,
+}
+
 /// A Response object that holds the result of the method invocation.
 @JsonSerializable()
 class Response implements ToJson {
+  final Result kind;
   final Map<String, dynamic>? result;
-  final Map<String, dynamic>? exception;
 
   static Response fromResult<R extends ToJson>(R result) =>
-      Response(result.toJson(), null);
+      Response(Result.ok, result.toJson());
   static Response fromException(XaynAiException exception) =>
-      Response(null, exception.toJson());
+      Response(Result.exception, exception.toJson());
 
-  static const ok = Response(null, null);
+  static const ok = Response(Result.ok, null);
 
-  const Response(this.result, this.exception);
+  const Response(this.kind, this.result);
 
-  bool isException() => exception != null ? true : false;
+  bool isException() => kind == Result.exception ? true : false;
 
   factory Response.fromJson(Map json) => _$ResponseFromJson(json);
 

--- a/bindings/dart/lib/src/web/worker/message/response.dart
+++ b/bindings/dart/lib/src/web/worker/message/response.dart
@@ -16,11 +16,12 @@ part 'response.g.dart';
 @JsonSerializable()
 class Response implements ToJson {
   final Map<String, dynamic>? result;
-  final XaynAiException? exception;
+  final Map<String, dynamic>? exception;
 
   static Response fromResult<R extends ToJson>(R result) =>
       Response(result.toJson(), null);
-  static Response fromError(XaynAiException error) => Response(null, error);
+  static Response fromError(XaynAiException error) =>
+      Response(null, error.toJson());
 
   static const ok = Response(null, null);
 

--- a/bindings/dart/lib/src/web/worker/message/response.dart
+++ b/bindings/dart/lib/src/web/worker/message/response.dart
@@ -20,8 +20,8 @@ class Response implements ToJson {
 
   static Response fromResult<R extends ToJson>(R result) =>
       Response(result.toJson(), null);
-  static Response fromError(XaynAiException error) =>
-      Response(null, error.toJson());
+  static Response fromException(XaynAiException exception) =>
+      Response(null, exception.toJson());
 
   static const ok = Response(null, null);
 

--- a/bindings/dart/lib/src/web/worker/oneshot.dart
+++ b/bindings/dart/lib/src/web/worker/oneshot.dart
@@ -102,9 +102,21 @@ class Receiver {
     }
 
     final result = await _port!.onMessage.first;
-    _port!.close();
-    _port = null;
+    close();
 
     return result;
+  }
+
+  /// Closes the receiver half of the [MessageChannel].
+  ///
+  /// The method can only be called once. Calling the [Receiver.close]
+  /// method again leads to a [StateError].
+  void close() {
+    if (_port == null) {
+      throw StateError('Receiver.close was already called');
+    }
+
+    _port!.close();
+    _port = null;
   }
 }

--- a/bindings/dart/lib/src/web/worker/worker.dart
+++ b/bindings/dart/lib/src/web/worker/worker.dart
@@ -9,7 +9,7 @@ import 'package:xayn_ai_ffi_dart/src/web/worker/message/request.dart'
 import 'package:xayn_ai_ffi_dart/src/web/worker/message/response.dart'
     show Response;
 import 'package:xayn_ai_ffi_dart/src/web/worker/method_handler.dart'
-    show MethodHandler;
+    show MethodHandler, SendResponse;
 
 void main() async {
   try {
@@ -46,7 +46,7 @@ Future<void> handleRequests() async {
     try {
       ai = await methodHandler[request.method](ai, request);
     } on XaynAiException catch (error) {
-      request.sender.send(Response.fromError(error));
+      request.sender.sendResponse(Response.fromError(error));
     } catch (error) {
       print(
           'Web worker error while handling the method call `${request.method}`: $error');

--- a/bindings/dart/lib/src/web/worker/worker.dart
+++ b/bindings/dart/lib/src/web/worker/worker.dart
@@ -45,8 +45,8 @@ Future<void> handleRequests() async {
     final request = Request.fromJson(json);
     try {
       ai = await methodHandler[request.method](ai, request);
-    } on XaynAiException catch (error) {
-      request.sender.sendResponse(Response.fromError(error));
+    } on XaynAiException catch (exception) {
+      request.sender.sendResponse(Response.fromException(exception));
     } catch (error) {
       print(
           'Web worker error while handling the method call `${request.method}`: $error');

--- a/bindings/dart/lib/src/web/worker/worker.dart
+++ b/bindings/dart/lib/src/web/worker/worker.dart
@@ -1,17 +1,21 @@
 import 'dart:async' show StreamController;
 import 'dart:html' show DedicatedWorkerGlobalScope;
 
+import 'package:xayn_ai_ffi_dart/src/common/result/error.dart'
+    show XaynAiException;
 import 'package:xayn_ai_ffi_dart/src/web/ffi/ai.dart' as ffi show XaynAi;
 import 'package:xayn_ai_ffi_dart/src/web/worker/message/request.dart'
     show Request;
+import 'package:xayn_ai_ffi_dart/src/web/worker/message/response.dart'
+    show Response;
 import 'package:xayn_ai_ffi_dart/src/web/worker/method_handler.dart'
     show MethodHandler;
 
 void main() async {
   try {
     await handleRequests();
-  } catch (e) {
-    print(e);
+  } catch (error) {
+    print('Web worker error while handling a request: $error');
   }
 }
 
@@ -30,7 +34,7 @@ class MessageStream<T> {
   }
 }
 
-/// A Function that handles the incoming [Request]s.
+/// A function that handles the incoming [Request]s.
 /// [Request]s are processed sequentially in the order in which they arrived.
 Future<void> handleRequests() async {
   final messageStream = MessageStream<Map>();
@@ -41,8 +45,11 @@ Future<void> handleRequests() async {
     final request = Request.fromJson(json);
     try {
       ai = await methodHandler[request.method](ai, request);
-    } catch (e) {
-      print(e);
+    } on XaynAiException catch (error) {
+      request.sender.send(Response.fromError(error));
+    } catch (error) {
+      print(
+          'Web worker error while handling the method call `${request.method}`: $error');
     }
   }
 }


### PR DESCRIPTION
Ticket:

- [TY-2168]

Summary:

- added exception handling in web worker and `XaynAi`.

Tested the following cases on Chrome, Firefox, Safari (sequential version) and Chrome, Firefox (multithreaded version)

`XaynAI.create` `XaynExcpetion` (invalid model) raised on worker side
- worker is terminated, `XaynExcpetion` is thrown on main 

`XaynAI.create` throws `TimeoutException` (worker not responding) 
- worker is terminated, `TimeoutException` is thrown on main 

`XaynAI.free` throws `TimeoutException` (worker not responding) 
- worker is terminated, `TimeoutException` is thrown on main 

`XaynAI.free` `XaynExcpetion` raised on web worker side 
- worker is terminated, `XaynExcpetion` is thrown on main 

Exception handling for `WebAssembly.RuntimeError` will be part of [TY-2218].

## `XaynAi` API change

```
Exceptions other than [XaynAiException] that are thrown on the web worker
side are not sent back, but caught and their error message is logged in
the console. In this case, the called method/static function of [XaynAi]
throws a [TimeoutException]. The timeout is set to 15 seconds.

After a [TimeoutException] was thrown, the instance must be disposed by calling [XaynAi.free]. 
The instance must not be used afterwards.
Note: Calling [XaynAi.free] can also throw a [XaynAiException] or a [TimeoutException].
```

[TY-2168]: https://xainag.atlassian.net/browse/TY-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TY-2218]: https://xainag.atlassian.net/browse/TY-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ