### PR TITLE
[Merged by Bors] - TY-2136 impl kpe models manually [7]

### DIFF
--- a/kpe/benches/kpe.rs
+++ b/kpe/benches/kpe.rs
@@ -1,31 +1,25 @@
-//! Run as `cargo bench --bench kpe.
-
-use std::{io::Result, path::Path};
+//! Run as `cargo bench --bench kpe`.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ndarray::{s, Array1, Axis};
 
 use kpe::Builder;
-use test_utils::smbert;
+use test_utils::kpe::{bert, classifier, cnn, vocab};
 
 fn bench_kpe(manager: &mut Criterion) {
-    // TODO: change assets once available
     let pipeline = Builder::from_files(
-        smbert::vocab().unwrap(),
-        smbert::model().unwrap(),
-        smbert::model().unwrap(),
-        smbert::model().unwrap(),
+        vocab().unwrap(),
+        bert().unwrap(),
+        cnn().unwrap(),
+        classifier().unwrap(),
     )
     .unwrap()
     .with_accents(false)
-    .with_lowercase(true)
-    .with_token_size(512)
-    .unwrap()
-    .with_key_phrase_size(5)
+    .with_lowercase(false)
+    .with_token_size(128)
     .unwrap()
     .build()
     .unwrap();
-    let sequence = "This embedding fits perfectly and this embedding fits well.";
+    let sequence = "This sequence will be split into key phrases.";
     manager.bench_function("KPE", |bencher| {
         bencher.iter(|| pipeline.run(black_box(sequence)).unwrap())
     });

--- a/kpe/src/model/bert.rs
+++ b/kpe/src/model/bert.rs
@@ -220,9 +220,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "run slow test with `cargo test --release -- --ignored`"]
     fn test_run() {
-        let token_size = 64;
+        let token_size = 2;
         let model = BufReader::new(File::open(bert().unwrap()).unwrap());
         let model = Bert::new(model, token_size).unwrap();
 

--- a/kpe/src/pipeline.rs
+++ b/kpe/src/pipeline.rs
@@ -43,3 +43,51 @@ impl Pipeline {
         Ok(key_phrases.rank(scores))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::builder::Builder;
+    use test_utils::kpe::{bert, classifier, cnn, vocab};
+
+    #[test]
+    fn test_run_unique() {
+        assert_eq!(
+            Builder::from_files(
+                vocab().unwrap(),
+                bert().unwrap(),
+                cnn().unwrap(),
+                classifier().unwrap(),
+            )
+            .unwrap()
+            .with_token_size(7)
+            .unwrap()
+            .build()
+            .unwrap()
+            .run("a b c d e")
+            .unwrap()
+            .len(),
+            15,
+        );
+    }
+
+    #[test]
+    fn test_run_duplicate() {
+        assert_eq!(
+            Builder::from_files(
+                vocab().unwrap(),
+                bert().unwrap(),
+                cnn().unwrap(),
+                classifier().unwrap(),
+            )
+            .unwrap()
+            .with_token_size(7)
+            .unwrap()
+            .build()
+            .unwrap()
+            .run("a a a a a")
+            .unwrap()
+            .len(),
+            5,
+        );
+    }
+}


### PR DESCRIPTION
**References**

- [TY-2136]
- [TY-2137]

**Summary**

- add full run pipeline tests
- adjust benchmark
- reduce token size of slow tests as much as possible & remove their ignored flag


[TY-2136]: https://xainag.atlassian.net/browse/TY-2136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2137]: https://xainag.atlassian.net/browse/TY-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ