### PR TITLE
[Merged by Bors] - TY-2136 impl kpe models manually [4]

### DIFF
--- a/kpe/src/lib.rs
+++ b/kpe/src/lib.rs
@@ -9,7 +9,6 @@
 //!         .with_accents(false)
 //!         .with_lowercase(true)
 //!         .with_token_size(64)?
-//!         .with_key_phrase_size(5)?
 //!         .build()?;
 //!
 //!     let key_phrases = kpe.run("This is a sequence.")?;

--- a/kpe/src/model/cnn.rs
+++ b/kpe/src/model/cnn.rs
@@ -30,6 +30,9 @@ pub struct CnnModel {
 pub struct Features(pub Arc<Tensor>);
 
 impl CnnModel {
+    /// The maximum number of words per key phrase.
+    pub const KEY_PHRASE_SIZE: usize = 5;
+
     /// Creates a model from an onnx model file.
     ///
     /// Requires the maximum number of tokens per tokenized sequence and the size of the embedding

--- a/kpe/src/pipeline.rs
+++ b/kpe/src/pipeline.rs
@@ -13,7 +13,7 @@ use crate::{
 ///
 /// [`Builder`]: crate::builder::Builder
 pub struct Pipeline {
-    pub(crate) tokenizer: Tokenizer,
+    pub(crate) tokenizer: Tokenizer<{ CnnModel::KEY_PHRASE_SIZE }>,
     pub(crate) bert: BertModel,
     pub(crate) cnn: CnnModel,
     pub(crate) classifier: ClassifierModel,

--- a/kpe/src/tokenizer/mod.rs
+++ b/kpe/src/tokenizer/mod.rs
@@ -9,10 +9,9 @@ use thiserror::Error;
 
 /// A pre-configured Bert tokenizer for key phrase extraction.
 #[derive(Debug)]
-pub struct Tokenizer {
+pub struct Tokenizer<const KEY_PHRASE_SIZE: usize> {
     tokenizer: BertTokenizer<i64>,
     token_size: usize,
-    key_phrase_size: usize,
     key_phrase_max_count: Option<usize>,
     key_phrase_min_score: Option<f32>,
 }
@@ -24,22 +23,20 @@ pub enum TokenizerError {
     Builder(#[from] BuilderError),
 }
 
-impl Tokenizer {
+impl<const KEY_PHRASE_SIZE: usize> Tokenizer<KEY_PHRASE_SIZE> {
     /// Creates a tokenizer from a vocabulary.
     ///
     /// Can be set to keep accents and to lowercase the sequences. Requires the maximum number of
     /// tokens per tokenized sequence, which applies to padding and truncation and includes special
     /// tokens as well.
     ///
-    /// Also requires the maximum number of words per key phrase. Optionally takes
-    /// an upper count for the number of returned key phrases as well as a lower threshold for the
-    /// scores of returned key phrases.
+    /// Optionally takes an upper count for the number of returned key phrases as well as a lower
+    /// threshold for the scores of returned key phrases.
     pub fn new(
         vocab: impl BufRead,
         accents: bool,
         lowercase: bool,
         token_size: usize,
-        key_phrase_size: usize,
         key_phrase_max_count: Option<usize>,
         key_phrase_min_score: Option<f32>,
     ) -> Result<Self, TokenizerError> {
@@ -54,7 +51,6 @@ impl Tokenizer {
         Ok(Tokenizer {
             tokenizer,
             token_size,
-            key_phrase_size,
             key_phrase_max_count,
             key_phrase_min_score,
         })


### PR DESCRIPTION
**References**

- [TY-2136]
- [TY-2137]

**Summary**

- remove the `key_phrase_size` as a configurable model parameter and make it a constant of the model: this value is solely determined by the model asset and hence not configurable on the fly
  - const generic for the tokenizer to keep its tests independent of the model asset
  - const value for the model to make it adjustable in the rare event of a new model

**Todo**

- ~rebase once #292 and #293 are merged~


[TY-2136]: https://xainag.atlassian.net/browse/TY-2136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2137]: https://xainag.atlassian.net/browse/TY-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ