### PR TITLE
[Merged by Bors] - TY-2136 impl kpe models manually [6]

### DIFF
--- a/rubert/src/builder.rs
+++ b/rubert/src/builder.rs
@@ -88,13 +88,16 @@ impl<V, M, K, P> Builder<V, M, K, P> {
     /// Defaults to `128`.
     ///
     /// # Errors
-    /// Fails if `size` is less than two.
-    pub fn with_token_size(mut self, size: usize) -> Result<Self, BuilderError> {
-        if size < 2 {
-            Err(BuilderError::TokenSize)
-        } else {
+    /// Fails if `size` is less than two or greater than 512.
+    pub fn with_token_size(mut self, size: usize) -> Result<Self, BuilderError>
+    where
+        K: BertModel,
+    {
+        if K::TOKEN_RANGE.contains(&size) {
             self.token_size = size;
             Ok(self)
+        } else {
+            Err(BuilderError::TokenSize)
         }
     }
 

--- a/rubert/src/lib.rs
+++ b/rubert/src/lib.rs
@@ -57,7 +57,7 @@ pub type QAMBertBuilder<V, M> = Builder<V, M, kinds::QAMBert, NonePooler>;
 
 #[cfg(doc)]
 pub use crate::{
-    model::ModelError,
+    model::{BertModel, ModelError},
     pooler::{Embedding, PoolerError},
     tokenizer::TokenizerError,
 };

--- a/rubert/src/model.rs
+++ b/rubert/src/model.rs
@@ -66,9 +66,6 @@ pub trait BertModel: Sized {
     /// Creates a model from an onnx model file.
     ///
     /// Requires the maximum number of tokens per tokenized sequence.
-    ///
-    /// # Panics
-    /// Panics if the model is empty (due to the way tract implemented the onnx model parsing).
     fn load(
         // `Read` instead of `AsRef<Path>` is needed for wasm
         mut model: impl Read,
@@ -105,6 +102,8 @@ pub trait BertModel: Sized {
 }
 
 /// The predicted encoding.
+///
+/// The prediction is of shape `(1, token_size, embedding_size)`.
 #[derive(Clone, Deref, From)]
 pub struct Prediction(Arc<Tensor>);
 

--- a/rubert/src/pipeline.rs
+++ b/rubert/src/pipeline.rs
@@ -82,7 +82,7 @@ where
 
     /// Gets the embedding size.
     pub fn embedding_size(&self) -> usize {
-        <K as BertModel>::EMBEDDING_SIZE
+        K::EMBEDDING_SIZE
     }
 }
 

--- a/rubert/src/pipeline.rs
+++ b/rubert/src/pipeline.rs
@@ -2,7 +2,7 @@ use displaydoc::Display;
 use thiserror::Error;
 
 use crate::{
-    model::{Model, ModelError},
+    model::{BertModel, Model, ModelError},
     pooler::{Embedding1, Embedding2, PoolerError},
     tokenizer::{Tokenizer, TokenizerError},
     AveragePooler,
@@ -32,7 +32,10 @@ pub enum PipelineError {
     Pooler(#[from] PoolerError),
 }
 
-impl<K> Pipeline<K, NonePooler> {
+impl<K> Pipeline<K, NonePooler>
+where
+    K: BertModel,
+{
     /// Computes the embedding of the sequence.
     pub fn run(&self, sequence: impl AsRef<str>) -> Result<Embedding2, PipelineError> {
         let encoding = self.tokenizer.encode(sequence);
@@ -41,7 +44,10 @@ impl<K> Pipeline<K, NonePooler> {
     }
 }
 
-impl<K> Pipeline<K, FirstPooler> {
+impl<K> Pipeline<K, FirstPooler>
+where
+    K: BertModel,
+{
     /// Computes the embedding of the sequence.
     pub fn run(&self, sequence: impl AsRef<str>) -> Result<Embedding1, PipelineError> {
         let encoding = self.tokenizer.encode(sequence);
@@ -50,7 +56,10 @@ impl<K> Pipeline<K, FirstPooler> {
     }
 }
 
-impl<K> Pipeline<K, AveragePooler> {
+impl<K> Pipeline<K, AveragePooler>
+where
+    K: BertModel,
+{
     /// Computes the embedding of the sequence.
     pub fn run(&self, sequence: impl AsRef<str>) -> Result<Embedding1, PipelineError> {
         let encoding = self.tokenizer.encode(sequence);
@@ -62,15 +71,18 @@ impl<K> Pipeline<K, AveragePooler> {
     }
 }
 
-impl<K, P> Pipeline<K, P> {
+impl<K, P> Pipeline<K, P>
+where
+    K: BertModel,
+{
     /// Gets the token size.
     pub fn token_size(&self) -> usize {
-        self.tokenizer.token_size
+        self.model.token_size
     }
 
     /// Gets the embedding size.
     pub fn embedding_size(&self) -> usize {
-        self.model.embedding_size
+        <K as BertModel>::EMBEDDING_SIZE
     }
 }
 

--- a/rubert/src/pooler.rs
+++ b/rubert/src/pooler.rs
@@ -15,9 +15,13 @@ where
     D: Dimension;
 
 /// A 1-dimensional sequence embedding.
+///
+/// The embedding is of shape `(embedding_size,)`.
 pub type Embedding1 = Embedding<Ix1>;
 
 /// A 2-dimensional sequence embedding.
+///
+/// The embedding is of shape `(token_size, embedding_size)`.
 pub type Embedding2 = Embedding<Ix2>;
 
 impl<S, D> PartialEq<ArrayBase<S, D>> for Embedding<D>

--- a/rubert/src/tokenizer.rs
+++ b/rubert/src/tokenizer.rs
@@ -22,14 +22,20 @@ pub enum TokenizerError {
 }
 
 /// The token ids of the encoded sequence.
+///
+/// The token ids are of shape `(1, token_size)`.
 #[derive(Clone, Deref, From)]
 pub struct TokenIds(pub Array2<i64>);
 
 /// The attention mask of the encoded sequence.
+///
+/// The attention mask is of shape `(1, token_size)`.
 #[derive(Clone, Deref, From)]
 pub struct AttentionMask(pub Array2<i64>);
 
 /// The type ids of the encoded sequence.
+///
+/// The type ids are of shape `(1, token_size)`.
 #[derive(Clone, Deref, From)]
 pub struct TypeIds(pub Array2<i64>);
 

--- a/rubert/src/tokenizer.rs
+++ b/rubert/src/tokenizer.rs
@@ -11,7 +11,6 @@ use ndarray::{Array1, Array2, Axis};
 #[derive(Debug)]
 pub struct Tokenizer {
     tokenizer: BertTokenizer<i64>,
-    pub(crate) token_size: usize,
 }
 
 /// The potential errors of the tokenizer.
@@ -67,10 +66,7 @@ impl Tokenizer {
             .with_padding(Padding::fixed(token_size, "[PAD]"))
             .build()?;
 
-        Ok(Tokenizer {
-            tokenizer,
-            token_size,
-        })
+        Ok(Tokenizer { tokenizer })
     }
 
     /// Encodes the sequence.


### PR DESCRIPTION
**References**

- #302

**Summary**

some follow up cleanup for `rubert` noticed during #302:
- update docs: tract's internals changed & additional shape info
- constify model shapes and add debug assertions: the embedding size is (de facto) fixed per model kind and this gives us additional shape safety during model creation
- restrict token size range: this is inherently given by the onnx models
- use ndarray's shape error instead of a custom one

the additional exposure of the `BertModel` trait doesn't allow it to be hidden anymore (at least without a lot of cumbersome wrapping), it is still unimplementable from outside the crate, but i linked it in the docs. this also allows us to remove the `Model::new()` wrapper. i'd say that the additional shape safety is worth the trait doc exposure.
