### PR TITLE
[Merged by Bors] - FIX: tokenizer offsets

### DIFF
--- a/rubert-tokenizer/src/lib.rs
+++ b/rubert-tokenizer/src/lib.rs
@@ -64,6 +64,7 @@ mod tokenizer;
 pub use crate::{
     builder::{Builder, BuilderError},
     model::ModelError,
+    normalizer::string::Offsets,
     post_tokenizer::{
         encoding::Encoding,
         padding::{Padding, PaddingError},

--- a/rubert-tokenizer/src/normalizer/string.rs
+++ b/rubert-tokenizer/src/normalizer/string.rs
@@ -5,7 +5,7 @@ use unicode_normalization_alignments::UnicodeNormalization;
 use crate::normalizer::pattern::Pattern;
 
 /// Offsets of a subsequence relative to a sequence.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Offsets(pub usize, pub usize);
 
 impl Offsets {

--- a/rubert-tokenizer/src/post_tokenizer/encoding.rs
+++ b/rubert-tokenizer/src/post_tokenizer/encoding.rs
@@ -489,8 +489,15 @@ impl<N> Encoding<N> {
             .extend(iter::repeat(N::zero()).take(pad_length));
         self.special_tokens_mask
             .extend(iter::repeat(N::one()).take(pad_length));
-        self.offsets
-            .extend(iter::repeat(Offsets(0, 0)).take(pad_length));
+        self.offsets.extend(
+            iter::repeat(
+                self.offsets
+                    .last()
+                    .map(|&Offsets(_, end)| Offsets(end, end))
+                    .unwrap_or_default(),
+            )
+            .take(pad_length),
+        );
 
         self
     }

--- a/rubert-tokenizer/src/post_tokenizer/mod.rs
+++ b/rubert-tokenizer/src/post_tokenizer/mod.rs
@@ -85,9 +85,19 @@ where
             .chain(encoding.word_indices)
             .chain(once(None))
             .collect();
-        let offsets = once(Offsets(0, 0))
+        let cls_token_offset = encoding
+            .offsets
+            .first()
+            .map(|&Offsets(start, _)| Offsets(start, start))
+            .unwrap_or_default();
+        let sep_token_offset = encoding
+            .offsets
+            .last()
+            .map(|&Offsets(_, end)| Offsets(end, end))
+            .unwrap_or_default();
+        let offsets = once(cls_token_offset)
             .chain(encoding.offsets)
-            .chain(once(Offsets(0, 0)))
+            .chain(once(sep_token_offset))
             .collect();
         let special_tokens_mask = once(N::one())
             .chain(encoding.special_tokens_mask)


### PR DESCRIPTION
**Summary**

- fix the token offsets computed during the tokenizer's encoding: some special tokens had default offsets, but their offsets must be aligned with the offsets of their surrounding tokens
- expose `Offsets`: this is already part of the public api, but it was not nameable
