### PR TITLE
[Merged by Bors] - TY-2136 impl kpe models manually [5]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "displaydoc",
+ "layer",
  "ndarray",
  "rubert-tokenizer",
  "test-utils",

--- a/kpe/Cargo.toml
+++ b/kpe/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 derive_more = { version = "0.99.16", default-features = false, features = ["deref", "from"] }
 displaydoc = "0.2.3"
+layer = { path = "../layer" }
 # to be kept in sync with tract-core
 ndarray = "=0.15.3"
 rubert-tokenizer = { path = "../rubert-tokenizer" }

--- a/kpe/src/builder.rs
+++ b/kpe/src/builder.rs
@@ -79,7 +79,7 @@ impl<V, M> Builder<V, M> {
             classifier,
             accents: false,
             lowercase: true,
-            token_size: 1024,
+            token_size: 512,
             key_phrase_max_count: None,
             key_phrase_min_score: None,
         }
@@ -103,12 +103,12 @@ impl<V, M> Builder<V, M> {
 
     /// Sets the token size for the tokenizer and the models.
     ///
-    /// Defaults to `1024`.
+    /// Defaults to `512`.
     ///
     /// # Errors
-    /// Fails if `size` is less than two.
+    /// Fails if `size` is less than two or greater than 512.
     pub fn with_token_size(mut self, size: usize) -> Result<Self, BuilderError> {
-        if size > 1 {
+        if size > 1 && size < 513 {
             self.token_size = size;
             Ok(self)
         } else {

--- a/kpe/src/builder.rs
+++ b/kpe/src/builder.rs
@@ -8,7 +8,7 @@ use displaydoc::Display;
 use thiserror::Error;
 
 use crate::{
-    model::{bert::BertModel, classifier::ClassifierModel, cnn::CnnModel, ModelError},
+    model::{bert::Bert, classifier::Classifier, cnn::Cnn, ModelError},
     pipeline::Pipeline,
     tokenizer::{Tokenizer, TokenizerError},
 };
@@ -165,9 +165,9 @@ impl<V, M> Builder<V, M> {
             self.key_phrase_max_count,
             self.key_phrase_min_score,
         )?;
-        let bert = BertModel::new(self.bert, self.token_size)?;
-        let cnn = CnnModel::new(self.cnn)?;
-        let classifier = ClassifierModel::new(self.classifier)?;
+        let bert = Bert::new(self.bert, self.token_size)?;
+        let cnn = Cnn::new(self.cnn)?;
+        let classifier = Classifier::new(self.classifier)?;
 
         Ok(Pipeline {
             tokenizer,

--- a/kpe/src/builder.rs
+++ b/kpe/src/builder.rs
@@ -108,7 +108,7 @@ impl<V, M> Builder<V, M> {
     /// # Errors
     /// Fails if `size` is less than two or greater than 512.
     pub fn with_token_size(mut self, size: usize) -> Result<Self, BuilderError> {
-        if size > 1 && size < 513 {
+        if (2..=512).contains(&size) {
             self.token_size = size;
             Ok(self)
         } else {

--- a/kpe/src/builder.rs
+++ b/kpe/src/builder.rs
@@ -79,7 +79,7 @@ impl<V, M> Builder<V, M> {
             classifier,
             accents: false,
             lowercase: true,
-            token_size: 512,
+            token_size: *Bert::TOKEN_RANGE.end(),
             key_phrase_max_count: None,
             key_phrase_min_score: None,
         }
@@ -108,7 +108,7 @@ impl<V, M> Builder<V, M> {
     /// # Errors
     /// Fails if `size` is less than two or greater than 512.
     pub fn with_token_size(mut self, size: usize) -> Result<Self, BuilderError> {
-        if (2..=512).contains(&size) {
+        if Bert::TOKEN_RANGE.contains(&size) {
             self.token_size = size;
             Ok(self)
         } else {

--- a/kpe/src/lib.rs
+++ b/kpe/src/lib.rs
@@ -1,6 +1,6 @@
 //! The KPE pipeline extracts key phrases from a sequence.
 //!
-//! ```no_run
+//! ```compile_fail
 //! use kpe::Builder;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/kpe/src/lib.rs
+++ b/kpe/src/lib.rs
@@ -1,14 +1,19 @@
 //! The KPE pipeline extracts key phrases from a sequence.
 //!
-//! ```compile_fail
+//! ```no_run
 //! use kpe::Builder;
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let kpe = Builder::from_files("vocab.txt", "bert.onnx", "cnn.onnx", "classifier.onnx")?
-//!         .with_accents(false)
-//!         .with_lowercase(true)
-//!         .with_token_size(64)?
-//!         .build()?;
+//!     let kpe = Builder::from_files(
+//!         "vocab.txt",
+//!         "bert.onnx",
+//!         "cnn.binparams",
+//!         "classifier.binparams",
+//!     )?
+//!     .with_accents(false)
+//!     .with_lowercase(true)
+//!     .with_token_size(64)?
+//!     .build()?;
 //!
 //!     let key_phrases = kpe.run("This is a sequence.")?;
 //!     assert_eq!(key_phrases.len(), 12);

--- a/kpe/src/model/bert.rs
+++ b/kpe/src/model/bert.rs
@@ -97,6 +97,7 @@ impl BertModel {
 impl Embeddings {
     /// Collects the valid embeddings according to the mask.
     pub fn collect(self, valid_mask: ValidMask) -> Result<Array2<f32>, ModelError> {
+        debug_assert_eq!(self.shape()[0], 1);
         valid_mask
             .iter()
             .zip(self.to_array_view::<f32>()?.rows())

--- a/kpe/src/model/bert.rs
+++ b/kpe/src/model/bert.rs
@@ -33,9 +33,6 @@ impl BertModel {
     /// Creates a model from an onnx model file.
     ///
     /// Requires the maximum number of tokens per tokenized sequence.
-    ///
-    /// # Panics
-    /// Panics if the model is empty (due to the way tract implemented the onnx model parsing).
     pub fn new(mut model: impl Read, token_size: usize) -> Result<Self, ModelError> {
         let input_fact = InferenceFact::dt_shape(i64::datum_type(), &[1, token_size]);
         let plan = tract_onnx::onnx()
@@ -116,7 +113,7 @@ mod tests {
     use tract_onnx::prelude::IntoArcTensor;
 
     use super::*;
-    use test_utils::smbert::model;
+    use test_utils::kpe::bert;
 
     #[test]
     fn test_embeddings_collect_full() {
@@ -199,9 +196,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "missing bert model asset"]
     fn test_token_size_invalid() {
-        let model = BufReader::new(File::open(model().unwrap()).unwrap());
+        let model = BufReader::new(File::open(bert().unwrap()).unwrap());
         assert!(matches!(
             BertModel::new(model, 0).unwrap_err(),
             ModelError::Tract(_),
@@ -209,10 +205,9 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "missing bert model asset"]
     fn test_run() {
         let token_size = 64;
-        let model = BufReader::new(File::open(model().unwrap()).unwrap());
+        let model = BufReader::new(File::open(bert().unwrap()).unwrap());
         let model = BertModel::new(model, token_size).unwrap();
 
         let token_ids = Array2::from_elem((1, token_size), 0).into();

--- a/kpe/src/model/classifier.rs
+++ b/kpe/src/model/classifier.rs
@@ -4,7 +4,7 @@ use ndarray::{ErrorKind, ShapeError};
 
 use crate::{
     model::{
-        cnn::{CnnModel, Features},
+        cnn::{Cnn, Features},
         ModelError,
     },
     tokenizer::encoding::ActiveMask,
@@ -13,7 +13,7 @@ use layer::{activation::Linear, dense::Dense, io::BinParams};
 
 /// A Classifier model.
 #[derive(Debug)]
-pub struct ClassifierModel {
+pub struct Classifier {
     layer: Dense<Linear>,
 }
 
@@ -23,7 +23,7 @@ pub struct ClassifierModel {
 #[derive(Clone, Debug, Deref, From)]
 pub struct Scores(pub Vec<f32>);
 
-impl ClassifierModel {
+impl Classifier {
     /// Creates a model from a binary parameters file.
     pub fn new(mut params: BinParams) -> Result<Self, ModelError> {
         let layer = Dense::load(params.with_scope("dense"), Linear)?;
@@ -33,7 +33,7 @@ impl ClassifierModel {
             ));
         }
 
-        if layer.weights().shape() == [CnnModel::CHANNEL_OUT_SIZE, 1] {
+        if layer.weights().shape() == [Cnn::CHANNEL_OUT_SIZE, 1] {
             Ok(Self { layer })
         } else {
             Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into())
@@ -81,7 +81,7 @@ mod tests {
     #[test]
     fn test_model_empty() {
         matches!(
-            ClassifierModel::new(BinParams::default()).unwrap_err(),
+            Classifier::new(BinParams::default()).unwrap_err(),
             ModelError::Classifier(_),
         );
     }
@@ -90,9 +90,9 @@ mod tests {
     fn test_run_unique() {
         let output_size = 42;
         let model =
-            ClassifierModel::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
+            Classifier::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
                 .unwrap();
-        let features = Array2::zeros((CnnModel::CHANNEL_OUT_SIZE, output_size)).into();
+        let features = Array2::zeros((Cnn::CHANNEL_OUT_SIZE, output_size)).into();
         let active_mask = Array2::from_elem((output_size, output_size), true).into();
         assert_eq!(model.run(features, active_mask).unwrap().len(), output_size);
     }
@@ -101,9 +101,9 @@ mod tests {
     fn test_run_duplicate() {
         let output_size = 42;
         let model =
-            ClassifierModel::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
+            Classifier::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
                 .unwrap();
-        let features = Array2::zeros((CnnModel::CHANNEL_OUT_SIZE, output_size)).into();
+        let features = Array2::zeros((Cnn::CHANNEL_OUT_SIZE, output_size)).into();
         let active_mask = Array2::from_elem((output_size / 2, output_size), true).into();
         assert_eq!(
             model.run(features, active_mask).unwrap().len(),

--- a/kpe/src/model/classifier.rs
+++ b/kpe/src/model/classifier.rs
@@ -1,30 +1,16 @@
-use std::io::Read;
-
 use derive_more::{Deref, From};
-use ndarray::s;
-use tract_onnx::prelude::{
-    tvec,
-    Datum,
-    Framework,
-    InferenceFact,
-    InferenceModelExt,
-    IntoTensor,
-    TypedModel,
-    TypedSimplePlan,
-};
+use ndarray::{s, Array1, Array2};
 
 use crate::{
-    model::{
-        cnn::{CnnModel, Features},
-        ModelError,
-    },
+    model::{cnn::Features, ModelError},
     tokenizer::encoding::ActiveMask,
 };
+use layer::{activation::Linear, dense::Dense};
 
 /// A Classifier onnx model.
 #[derive(Debug)]
 pub struct ClassifierModel {
-    plan: TypedSimplePlan<TypedModel>,
+    dense: Dense<Linear>,
 }
 
 /// The inferred scores.
@@ -39,40 +25,25 @@ impl ClassifierModel {
     ///
     /// # Panics
     /// Panics if the model is empty (due to the way tract implemented the onnx model parsing).
-    pub fn new(mut model: impl Read, cnn_out_channel_size: usize) -> Result<Self, ModelError> {
-        let input_fact = InferenceFact::dt_shape(
-            f32::datum_type(),
-            &[1, CnnModel::KEY_PHRASE_SIZE, cnn_out_channel_size],
-        );
-        let plan = tract_onnx::onnx()
-            .model_for_read(&mut model)?
-            .with_input_fact(0, input_fact)? // convolved features
-            .into_optimized()?
-            .into_runnable()?;
+    pub fn new(weights: Array2<f32>, bias: Array1<f32>) -> Result<Self, ModelError> {
+        let dense = Dense::new(weights, bias, Linear)?;
 
-        Ok(ClassifierModel { plan })
+        Ok(ClassifierModel { dense })
     }
 
     /// Runs the model on the convolved features to compute the scores.
     pub fn run(&self, features: Features, active_mask: ActiveMask) -> Result<Scores, ModelError> {
         debug_assert_eq!(features.shape()[1..], active_mask.shape()[..]);
-        let inputs = tvec!(features.0.into_tensor());
-        let outputs = self.plan.run(inputs)?;
-        debug_assert!(outputs[0]
-            .to_array_view::<f32>()?
-            .iter()
-            .all(|v| !v.is_infinite() && !v.is_nan()));
+        let (scores, _) = self.dense.run(features.0.slice(s![0, .., ..]), false);
+        debug_assert!(scores.iter().all(|v| !v.is_infinite() && !v.is_nan()));
 
-        // TODO: check if the shapes match once we have the models loaded
-        let scores = outputs[0].to_array_view::<f32>()?;
-        let scores = scores.slice(s![0, .., 0]);
         let scores = active_mask
             .rows()
             .into_iter()
             .map(|active| {
                 active
                     .iter()
-                    .zip(scores)
+                    .zip(scores.iter())
                     .filter_map(|(active, score)| active.then(|| score))
                     .copied()
                     .reduce(f32::max)
@@ -87,51 +58,20 @@ impl ClassifierModel {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, io::BufReader};
-
-    use ndarray::{Array2, Array3};
-    use tract_onnx::prelude::IntoArcTensor;
+    use ndarray::Array3;
 
     use super::*;
-    use test_utils::smbert::model;
 
     #[test]
-    fn test_model_empty() {
-        assert!(matches!(
-            ClassifierModel::new(Vec::new().as_slice(), 128).unwrap_err(),
-            ModelError::Tract(_),
-        ));
-    }
-
-    #[test]
-    fn test_model_invalid() {
-        assert!(matches!(
-            ClassifierModel::new([0].as_ref(), 128).unwrap_err(),
-            ModelError::Tract(_),
-        ));
-    }
-
-    #[test]
-    #[ignore = "missing classifier model asset"]
-    fn test_cnn_out_channel_size_invalid() {
-        let model = BufReader::new(File::open(model().unwrap()).unwrap());
-        assert!(matches!(
-            ClassifierModel::new(model, 0).unwrap_err(),
-            ModelError::Tract(_),
-        ));
-    }
-
-    #[test]
-    #[ignore = "missing classifier model asset"]
+    #[ignore = "check actual weight shapes"]
     fn test_run() {
-        let cnn_out_channel_size = 128;
+        let key_phrase_size = 5;
+        let channel_out_size = 128;
         let key_phrase_choices = 10;
-        let model = BufReader::new(File::open(model().unwrap()).unwrap());
-        let model = ClassifierModel::new(model, cnn_out_channel_size).unwrap();
+        let model =
+            ClassifierModel::new(Array2::zeros((channel_out_size, 1)), Array1::zeros(1)).unwrap();
 
-        let features = Array3::from_elem((1, CnnModel::KEY_PHRASE_SIZE, cnn_out_channel_size), 0)
-            .into_arc_tensor()
-            .into();
+        let features = Array3::zeros((1, key_phrase_size, channel_out_size)).into();
         let active_mask =
             Array2::from_elem((key_phrase_choices, key_phrase_choices + 5), false).into();
         let scores = model.run(features, active_mask).unwrap();

--- a/kpe/src/model/classifier.rs
+++ b/kpe/src/model/classifier.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use layer::{activation::Linear, dense::Dense, io::BinParams};
 
-/// A Classifier onnx model.
+/// A Classifier model.
 #[derive(Debug)]
 pub struct ClassifierModel {
     layer: Dense<Linear>,
@@ -39,6 +39,7 @@ impl ClassifierModel {
             .into_iter()
             .all(|row| row.iter().any(|active| *active)));
         let (scores, _) = self.layer.run(features.t(), false);
+        debug_assert_eq!(scores.shape(), [features.shape()[1], 1]);
         debug_assert!(scores.iter().all(|v| !v.is_infinite() && !v.is_nan()));
 
         let scores = active_mask
@@ -54,6 +55,7 @@ impl ClassifierModel {
                     .unwrap(/* active mask must have entries in each row */)
             })
             .collect::<Vec<f32>>();
+        debug_assert_eq!(scores.len(), active_mask.shape()[0]);
         debug_assert!(scores.iter().all(|v| !v.is_infinite() && !v.is_nan()));
 
         Ok(scores.into())

--- a/kpe/src/model/classifier.rs
+++ b/kpe/src/model/classifier.rs
@@ -1,16 +1,16 @@
 use derive_more::{Deref, From};
-use ndarray::{s, Array1, Array2};
+use ndarray::s;
 
 use crate::{
     model::{cnn::Features, ModelError},
     tokenizer::encoding::ActiveMask,
 };
-use layer::{activation::Linear, dense::Dense};
+use layer::{activation::Linear, dense::Dense, io::BinParams};
 
 /// A Classifier onnx model.
 #[derive(Debug)]
 pub struct ClassifierModel {
-    dense: Dense<Linear>,
+    layer: Dense<Linear>,
 }
 
 /// The inferred scores.
@@ -18,23 +18,22 @@ pub struct ClassifierModel {
 pub struct Scores(pub Vec<f32>);
 
 impl ClassifierModel {
-    /// Creates a model from an onnx model file.
-    ///
-    /// Requires the maximum number of words per key phrase and the size of the output channel of
-    /// the CNN model.
-    ///
-    /// # Panics
-    /// Panics if the model is empty (due to the way tract implemented the onnx model parsing).
-    pub fn new(weights: Array2<f32>, bias: Array1<f32>) -> Result<Self, ModelError> {
-        let dense = Dense::new(weights, bias, Linear)?;
+    /// Creates a model from a binary parameters file.
+    pub fn new(mut params: BinParams) -> Result<Self, ModelError> {
+        let layer = Dense::load(params.with_scope("dense"), Linear)?;
+        if !params.is_empty() {
+            return Err(ModelError::UnusedParams(
+                params.keys().map(Into::into).collect(),
+            ));
+        }
 
-        Ok(ClassifierModel { dense })
+        Ok(Self { layer })
     }
 
     /// Runs the model on the convolved features to compute the scores.
     pub fn run(&self, features: Features, active_mask: ActiveMask) -> Result<Scores, ModelError> {
         debug_assert_eq!(features.shape()[1..], active_mask.shape()[..]);
-        let (scores, _) = self.dense.run(features.0.slice(s![0, .., ..]), false);
+        let (scores, _) = self.layer.run(features.0.slice(s![0, .., ..]), false);
         debug_assert!(scores.iter().all(|v| !v.is_infinite() && !v.is_nan()));
 
         let scores = active_mask
@@ -58,22 +57,25 @@ impl ClassifierModel {
 
 #[cfg(test)]
 mod tests {
-    use ndarray::Array3;
+    use ndarray::{Array2, Array3};
 
     use super::*;
+    use test_utils::kpe::classifier;
 
     #[test]
     #[ignore = "check actual weight shapes"]
     fn test_run() {
-        let key_phrase_size = 5;
-        let channel_out_size = 128;
-        let key_phrase_choices = 10;
         let model =
-            ClassifierModel::new(Array2::zeros((channel_out_size, 1)), Array1::zeros(1)).unwrap();
+            ClassifierModel::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
+                .unwrap();
 
+        let key_phrase_size = 5;
+        let channel_out_size = 512;
+        let key_phrase_choices = 10;
         let features = Array3::zeros((1, key_phrase_size, channel_out_size)).into();
         let active_mask =
             Array2::from_elem((key_phrase_choices, key_phrase_choices + 5), false).into();
+
         let scores = model.run(features, active_mask).unwrap();
         assert_eq!(scores.len(), key_phrase_choices);
     }

--- a/kpe/src/model/classifier.rs
+++ b/kpe/src/model/classifier.rs
@@ -1,5 +1,4 @@
 use derive_more::{Deref, From};
-use ndarray::s;
 
 use crate::{
     model::{cnn::Features, ModelError},
@@ -14,7 +13,9 @@ pub struct ClassifierModel {
 }
 
 /// The inferred scores.
-#[derive(Clone, Deref, From)]
+///
+/// The scores are of shape `(len(key_phrase_choices),)`.
+#[derive(Clone, Debug, Deref, From)]
 pub struct Scores(pub Vec<f32>);
 
 impl ClassifierModel {
@@ -32,8 +33,12 @@ impl ClassifierModel {
 
     /// Runs the model on the convolved features to compute the scores.
     pub fn run(&self, features: Features, active_mask: ActiveMask) -> Result<Scores, ModelError> {
-        debug_assert_eq!(features.shape()[1..], active_mask.shape()[..]);
-        let (scores, _) = self.layer.run(features.0.slice(s![0, .., ..]), false);
+        debug_assert_eq!(features.shape()[1], active_mask.shape()[1]);
+        debug_assert!(active_mask
+            .rows()
+            .into_iter()
+            .all(|row| row.iter().any(|active| *active)));
+        let (scores, _) = self.layer.run(features.t(), false);
         debug_assert!(scores.iter().all(|v| !v.is_infinite() && !v.is_nan()));
 
         let scores = active_mask
@@ -57,26 +62,55 @@ impl ClassifierModel {
 
 #[cfg(test)]
 mod tests {
-    use ndarray::{Array2, Array3};
+    use ndarray::Array2;
 
     use super::*;
     use test_utils::kpe::classifier;
 
     #[test]
-    #[ignore = "check actual weight shapes"]
-    fn test_run() {
+    fn test_model_shapes() {
         let model =
             ClassifierModel::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
                 .unwrap();
+        assert_eq!(model.layer.weights().shape(), [512, 1],);
+        assert_eq!(model.layer.bias().shape(), [1]);
+    }
 
-        let key_phrase_size = 5;
+    #[test]
+    fn test_model_empty() {
+        matches!(
+            ClassifierModel::new(BinParams::default()).unwrap_err(),
+            ModelError::Classifier(_),
+        );
+    }
+
+    #[test]
+    fn test_run_unique() {
         let channel_out_size = 512;
-        let key_phrase_choices = 10;
-        let features = Array3::zeros((1, key_phrase_size, channel_out_size)).into();
-        let active_mask =
-            Array2::from_elem((key_phrase_choices, key_phrase_choices + 5), false).into();
+        let output_size = 42;
+
+        let model =
+            ClassifierModel::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
+                .unwrap();
+        let features = Array2::zeros((channel_out_size, output_size)).into();
+        let active_mask = Array2::from_elem((output_size, output_size), true).into();
 
         let scores = model.run(features, active_mask).unwrap();
-        assert_eq!(scores.len(), key_phrase_choices);
+        assert_eq!(scores.len(), output_size);
+    }
+
+    #[test]
+    fn test_run_duplicate() {
+        let channel_out_size = 512;
+        let output_size = 42;
+
+        let model =
+            ClassifierModel::new(BinParams::deserialize_from_file(classifier().unwrap()).unwrap())
+                .unwrap();
+        let features = Array2::zeros((channel_out_size, output_size)).into();
+        let active_mask = Array2::from_elem((output_size / 2, output_size), true).into();
+
+        let scores = model.run(features, active_mask).unwrap();
+        assert_eq!(scores.len(), output_size / 2);
     }
 }

--- a/kpe/src/model/cnn.rs
+++ b/kpe/src/model/cnn.rs
@@ -1,33 +1,21 @@
-use std::{io::Read, sync::Arc};
-
 use derive_more::{Deref, From};
-use ndarray::{ErrorKind, ShapeError};
-use tract_onnx::prelude::{
-    tvec,
-    Datum,
-    Framework,
-    InferenceFact,
-    InferenceModelExt,
-    Tensor,
-    TypedModel,
-    TypedSimplePlan,
-};
+use ndarray::{concatenate, Array1, Array3, Axis, ErrorKind, ShapeError};
 
 use crate::{
     model::{bert::Embeddings, ModelError},
     tokenizer::encoding::ValidMask,
 };
+use layer::{activation::Relu, conv::Conv1D};
 
 /// A CNN onnx model.
 #[derive(Debug)]
 pub struct CnnModel {
-    plan: TypedSimplePlan<TypedModel>,
-    pub out_channel_size: usize,
+    layers: Vec<Conv1D<Relu>>,
 }
 
 /// The inferred features.
 #[derive(Clone, Deref, From)]
-pub struct Features(pub Arc<Tensor>);
+pub struct Features(pub Array3<f32>);
 
 impl CnnModel {
     /// The maximum number of words per key phrase.
@@ -40,33 +28,27 @@ impl CnnModel {
     ///
     /// # Panics
     /// Panics if the model is empty (due to the way tract implemented the onnx model parsing).
-    pub fn new(
-        mut model: impl Read,
-        token_size: usize,
-        embedding_size: usize,
-    ) -> Result<Self, ModelError> {
-        let input_fact =
-            InferenceFact::dt_shape(f32::datum_type(), &[1, token_size, embedding_size]);
-        let plan = tract_onnx::onnx()
-            .model_for_read(&mut model)?
-            .with_input_fact(0, input_fact)? // valid embeddings
-            .into_optimized()?
-            .into_runnable()?;
+    pub fn new(weights: Vec<Array3<f32>>, bias: Vec<Array1<f32>>) -> Result<Self, ModelError> {
+        if weights.is_empty() || weights.len() != bias.len() {
+            return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into());
+        }
+        let weights_shape = &weights[0].shape()[..2];
+        let bias_shape = bias[0].shape();
+        if weights.iter().zip(bias.iter()).any(|(w, b)| {
+            let ws = &w.shape()[..2];
+            let bs = b.shape();
+            ws != weights_shape || bs != bias_shape || ws[0] != bs[0]
+        }) {
+            return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into());
+        }
 
-        let out_channel_size = plan
-            .model()
-            .output_fact(0)?
-            .shape
-            .as_concrete()
-            .map(|shape| shape.get(1).copied())
-            .flatten()
-            .ok_or_else(|| ShapeError::from_kind(ErrorKind::IncompatibleShape))?;
-        debug_assert!(out_channel_size > 0);
+        let layers = weights
+            .into_iter()
+            .zip(bias.into_iter())
+            .map(|(weights, bias)| Conv1D::new(weights, bias, Relu, 1, 0, 1, 1))
+            .collect::<Result<_, _>>()?;
 
-        Ok(CnnModel {
-            plan,
-            out_channel_size,
-        })
+        Ok(Self { layers })
     }
 
     /// Runs the model on the valid embeddings to compute the convolved features.
@@ -76,81 +58,83 @@ impl CnnModel {
         valid_mask: ValidMask,
     ) -> Result<Features, ModelError> {
         debug_assert_eq!(embeddings.shape()[1], valid_mask.len());
-        // TODO: check if the zero padding gives the expected results from the cnn
-        let inputs = tvec!(embeddings.collect(valid_mask)?.into());
-        let outputs = self.plan.run(inputs)?;
-        debug_assert!(outputs[0]
-            .to_array_view::<f32>()?
-            .iter()
-            .all(|v| !v.is_infinite() && !v.is_nan()));
+        let valid_embeddings = embeddings.collect(valid_mask)?;
 
-        Ok(outputs[0].clone().into())
+        let features = self
+            .layers
+            .iter()
+            .map(|layer| layer.run(valid_embeddings.view()))
+            .collect::<Result<Vec<_>, _>>()?;
+        let features = features
+            .iter()
+            .map(|features| features.view())
+            .collect::<Vec<_>>();
+        let features = concatenate(Axis(1), &features)?;
+        debug_assert!(features.iter().all(|v| !v.is_infinite() && !v.is_nan()));
+
+        Ok(features.into())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{fs::File, io::BufReader};
-
-    use ndarray::Array3;
+    use ndarray::{Array1, Array3};
     use tract_onnx::prelude::IntoArcTensor;
 
     use super::*;
-    use test_utils::smbert::model;
 
     #[test]
-    fn test_model_empty() {
+    fn test_model_empty_weights() {
         assert!(matches!(
-            CnnModel::new(Vec::new().as_slice(), 10, 128).unwrap_err(),
-            ModelError::Tract(_),
+            CnnModel::new(vec![], vec![Array1::zeros(2)]).unwrap_err(),
+            ModelError::Shape(_),
         ));
     }
 
     #[test]
-    fn test_model_invalid() {
+    fn test_model_empty_bias() {
         assert!(matches!(
-            CnnModel::new([0].as_ref(), 10, 128).unwrap_err(),
-            ModelError::Tract(_),
+            CnnModel::new(vec![Array3::zeros((2, 3, 3))], vec![]).unwrap_err(),
+            ModelError::Shape(_),
         ));
     }
 
     #[test]
-    #[ignore = "missing cnn model asset"]
-    fn test_token_size_invalid() {
-        let model = BufReader::new(File::open(model().unwrap()).unwrap());
+    fn test_model_different_weights_bias() {
         assert!(matches!(
-            CnnModel::new(model, 0, 128).unwrap_err(),
-            ModelError::Tract(_),
+            CnnModel::new(
+                vec![Array3::zeros((2, 3, 3)), Array3::zeros((2, 3, 3))],
+                vec![Array1::zeros(2)],
+            )
+            .unwrap_err(),
+            ModelError::Shape(_),
         ));
     }
 
     #[test]
-    #[ignore = "missing cnn model asset"]
-    fn test_embedding_size_invalid() {
-        let model = BufReader::new(File::open(model().unwrap()).unwrap());
-        assert!(matches!(
-            CnnModel::new(model, 10, 0).unwrap_err(),
-            ModelError::Tract(_),
-        ));
-    }
-
-    #[test]
-    #[ignore = "missing cnn model asset"]
+    #[ignore = "check actual weight shapes"]
     fn test_run() {
-        let token_size = 62;
-        let embedding_size = 128;
-        let key_phrase_size = 5;
-        let model = BufReader::new(File::open(model().unwrap()).unwrap());
-        let model = CnnModel::new(model, token_size, embedding_size).unwrap();
+        let channel_out_size = 512;
+        let channel_grouped_size = 128;
+        let key_phrase_size = 1;
+        let weights = (1..=key_phrase_size)
+            .map(|kernel_size| Array3::zeros((channel_out_size, channel_grouped_size, kernel_size)))
+            .collect();
+        let bias = vec![Array1::zeros(channel_out_size); key_phrase_size];
+        let model = CnnModel::new(weights, bias).unwrap();
 
-        let embeddings = Array3::from_elem((1, token_size, embedding_size), 0)
+        let batch_size = 1;
+        let token_size = 128; // channel_in_size
+        let embedding_size = 512; // input_size
+        let embeddings = Array3::<f32>::zeros((batch_size, token_size, embedding_size))
             .into_arc_tensor()
             .into();
         let valid_mask = vec![false; token_size].into();
+
         let features = model.run(embeddings, valid_mask).unwrap();
         assert_eq!(
             features.shape(),
-            [1, key_phrase_size, model.out_channel_size],
+            [batch_size, key_phrase_size, channel_out_size],
         );
     }
 }

--- a/kpe/src/model/cnn.rs
+++ b/kpe/src/model/cnn.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use layer::{activation::Relu, conv::Conv1D, io::BinParams};
 
-/// A CNN onnx model.
+/// A CNN model.
 #[derive(Debug)]
 pub struct CnnModel {
     layers: [Conv1D<Relu>; Self::KEY_PHRASE_SIZE],
@@ -88,10 +88,12 @@ impl CnnModel {
         Ok(features.into())
     }
 
+    /// Gets the channel out size of the CNN layers.
     fn channel_out_size(&self) -> usize {
         self.layers[0].channel_out_size()
     }
 
+    /// Computes the output size of the concatenated CNN layers.
     fn output_size(&self, valid_size: usize) -> usize {
         debug_assert!(valid_size >= Self::KEY_PHRASE_SIZE);
         Self::KEY_PHRASE_SIZE * valid_size

--- a/kpe/src/model/cnn.rs
+++ b/kpe/src/model/cnn.rs
@@ -2,7 +2,10 @@ use derive_more::{Deref, From};
 use ndarray::{concatenate, s, Array2, Axis, ErrorKind, NewAxis, ShapeError};
 
 use crate::{
-    model::{bert::Embeddings, ModelError},
+    model::{
+        bert::{BertModel, Embeddings},
+        ModelError,
+    },
     tokenizer::encoding::ValidMask,
 };
 use layer::{activation::Relu, conv::Conv1D, io::BinParams};
@@ -23,6 +26,9 @@ impl CnnModel {
     /// The maximum number of words per key phrase.
     pub const KEY_PHRASE_SIZE: usize = 5;
 
+    /// The number of channels going out of the CNN layers.
+    pub const CHANNEL_OUT_SIZE: usize = 512;
+
     /// Creates a model from a binary parameters file.
     pub fn new(mut params: BinParams) -> Result<Self, ModelError> {
         let mut new_layer = |scope| Conv1D::load(params.with_scope(scope), Relu, 1, 0, 1, 1);
@@ -39,16 +45,19 @@ impl CnnModel {
             ));
         }
 
-        let channel_out_size = layers[0].channel_out_size();
-        let channel_grouped_size = layers[0].channel_grouped_size();
-        if layers.iter().enumerate().any(|(kernel_size, layer)| {
-            layer.weights().shape() != [channel_out_size, channel_grouped_size * (kernel_size + 1)]
-                || layer.bias().shape() != [1, channel_out_size, 1]
-        }) {
-            return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into());
+        if layers
+            .iter()
+            .zip(1..=Self::KEY_PHRASE_SIZE)
+            .all(|(layer, kernel_size)| {
+                layer.channel_out_size() == Self::CHANNEL_OUT_SIZE
+                    && layer.channel_grouped_size() == BertModel::EMBEDDING_SIZE
+                    && layer.kernel_size() == kernel_size
+            })
+        {
+            Ok(Self { layers })
+        } else {
+            Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into())
         }
-
-        Ok(Self { layers })
     }
 
     /// Runs the model on the valid embeddings to compute the convolved features.
@@ -57,12 +66,20 @@ impl CnnModel {
         embeddings: Embeddings,
         valid_mask: ValidMask,
     ) -> Result<Features, ModelError> {
-        if valid_mask.iter().filter(|valid| **valid).count() < Self::KEY_PHRASE_SIZE {
+        let valid_size = valid_mask.iter().filter(|valid| **valid).count();
+        if valid_size < Self::KEY_PHRASE_SIZE {
             return Err(ModelError::NotEnoughWords);
         }
 
-        debug_assert_eq!(embeddings.shape()[1], valid_mask.len());
+        debug_assert_eq!(
+            embeddings.shape(),
+            [1, valid_mask.len(), BertModel::EMBEDDING_SIZE],
+        );
         let valid_embeddings = embeddings.collect(valid_mask)?;
+        debug_assert_eq!(
+            valid_embeddings.shape(),
+            [valid_size, BertModel::EMBEDDING_SIZE],
+        );
 
         let run_layer =
             |idx: usize| self.layers[idx].run(valid_embeddings.t().slice(s![NewAxis, .., ..]));
@@ -79,18 +96,13 @@ impl CnnModel {
         debug_assert_eq!(
             features.shape(),
             [
-                self.channel_out_size(),
+                Self::CHANNEL_OUT_SIZE,
                 self.output_size(valid_embeddings.shape()[0]),
             ],
         );
         debug_assert!(features.iter().all(|v| !v.is_infinite() && !v.is_nan()));
 
         Ok(features.into())
-    }
-
-    /// Gets the channel out size of the CNN layers.
-    fn channel_out_size(&self) -> usize {
-        self.layers[0].channel_out_size()
     }
 
     /// Computes the output size of the concatenated CNN layers.
@@ -111,15 +123,8 @@ mod tests {
 
     #[test]
     fn test_model_shapes() {
-        let model =
-            CnnModel::new(BinParams::deserialize_from_file(cnn().unwrap()).unwrap()).unwrap();
-        for kernel_size in 1..=CnnModel::KEY_PHRASE_SIZE {
-            assert_eq!(
-                model.layers[kernel_size - 1].weights().shape(),
-                [512, 768 * kernel_size],
-            );
-            assert_eq!(model.layers[kernel_size - 1].bias().shape(), [1, 512, 1]);
-        }
+        assert_eq!(CnnModel::KEY_PHRASE_SIZE, 5);
+        assert_eq!(CnnModel::CHANNEL_OUT_SIZE, 512);
     }
 
     #[test]
@@ -133,11 +138,9 @@ mod tests {
     #[test]
     fn test_run_full() {
         let token_size = 4 * CnnModel::KEY_PHRASE_SIZE;
-        let embedding_size = 768;
-
         let model =
             CnnModel::new(BinParams::deserialize_from_file(cnn().unwrap()).unwrap()).unwrap();
-        let embeddings = Array3::<f32>::zeros((1, token_size, embedding_size))
+        let embeddings = Array3::<f32>::zeros((1, token_size, BertModel::EMBEDDING_SIZE))
             .into_arc_tensor()
             .into();
         let valid_mask = vec![true; token_size].into();
@@ -145,18 +148,16 @@ mod tests {
         let features = model.run(embeddings, valid_mask).unwrap();
         assert_eq!(
             features.shape(),
-            [model.channel_out_size(), model.output_size(token_size)],
+            [CnnModel::CHANNEL_OUT_SIZE, model.output_size(token_size)],
         );
     }
 
     #[test]
     fn test_run_sparse() {
         let token_size = 4 * CnnModel::KEY_PHRASE_SIZE;
-        let embedding_size = 768;
-
         let model =
             CnnModel::new(BinParams::deserialize_from_file(cnn().unwrap()).unwrap()).unwrap();
-        let embeddings = Array3::<f32>::zeros((1, token_size, embedding_size))
+        let embeddings = Array3::<f32>::zeros((1, token_size, BertModel::EMBEDDING_SIZE))
             .into_arc_tensor()
             .into();
         let valid_mask = (1..=token_size)
@@ -164,22 +165,21 @@ mod tests {
             .map(|e| e % 2 == 0)
             .collect::<Vec<_>>()
             .into();
-
-        let features = model.run(embeddings, valid_mask).unwrap();
         assert_eq!(
-            features.shape(),
-            [model.channel_out_size(), model.output_size(token_size / 2),],
+            model.run(embeddings, valid_mask).unwrap().shape(),
+            [
+                CnnModel::CHANNEL_OUT_SIZE,
+                model.output_size(token_size / 2),
+            ],
         );
     }
 
     #[test]
     fn test_run_min() {
         let token_size = 4 * CnnModel::KEY_PHRASE_SIZE;
-        let embedding_size = 768;
-
         let model =
             CnnModel::new(BinParams::deserialize_from_file(cnn().unwrap()).unwrap()).unwrap();
-        let embeddings = Array3::<f32>::zeros((1, token_size, embedding_size))
+        let embeddings = Array3::<f32>::zeros((1, token_size, BertModel::EMBEDDING_SIZE))
             .into_arc_tensor()
             .into();
         let valid_mask = (1..=token_size)
@@ -187,12 +187,10 @@ mod tests {
             .map(|e| e <= CnnModel::KEY_PHRASE_SIZE)
             .collect::<Vec<_>>()
             .into();
-
-        let features = model.run(embeddings, valid_mask).unwrap();
         assert_eq!(
-            features.shape(),
+            model.run(embeddings, valid_mask).unwrap().shape(),
             [
-                model.channel_out_size(),
+                CnnModel::CHANNEL_OUT_SIZE,
                 model.output_size(CnnModel::KEY_PHRASE_SIZE),
             ],
         );
@@ -201,15 +199,12 @@ mod tests {
     #[test]
     fn test_run_empty() {
         let token_size = 4 * CnnModel::KEY_PHRASE_SIZE;
-        let embedding_size = 768;
-
         let model =
             CnnModel::new(BinParams::deserialize_from_file(cnn().unwrap()).unwrap()).unwrap();
-        let embeddings = Array3::<f32>::zeros((1, token_size, embedding_size))
+        let embeddings = Array3::<f32>::zeros((1, token_size, BertModel::EMBEDDING_SIZE))
             .into_arc_tensor()
             .into();
         let valid_mask = vec![false; token_size].into();
-
         matches!(
             model.run(embeddings, valid_mask).unwrap_err(),
             ModelError::NotEnoughWords,

--- a/kpe/src/model/mod.rs
+++ b/kpe/src/model/mod.rs
@@ -9,6 +9,8 @@ use ndarray::ShapeError;
 use thiserror::Error;
 use tract_onnx::prelude::TractError;
 
+use layer::{conv::ConvError, utils::IncompatibleMatrices};
+
 /// The potential errors of the models.
 #[derive(Debug, Display, Error)]
 pub enum ModelError {
@@ -18,4 +20,8 @@ pub enum ModelError {
     Tract(#[from] TractError),
     /// Invalid array shapes: {0}
     Shape(#[from] ShapeError),
+    /// Failed to read or run the CNN model: {0}
+    Cnn(#[from] ConvError),
+    /// Failed to read or run the classifier model: {0}
+    Classifier(#[from] IncompatibleMatrices),
 }

--- a/kpe/src/model/mod.rs
+++ b/kpe/src/model/mod.rs
@@ -9,19 +9,26 @@ use ndarray::ShapeError;
 use thiserror::Error;
 use tract_onnx::prelude::TractError;
 
-use layer::{conv::ConvError, utils::IncompatibleMatrices};
+use layer::{conv::ConvError, io::LoadingLayerFailed};
 
 /// The potential errors of the models.
 #[derive(Debug, Display, Error)]
 pub enum ModelError {
     /// Failed to read the onnx model: {0}
     Read(#[from] IoError),
+
     /// Failed to run a tract operation: {0}
     Tract(#[from] TractError),
+
     /// Invalid array shapes: {0}
     Shape(#[from] ShapeError),
+
     /// Failed to read or run the CNN model: {0}
     Cnn(#[from] ConvError),
-    /// Failed to read or run the classifier model: {0}
-    Classifier(#[from] IncompatibleMatrices),
+
+    /// Failed to read the Classifier model: {0}
+    Classifier(#[from] LoadingLayerFailed),
+
+    /// Remaining parameters must be used: {0:?}
+    UnusedParams(Vec<String>),
 }

--- a/kpe/src/model/mod.rs
+++ b/kpe/src/model/mod.rs
@@ -31,4 +31,7 @@ pub enum ModelError {
 
     /// Remaining parameters must be used: {0:?}
     UnusedParams(Vec<String>),
+
+    /// The sequence must contain at least `KEY_PHRASE_SIZE` valid words
+    NotEnoughWords,
 }

--- a/kpe/src/pipeline.rs
+++ b/kpe/src/pipeline.rs
@@ -6,7 +6,7 @@ use crate::{
     tokenizer::{key_phrase::RankedKeyPhrases, Tokenizer, TokenizerError},
 };
 
-/// A pipeline for a bert model.
+/// A pipeline for a KPE model.
 ///
 /// Can be created via the [`Builder`] and consists of a tokenizer, a Bert model, a CNN model and a
 /// Classifier model.

--- a/kpe/src/pipeline.rs
+++ b/kpe/src/pipeline.rs
@@ -2,7 +2,7 @@ use displaydoc::Display;
 use thiserror::Error;
 
 use crate::{
-    model::{bert::BertModel, classifier::ClassifierModel, cnn::CnnModel, ModelError},
+    model::{bert::Bert, classifier::Classifier, cnn::Cnn, ModelError},
     tokenizer::{key_phrase::RankedKeyPhrases, Tokenizer, TokenizerError},
 };
 
@@ -13,10 +13,10 @@ use crate::{
 ///
 /// [`Builder`]: crate::builder::Builder
 pub struct Pipeline {
-    pub(crate) tokenizer: Tokenizer<{ CnnModel::KEY_PHRASE_SIZE }>,
-    pub(crate) bert: BertModel,
-    pub(crate) cnn: CnnModel,
-    pub(crate) classifier: ClassifierModel,
+    pub(crate) tokenizer: Tokenizer<{ Cnn::KEY_PHRASE_SIZE }>,
+    pub(crate) bert: Bert,
+    pub(crate) cnn: Cnn,
+    pub(crate) classifier: Classifier,
 }
 
 /// The potential errors of the [`Pipeline`].

--- a/kpe/src/tokenizer/encoding.rs
+++ b/kpe/src/tokenizer/encoding.rs
@@ -4,22 +4,32 @@ use ndarray::{Array1, Array2, Axis};
 use crate::tokenizer::{key_phrase::KeyPhrases, Tokenizer};
 
 /// The token ids of the encoded sequence.
+///
+/// The token ids are of shape `(1, token_size)`.
 #[derive(Clone, Deref, From)]
 pub struct TokenIds(pub Array2<i64>);
 
 /// The attention mask of the encoded sequence.
+///
+/// The attention mask is of shape `(1, token_size)`.
 #[derive(Clone, Deref, From)]
 pub struct AttentionMask(pub Array2<i64>);
 
 /// The type ids of the encoded sequence.
+///
+/// The type ids are of shape `(1, token_size)`.
 #[derive(Clone, Deref, From)]
 pub struct TypeIds(pub Array2<i64>);
 
 /// The starting tokens mask of the encoded sequence.
+///
+/// The valid mask is of shape `(token_size,)`.
 #[derive(Clone, Deref, From)]
 pub struct ValidMask(pub Vec<bool>);
 
 /// The active words mask for each key phrase.
+///
+/// The active mask is of shape `(key_phrase_choices, key_phrase_mentions)`.
 #[derive(Clone, Deref, From)]
 pub struct ActiveMask(pub Array2<bool>);
 

--- a/kpe/src/tokenizer/key_phrase.rs
+++ b/kpe/src/tokenizer/key_phrase.rs
@@ -64,7 +64,7 @@ impl<const KEY_PHRASE_SIZE: usize> KeyPhrases<KEY_PHRASE_SIZE> {
         }
     }
 
-    /// Creates the mask of active/mentioned key phrases for each unique keyphrase.
+    /// Creates the mask of active/mentioned key phrases for each unique key phrase.
     pub fn active_mask(&self) -> ActiveMask {
         Array2::from_shape_fn((self.choices.len(), self.mentions.len()), |(i, j)| {
             i as i64 == self.mentions[j]

--- a/layer/src/activation.rs
+++ b/layer/src/activation.rs
@@ -27,7 +27,7 @@ pub trait ActivationFunction<A> {
 }
 
 /// reLu activation function.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Relu;
 
 impl<A> ActivationFunction<A> for Relu
@@ -59,7 +59,7 @@ impl Relu {
 }
 
 /// Softmax activation function.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Softmax {
     rel_axis_idx: isize,
 }
@@ -115,7 +115,7 @@ where
 ///
 /// Like common this is a identity function used
 /// in cases where there no activation function is needed.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Linear;
 
 impl<A> ActivationFunction<A> for Linear {

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -190,7 +190,8 @@ where
 
     /// Computes the forward pass of the input through the layer.
     ///
-    /// The input is of shape `(batch_size, channel_in_size, input_size)`.
+    /// The input is of shape `(batch_size, channel_in_size, input_size)` and the output is of shape
+    /// `(batch_size, channel_out_size, output_size)`.
     pub fn run(
         &self,
         input: ArrayBase<impl Data<Elem = f32>, Ix3>,

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -161,14 +161,14 @@ where
 
     /// Gets the weights.
     ///
-    /// The weights are in shape `(channel_out_size, channel_grouped_size * kernel_size)`.
+    /// The weights are of shape `(channel_out_size, channel_grouped_size * kernel_size)`.
     pub fn weights(&self) -> ArrayView2<f32> {
         self.weights.view()
     }
 
     /// Gets the bias.
     ///
-    /// The bias is in shape `(1, bias_size, 1)`.
+    /// The bias is of shape `(1, bias_size, 1)`.
     pub fn bias(&self) -> ArrayView3<f32> {
         self.bias.view()
     }

--- a/layer/src/dense.rs
+++ b/layer/src/dense.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// This can be used for both 1D and 2D inputs depending
 /// on the activation function.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Dense<AF>
 where
     AF: ActivationFunction<f32>,


### PR DESCRIPTION
**References**

- [TY-2136]
- [TY-2137]

**Summary**

- load cnn and classifier from binparams
- remove padding in valid embedding collection
- fix shape mismatches in cnn and classifier
- add more assertions and tests for all models (some tests are marked as ignored because they take quite long, but we may also enable them unconditionally for better test coverage on the ci)
- add more shape docs and fix some typos
- constify some model shapes: the shapes of the three models are (de facto) fixed and interdependent and this gives additional shape safety already during pipeline creation

[TY-2136]: https://xainag.atlassian.net/browse/TY-2136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2137]: https://xainag.atlassian.net/browse/TY-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ