### PR TITLE
[Merged by Bors] - TY-2136 impl kpe models manually [3]

### DIFF
--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -1,12 +1,36 @@
 use displaydoc::Display;
-use ndarray::{azip, Array1, Array2, Array3, ArrayBase, Data, ErrorKind, Ix2, Ix3, ShapeError};
+use ndarray::{
+    azip,
+    Array1,
+    Array2,
+    Array3,
+    ArrayBase,
+    ArrayView2,
+    ArrayView3,
+    Data,
+    ErrorKind,
+    Ix2,
+    Ix3,
+    ShapeError,
+};
 use thiserror::Error;
 
+use crate::io::{BinParamsWithScope, LoadingLayerFailed};
+
 /// A 1-dimensional convolutional layer.
+///
+/// The layer can be configured via:
+/// - stride: Strides of the convolving kernel, must be positive.
+/// - padding: Zero-padding of the input (unimplemented for `padding != 0`).
+/// - dilation: Spacing between the convolving kernel elements, must be positive (unimplemented
+/// for `dilation != 1`).
+/// - groups: Grouping of the input, must be positive and must divide the `channel_in_size`
+/// (unimplemented for `groups != 1`).
+#[derive(Debug)]
 pub struct Conv1D {
     // params
     weights: Array2<f32>,
-    bias: Option<Array3<f32>>,
+    bias: Array3<f32>,
 
     // configs
     stride: usize,
@@ -39,6 +63,10 @@ pub enum ConvError {
 
     /// Channel out size must be divisible by groups
     ChannelOutSize,
+
+    /// Loading failed.
+    #[displaydoc("{0}")]
+    Load(#[from] LoadingLayerFailed),
 }
 
 impl Conv1D {
@@ -46,17 +74,9 @@ impl Conv1D {
     ///
     /// The weights are of shape `(channel_out_size, channel_in_size/groups, kernel_size)` and the
     /// bias is of shape `(channel_out_size,)`.
-    ///
-    /// The layer can be configured via:
-    /// - stride: Strides of the convolving kernel, must be positive.
-    /// - padding: Zero-padding of the input (unimplemented for `padding != 0`).
-    /// - dilation: Spacing between the convolving kernel elements, must be positive (unimplemented
-    /// for `dilation != 1`).
-    /// - groups: Grouping of the input, must be positive and must divide the `channel_in_size`
-    /// (unimplemented for `groups != 1`).
     pub fn new(
         weights: Array3<f32>,
-        bias: Option<Array1<f32>>,
+        bias: Array1<f32>,
         stride: usize,
         padding: usize,
         dilation: usize,
@@ -80,22 +100,17 @@ impl Conv1D {
         let channel_grouped_size = weights_shape[1];
         let kernel_size = weights_shape[2];
         let dilated_kernel_size = dilation * (kernel_size - 1) + 1;
+        let bias_size = bias.len();
 
         if channel_out_size % groups != 0 {
             return Err(ConvError::ChannelOutSize);
         }
+        if channel_out_size != bias_size {
+            return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into());
+        }
 
         let weights = weights.into_shape((channel_out_size, channel_grouped_size * kernel_size))?;
-        let bias = bias
-            .map(|bias| {
-                let bias_size = bias.len();
-                if bias_size == channel_out_size {
-                    bias.into_shape((1, bias_size, 1))
-                } else {
-                    Err(ShapeError::from_kind(ErrorKind::IncompatibleShape))
-                }
-            })
-            .transpose()?;
+        let bias = bias.into_shape((1, bias_size, 1))?;
 
         Ok(Self {
             weights,
@@ -111,6 +126,53 @@ impl Conv1D {
             kernel_size,
             dilated_kernel_size,
         })
+    }
+
+    /// Loads a 1-dimensional convolutional layer from a binary.
+    pub fn load(
+        mut params: BinParamsWithScope,
+        stride: usize,
+        padding: usize,
+        dilation: usize,
+        groups: usize,
+    ) -> Result<Self, ConvError> {
+        let weights = params
+            .take("weights")
+            .map_err::<LoadingLayerFailed, _>(Into::into)?;
+        let bias = params
+            .take("bias")
+            .map_err::<LoadingLayerFailed, _>(Into::into)?;
+
+        Self::new(weights, bias, stride, padding, dilation, groups)
+    }
+
+    /// Gets the weights.
+    ///
+    /// The weights are in shape `(channel_out_size, channel_grouped_size * kernel_size)`.
+    pub fn weights(&self) -> ArrayView2<f32> {
+        self.weights.view()
+    }
+
+    /// Gets the bias.
+    ///
+    /// The bias is in shape `(1, bias_size, 1)`.
+    pub fn bias(&self) -> ArrayView3<f32> {
+        self.bias.view()
+    }
+
+    /// Gets the first dimension of the original weights.
+    pub fn channel_out_size(&self) -> usize {
+        self.channel_out_size
+    }
+
+    /// Gets the second dimension of the original weights.
+    pub fn channel_grouped_size(&self) -> usize {
+        self.channel_grouped_size
+    }
+
+    /// Gets the third dimension of the original weights.
+    pub fn kernel_size(&self) -> usize {
+        self.kernel_size
     }
 
     /// Computes the forward pass of the input through the layer.
@@ -149,12 +211,9 @@ impl Conv1D {
             let input = self.unfold(input, output_size);
             output.assign(&self.weights.dot(&input));
         });
+        output += &self.bias;
 
-        if let Some(ref bias) = self.bias {
-            Ok(output + bias)
-        } else {
-            Ok(output)
-        }
+        Ok(output)
     }
 
     /// Unfolds the input for the kernel.
@@ -187,8 +246,9 @@ mod tests {
     #[test]
     fn test_conv1d_nonsingleton_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 1, 0, 1, 1)
+        let output = Conv1D::new(weights, bias, 1, 0, 1, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -202,8 +262,9 @@ mod tests {
     #[test]
     fn test_conv1d_singleton_kernel() {
         let weights = Array1::range(0., 6., 1.).into_shape((2, 3, 1)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 1, 0, 1, 1)
+        let output = Conv1D::new(weights, bias, 1, 0, 1, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -219,7 +280,7 @@ mod tests {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
         let bias = Array1::range(0., 2., 1.);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, Some(bias), 1, 0, 1, 1)
+        let output = Conv1D::new(weights, bias, 1, 0, 1, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -233,8 +294,9 @@ mod tests {
     #[test]
     fn test_conv1d_stride_with_nonsingleton_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 2, 0, 1, 1)
+        let output = Conv1D::new(weights, bias, 2, 0, 1, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -248,8 +310,9 @@ mod tests {
     #[test]
     fn test_conv1d_stride_with_singleton_kernel() {
         let weights = Array1::range(0., 6., 1.).into_shape((2, 3, 1)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 2, 0, 1, 1)
+        let output = Conv1D::new(weights, bias, 2, 0, 1, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -264,8 +327,9 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/cpu/Unfold2d")]
     fn test_conv1d_padding_with_nonsingleton_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 1, 1, 1, 1)
+        let output = Conv1D::new(weights, bias, 1, 1, 1, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -286,8 +350,9 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/cpu/Unfold2d")]
     fn test_conv1d_padding_with_singleton_kernel() {
         let weights = Array1::range(0., 6., 1.).into_shape((2, 3, 1)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 1, 1, 1, 1)
+        let output = Conv1D::new(weights, bias, 1, 1, 1, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -308,8 +373,9 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/NaiveDilatedConvolution")]
     fn test_conv1d_dilation() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 1, 0, 2, 1)
+        let output = Conv1D::new(weights, bias, 1, 0, 2, 1)
             .unwrap()
             .run(input)
             .unwrap();
@@ -321,8 +387,9 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/Convolution")]
     fn test_conv1d_groups() {
         let weights = Array1::range(0., 24., 1.).into_shape((2, 4, 3)).unwrap();
+        let bias = Array1::zeros(2);
         let input = Array1::range(0., 80., 1.).into_shape((2, 8, 5)).unwrap();
-        let output = Conv1D::new(weights, None, 1, 0, 1, 2)
+        let output = Conv1D::new(weights, bias, 1, 0, 1, 2)
             .unwrap()
             .run(input)
             .unwrap();

--- a/layer/src/dense.rs
+++ b/layer/src/dense.rs
@@ -1,6 +1,5 @@
 use std::ops::{AddAssign, DivAssign, MulAssign};
 
-use displaydoc::Display;
 use ndarray::{
     linalg::Dot,
     Array,
@@ -13,25 +12,12 @@ use ndarray::{
     Dimension,
     RemoveAxis,
 };
-use thiserror::Error;
 
 use crate::{
     activation::ActivationFunction,
-    io::{BinParamsWithScope, FailedToRetrieveParams, UnexpectedNumberOfDimensions},
+    io::{BinParamsWithScope, LoadingLayerFailed},
     utils::IncompatibleMatrices,
 };
-
-/// Failed to load the Dense layer
-#[derive(Debug, Display, Error)]
-#[prefix_enum_doc_attributes]
-pub enum LoadingDenseFailed {
-    /// {0}
-    IncompatibleMatrices(#[from] IncompatibleMatrices),
-    /// {0}
-    DimensionMismatch(#[from] UnexpectedNumberOfDimensions),
-    /// {0}
-    FailedToRetrieveParams(#[from] FailedToRetrieveParams),
-}
 
 /// A dense feed forward network layer.
 ///
@@ -76,7 +62,7 @@ where
     pub fn load(
         mut params: BinParamsWithScope,
         activation_function: AF,
-    ) -> Result<Self, LoadingDenseFailed> {
+    ) -> Result<Self, LoadingLayerFailed> {
         Self::new(
             params.take("weights")?,
             params.take("bias")?,

--- a/layer/src/io.rs
+++ b/layer/src/io.rs
@@ -14,6 +14,8 @@ use ndarray::{Array, ArrayBase, DataOwned, Dim, Dimension, IntoDimension, Ix, Ix
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::utils::IncompatibleMatrices;
+
 /// Deserialization helper representing a flattened array.
 ///
 /// The flattened array is in row-major order.
@@ -85,10 +87,13 @@ pub struct UnexpectedNumberOfDimensions {
     expected: usize,
 }
 
+/// Irretrievable parameters error.
 #[derive(Debug, Display, Error)]
 pub enum FailedToRetrieveParams {
-    /// {0}
+    /// Unexpected dimensionality.
+    #[displaydoc("{0}")]
     UnexpectedNumberOfDimensions(#[from] UnexpectedNumberOfDimensions),
+
     /// Missing parameters for {name}
     MissingParameters { name: String },
 }
@@ -284,6 +289,23 @@ impl BinParamsWithScope<'_> {
             prefix: self.prefix.clone() + scope + "/",
         }
     }
+}
+
+/// Failed to load the layer
+#[derive(Debug, Display, Error)]
+#[prefix_enum_doc_attributes]
+pub enum LoadingLayerFailed {
+    /// Incompatible matrices.
+    #[displaydoc("{0}")]
+    IncompatibleMatrices(#[from] IncompatibleMatrices),
+
+    /// Mismatched dimensions.
+    #[displaydoc("{0}")]
+    DimensionMismatch(#[from] UnexpectedNumberOfDimensions),
+
+    /// Irretrivable parameters.
+    #[displaydoc("{0}")]
+    FailedToRetrieveParams(#[from] FailedToRetrieveParams),
 }
 
 #[cfg(test)]

--- a/xayn-ai/src/ltr/list_net/model.rs
+++ b/xayn-ai/src/ltr/list_net/model.rs
@@ -27,8 +27,8 @@ use crate::ltr::list_net::data::{
 };
 use layer::{
     activation::{Linear, Relu, Softmax},
-    dense::{Dense, DenseGradientSet, LoadingDenseFailed},
-    io::{BinParams, LoadingBinParamsFailed},
+    dense::{Dense, DenseGradientSet},
+    io::{BinParams, LoadingBinParamsFailed, LoadingLayerFailed},
     utils::{he_normal_weights_init, kl_divergence, IncompatibleMatrices},
 };
 
@@ -41,7 +41,7 @@ pub enum LoadingListNetFailed {
 
     /// Failed to create instance of `Dense`.
     #[displaydoc("{0}")]
-    Dense(#[from] LoadingDenseFailed),
+    Dense(#[from] LoadingLayerFailed),
 
     /// Tried to load a ListNet containing incompatible matrices.
     #[displaydoc("{0}")]


### PR DESCRIPTION
**References**

- [TY-2136]
- [TY-2137]

**Summary**

- make the bias of the convolutional layer required: the original python/c source had this optionally, but we always require it anyways, which allows for a code simplifcation
- add an activation function to the convolutional layer: similarly to the dense layer the activation function is an integral part of the layer
- add loading of the convolutional layer from binary parameters


[TY-2136]: https://xainag.atlassian.net/browse/TY-2136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2137]: https://xainag.atlassian.net/browse/TY-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ