### PR TITLE
[Merged by Bors] - TY-2218 fix wasm RuntimeError handling

### DIFF
--- a/bindings/dart/lib/src/web/ffi/ai.dart
+++ b/bindings/dart/lib/src/web/ffi/ai.dart
@@ -4,6 +4,7 @@ library ai;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:js/js.dart' show JS;
+import 'package:js/js_util.dart' show instanceof;
 
 import 'package:xayn_ai_ffi_dart/src/common/data/document.dart' show Document;
 import 'package:xayn_ai_ffi_dart/src/common/data/history.dart' show History;
@@ -22,10 +23,12 @@ import 'package:xayn_ai_ffi_dart/src/web/reranker/analytics.dart'
     show JsAnalytics, ToAnalytics;
 import 'package:xayn_ai_ffi_dart/src/web/result/error.dart'
     show
-        RuntimeError,
+        ObjectToRuntimeError,
+        ObjectToXaynAiError,
         RuntimeErrorToException,
         XaynAiError,
-        XaynAiErrorToException;
+        XaynAiErrorToException,
+        runtimeError;
 import 'package:xayn_ai_ffi_dart/src/web/result/fault.dart'
     show JsFault, ToStrings;
 import 'package:xayn_ai_ffi_dart/src/web/result/outcomes.dart'
@@ -111,10 +114,14 @@ class XaynAi {
         ltrModel,
         serialized,
       );
-    } on XaynAiError catch (error) {
-      throw error.toException();
-    } on RuntimeError catch (error) {
-      throw error.toException();
+    } catch (error) {
+      if (instanceof(error, runtimeError)) {
+        throw error.toRuntimeError().toException();
+      } else if (XaynAiError.isXaynAiError(error)) {
+        throw error.toXaynAiError().toException();
+      } else {
+        rethrow;
+      }
     }
   }
 
@@ -142,13 +149,17 @@ class XaynAi {
             documents.toJsDocuments(),
           )
           .toRerankingOutcomes();
-    } on XaynAiError catch (error) {
-      throw error.toException();
-    } on RuntimeError catch (error) {
-      // the memory is automatically cleaned up by the js garbage collector once all reference to
-      // _ai are gone, which usually happens when creating a new wasm instance
-      _ai = null;
-      throw error.toException();
+    } catch (error) {
+      if (instanceof(error, runtimeError)) {
+        // the memory is automatically cleaned up by the js garbage collector once all reference to
+        // _ai are gone, which usually happens when creating a new wasm instance
+        _ai = null;
+        throw error.toRuntimeError().toException();
+      } else if (XaynAiError.isXaynAiError(error)) {
+        throw error.toXaynAiError().toException();
+      } else {
+        rethrow;
+      }
     }
   }
 
@@ -164,11 +175,15 @@ class XaynAi {
 
     try {
       return _ai!.serialize();
-    } on XaynAiError catch (error) {
-      throw error.toException();
-    } on RuntimeError catch (error) {
-      _ai = null;
-      throw error.toException();
+    } catch (error) {
+      if (instanceof(error, runtimeError)) {
+        _ai = null;
+        throw error.toRuntimeError().toException();
+      } else if (XaynAiError.isXaynAiError(error)) {
+        throw error.toXaynAiError().toException();
+      } else {
+        rethrow;
+      }
     }
   }
 
@@ -186,9 +201,13 @@ class XaynAi {
 
     try {
       return _ai!.faults().toStrings();
-    } on RuntimeError catch (error) {
-      _ai = null;
-      throw error.toException();
+    } catch (error) {
+      if (instanceof(error, runtimeError)) {
+        _ai = null;
+        throw error.toRuntimeError().toException();
+      } else {
+        rethrow;
+      }
     }
   }
 
@@ -204,9 +223,13 @@ class XaynAi {
 
     try {
       return _ai!.analytics()?.toAnalytics();
-    } on RuntimeError catch (error) {
-      _ai = null;
-      throw error.toException();
+    } catch (error) {
+      if (instanceof(error, runtimeError)) {
+        _ai = null;
+        throw error.toRuntimeError().toException();
+      } else {
+        rethrow;
+      }
     }
   }
 
@@ -222,11 +245,15 @@ class XaynAi {
 
     try {
       return _ai!.syncdataBytes();
-    } on XaynAiError catch (error) {
-      throw error.toException();
-    } on RuntimeError catch (error) {
-      _ai = null;
-      throw error.toException();
+    } catch (error) {
+      if (instanceof(error, runtimeError)) {
+        _ai = null;
+        throw error.toRuntimeError().toException();
+      } else if (XaynAiError.isXaynAiError(error)) {
+        throw error.toXaynAiError().toException();
+      } else {
+        rethrow;
+      }
     }
   }
 
@@ -242,11 +269,15 @@ class XaynAi {
 
     try {
       _ai!.synchronize(serialized);
-    } on XaynAiError catch (error) {
-      throw error.toException();
-    } on RuntimeError catch (error) {
-      _ai = null;
-      throw error.toException();
+    } catch (error) {
+      if (instanceof(error, runtimeError)) {
+        _ai = null;
+        throw error.toRuntimeError().toException();
+      } else if (XaynAiError.isXaynAiError(error)) {
+        throw error.toXaynAiError().toException();
+      } else {
+        rethrow;
+      }
     }
   }
 

--- a/bindings/dart/lib/src/web/reranker/ai.dart
+++ b/bindings/dart/lib/src/web/reranker/ai.dart
@@ -38,8 +38,7 @@ const int kReceiveTimeoutSeconds = 15;
 ///
 /// After a [TimeoutException] was thrown, the instance must be disposed by
 /// calling [XaynAi.free]. The instance must not be used afterwards.
-/// Note: Calling [XaynAi.free] can also throw a [XaynAiException] or a
-/// [TimeoutException].
+/// Note: Calling [XaynAi.free] can also throw a [TimeoutException].
 class XaynAi implements common.XaynAi {
   final Worker? _worker;
 

--- a/bindings/dart/lib/src/web/result/error.dart
+++ b/bindings/dart/lib/src/web/result/error.dart
@@ -20,7 +20,7 @@ class XaynAiError extends Error {
 
 extension ObjectToXaynAiError on Object {
   XaynAiError toXaynAiError() => XaynAiError(
-        (getProperty(this, 'code') as int),
+        getProperty(this, 'code') as int,
         getProperty(this, 'message') as String,
       );
 }

--- a/bindings/dart/lib/src/web/result/error.dart
+++ b/bindings/dart/lib/src/web/result/error.dart
@@ -1,19 +1,28 @@
 @JS()
 library error;
 
-import 'package:js/js.dart' show anonymous, JS;
+import 'package:js/js.dart' show JS;
+import 'package:js/js_util.dart' show getProperty, hasProperty;
 
 import 'package:xayn_ai_ffi_dart/src/common/result/error.dart'
     show Code, IntToCode, XaynAiException;
 
-@JS()
-@anonymous
-class XaynAiError {
-  external int get code;
+class XaynAiError extends Error {
+  final int code;
+  final String message;
 
-  external String get message;
+  static bool isXaynAiError(Object o) {
+    return hasProperty(o, 'code') && hasProperty(o, 'message');
+  }
 
-  external factory XaynAiError({int code, String message});
+  XaynAiError(this.code, this.message);
+}
+
+extension ObjectToXaynAiError on Object {
+  XaynAiError toXaynAiError() => XaynAiError(
+        (getProperty(this, 'code') as int),
+        getProperty(this, 'message') as String,
+      );
 }
 
 extension XaynAiErrorToException on XaynAiError {
@@ -22,12 +31,23 @@ extension XaynAiErrorToException on XaynAiError {
 }
 
 @JS('WebAssembly.RuntimeError')
-class RuntimeError {}
+external Function get runtimeError;
+
+class RuntimeError extends Error {
+  final String message;
+
+  RuntimeError(this.message);
+}
+
+extension ObjectToRuntimeError on Object {
+  RuntimeError toRuntimeError() =>
+      RuntimeError(getProperty(this, 'message') as String);
+}
 
 extension RuntimeErrorToException on RuntimeError {
   /// Creates an exception with a [`Code.panic`] from the JS runtime error.
   XaynAiException toException() => XaynAiException(
         Code.panic,
-        'JS WebAssembly RuntimeError: $this',
+        'JS WebAssembly RuntimeError: $message',
       );
 }

--- a/bindings/dart/lib/src/web/result/error.dart
+++ b/bindings/dart/lib/src/web/result/error.dart
@@ -31,6 +31,7 @@ extension XaynAiErrorToException on XaynAiError {
 }
 
 @JS('WebAssembly.RuntimeError')
+// see: https://github.com/lexaknyazev/wasm.dart/blob/a6c93afea4732c140f1f61f144795961c42c8613/wasm_interop/lib/wasm_interop.dart#L718
 external Function get runtimeError;
 
 class RuntimeError extends Error {


### PR DESCRIPTION
Ticket:

[TY-2218]

Summary:

I noticed this bug when I was trying to catch a `WebAssembly.RuntimeError` in `_XaynAi`. 
The code failed in the `on XaynAiError catch` block with following message:
`Web worker error while handling the method call Method.create: Undefined enum variant.`


There were two problems: 

1. The `RuntimeError` was interpreted as a `XaynAiError`. When Dart translate the code into JS it generates some like this for the `on XaynAiError catch` line


```js
if (type$.XaynAiError._is(t1))
```  

The same JS code is generated if you write:  

```dart
catch (error) {
	if (error is XaynAiError)
```

And here lies the problem, since `XaynAiError` is a `@JS()` type, `is` always returns `true`

From the Readme of the [js package](https://pub.dev/packages/js)

> `is` checks and `as` casts between JS interop types will always succeed
>
> For any two `@JS()` types, with or without `@anonymous`, a check of whether an object of one type `is` another type > will always return true, regardless of whether those two types are in the same prototype chain. Similarly, an explicit cast  using `as` will also succeed. 

2. Our Dart type `RuntimeError` did not refer to the `WebAssembly.RuntimeError`, instead Dart creates a new type for that (`V.RuntimeError0`). I found the solution to this problem in the [`wasm.dart`](https://github.com/lexaknyazev/wasm.dart/blob/a6c93afea4732c140f1f61f144795961c42c8613/wasm_interop/lib/wasm_interop.dart#L718) repo. 

The generated JS error handling code before the change:

```js
catch (exception) {
	t1 = H.unwrapException(exception);
	if (type$.XaynAiError._is(t1)) {
    	        error = t1;
    	        throw H.wrapException(V.XaynAiErrorToException_toException(error));
	} else if (t1 instanceof V.RuntimeError0) {
		error0 = t1;
		throw H.wrapException(V.RuntimeErrorToException_toException(error0));
	} else
		throw exception;
	}
```

and after:

```js
catch (exception) {
	error = H.unwrapException(exception);
	if (error instanceof self.WebAssembly.RuntimeError)
		throw H.wrapException(V.RuntimeErrorToException_toException(V.ObjectToRuntimeError_toRuntimeError(error)));
	else {
		t1 = error;
		if ("code" in t1 && "message" in t1)
			throw H.wrapException(V.XaynAiErrorToException_toException(V.ObjectToXaynAiError_toXaynAiError(error)));
		else
			throw exception;
		}
	}
```

The error `Undefined enum variant` was thrown in the `toCode` function because the value of `code` was `undefined` (it does not exist in `RuntimeError`).


Tested `flutter run`, `flutter build` and `flutter build --release` on Chrome, Firefox and Safari.

[TY-2218]: https://xainag.atlassian.net/browse/TY-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ