### PR TITLE
[Merged by Bors] - TY-2179 kpe correctness [1]

### DIFF
--- a/dev-tool/src/list_net/data_source.rs
+++ b/dev-tool/src/list_net/data_source.rs
@@ -529,12 +529,12 @@ mod tests {
     fn dummy_storage() -> InMemoryStorage {
         let mut storage = InMemoryStorage::default();
 
-        let inputs = Array::zeros((10, 50));
+        let inputs = Array::default((10, 50));
         let target_prob_dist = Array::ones((10,));
         storage.add_sample(inputs, target_prob_dist).unwrap();
 
         let inputs = Array::ones((10, 50));
-        let target_prob_dist = Array::zeros((10,));
+        let target_prob_dist = Array::default((10,));
         storage.add_sample(inputs, target_prob_dist).unwrap();
 
         let inputs = Array::from_elem((10, 50), 4.);
@@ -547,13 +547,13 @@ mod tests {
     #[test]
     fn test_adding_bad_matrices_fails() {
         let mut storage = InMemoryStorage::default();
-        let inputs = Array::zeros((10, 48));
+        let inputs = Array::default((10, 48));
         let target_prob_dist = Array::ones((10,));
         let err = storage.add_sample(inputs, target_prob_dist).unwrap_err();
 
         assert_eq!(&format!("{}", err), "Sample with bad array shapes. Expected shapes [10, 50] & [10] but got shapes [10, 48] & [10]." );
 
-        let inputs = Array::zeros((8, 50));
+        let inputs = Array::default((8, 50));
         let target_prob_dist = Array::ones((11,));
         let err = storage.add_sample(inputs, target_prob_dist).unwrap_err();
 

--- a/kpe/src/lib.rs
+++ b/kpe/src/lib.rs
@@ -11,7 +11,7 @@
 //!         "classifier.binparams",
 //!     )?
 //!     .with_accents(false)
-//!     .with_lowercase(true)
+//!     .with_lowercase(false)
 //!     .with_token_size(64)?
 //!     .build()?;
 //!
@@ -35,10 +35,8 @@ mod tokenizer;
 pub use crate::{
     builder::{Builder, BuilderError},
     pipeline::{Pipeline, PipelineError},
+    tokenizer::key_phrase::RankedKeyPhrases,
 };
 
 #[cfg(doc)]
-pub use crate::{
-    model::ModelError,
-    tokenizer::{key_phrase::RankedKeyPhrases, TokenizerError},
-};
+pub use crate::{model::ModelError, tokenizer::TokenizerError};

--- a/kpe/src/model/bert.rs
+++ b/kpe/src/model/bert.rs
@@ -237,7 +237,7 @@ mod tests {
         let model = BufReader::new(File::open(bert().unwrap()).unwrap());
         let model = Bert::new(model, token_size).unwrap();
 
-        let token_ids = Array2::ones((1, token_size)).into();
+        let token_ids = Array2::default((1, token_size)).into();
         let attention_mask = Array2::ones((1, token_size)).into();
         let type_ids = Array2::default((1, token_size)).into();
         let embeddings = model.run(token_ids, attention_mask, type_ids).unwrap();

--- a/kpe/src/model/classifier.rs
+++ b/kpe/src/model/classifier.rs
@@ -23,6 +23,13 @@ pub struct Classifier {
 #[derive(Clone, Debug, Deref, From)]
 pub struct Scores(pub Vec<f32>);
 
+impl Scores {
+    /// Checks if the scores are valid, i.e. finite.
+    pub fn is_valid(&self) -> bool {
+        self.iter().copied().all(f32::is_finite)
+    }
+}
+
 impl Classifier {
     /// Creates a model from a binary parameters file.
     pub fn new(mut params: BinParams) -> Result<Self, ModelError> {
@@ -43,32 +50,31 @@ impl Classifier {
     /// Runs the model on the convolved features to compute the scores.
     pub fn run(&self, features: Features, active_mask: ActiveMask) -> Result<Scores, ModelError> {
         debug_assert_eq!(features.shape()[1], active_mask.shape()[1]);
-        debug_assert!(features.iter().copied().all(f32::is_finite));
-        debug_assert!(active_mask
-            .rows()
-            .into_iter()
-            .all(|row| row.iter().any(|active| *active)));
+        debug_assert!(features.is_valid());
+        debug_assert!(active_mask.is_valid());
         let (scores, _) = self.layer.run(features.t(), false);
         debug_assert_eq!(scores.shape(), [features.shape()[1], 1]);
         debug_assert!(scores.iter().copied().all(f32::is_finite));
 
-        let scores = active_mask
-            .rows()
-            .into_iter()
-            .map(|active| {
-                active
+        let scores = Scores(
+            active_mask
+                .rows()
+                .into_iter()
+                .map(|active| {
+                    active
                     .iter()
                     .zip(scores.iter())
                     .filter_map(|(active, score)| active.then(|| score))
                     .copied()
                     .reduce(f32::max)
                     .unwrap(/* active mask must have entries in each row */)
-            })
-            .collect::<Vec<f32>>();
+                })
+                .collect::<Vec<f32>>(),
+        );
         debug_assert_eq!(scores.len(), active_mask.shape()[0]);
-        debug_assert!(scores.iter().copied().all(f32::is_finite));
+        debug_assert!(scores.is_valid());
 
-        Ok(scores.into())
+        Ok(scores)
     }
 }
 

--- a/kpe/src/model/cnn.rs
+++ b/kpe/src/model/cnn.rs
@@ -83,7 +83,7 @@ impl Cnn {
         );
         debug_assert!(embeddings.is_valid());
         let valid_size = cfg!(debug_assertions)
-            .then(|| valid_mask.size())
+            .then(|| valid_mask.count())
             .unwrap_or_default();
         let valid_embeddings = embeddings.collect(valid_mask)?;
         debug_assert_eq!(valid_embeddings.shape(), [valid_size, Bert::EMBEDDING_SIZE]);

--- a/kpe/src/model/cnn.rs
+++ b/kpe/src/model/cnn.rs
@@ -82,7 +82,9 @@ impl Cnn {
             [1, valid_mask.len(), Bert::EMBEDDING_SIZE],
         );
         debug_assert!(embeddings.is_valid());
-        let valid_size = valid_mask.size();
+        let valid_size = cfg!(debug_assertions)
+            .then(|| valid_mask.size())
+            .unwrap_or_default();
         let valid_embeddings = embeddings.collect(valid_mask)?;
         debug_assert_eq!(valid_embeddings.shape(), [valid_size, Bert::EMBEDDING_SIZE]);
         debug_assert!(valid_embeddings.iter().copied().all(f32::is_finite));

--- a/kpe/src/pipeline.rs
+++ b/kpe/src/pipeline.rs
@@ -51,43 +51,58 @@ mod tests {
 
     #[test]
     fn test_run_unique() {
-        assert_eq!(
-            Builder::from_files(
-                vocab().unwrap(),
-                bert().unwrap(),
-                cnn().unwrap(),
-                classifier().unwrap(),
-            )
-            .unwrap()
-            .with_token_size(7)
-            .unwrap()
-            .build()
-            .unwrap()
-            .run("a b c d e")
-            .unwrap()
-            .len(),
-            15,
-        );
+        let actual = Builder::from_files(
+            vocab().unwrap(),
+            bert().unwrap(),
+            cnn().unwrap(),
+            classifier().unwrap(),
+        )
+        .unwrap()
+        .with_token_size(8)
+        .unwrap()
+        .with_lowercase(false)
+        .build()
+        .unwrap()
+        .run("A b c d e.")
+        .unwrap();
+        let expected = [
+            // quantized, non-quantized
+            "A",
+            "b",
+            "d",  // c
+            "e.", // d
+            "c",  // e.
+            "A b c d e.",
+            "A b c",
+            "A b",     // A b c d
+            "A b c d", // A b
+            "b c d e.",
+            "d e.",   // c d e.
+            "c d e.", // d e.
+            "b c d",
+            "b c",
+            "c d",
+        ];
+        assert_eq!(actual.0, expected);
     }
 
     #[test]
     fn test_run_duplicate() {
-        assert_eq!(
-            Builder::from_files(
-                vocab().unwrap(),
-                bert().unwrap(),
-                cnn().unwrap(),
-                classifier().unwrap(),
-            )
-            .unwrap()
-            .with_token_size(7)
-            .unwrap()
-            .build()
-            .unwrap()
-            .run("a a a a a")
-            .unwrap()
-            .len(),
-            5,
-        );
+        let actual = Builder::from_files(
+            vocab().unwrap(),
+            bert().unwrap(),
+            cnn().unwrap(),
+            classifier().unwrap(),
+        )
+        .unwrap()
+        .with_token_size(7)
+        .unwrap()
+        .with_lowercase(false)
+        .build()
+        .unwrap()
+        .run("a a a a a")
+        .unwrap();
+        let expected = ["a", "a a", "a a a", "a a a a", "a a a a a"];
+        assert_eq!(actual.0, expected);
     }
 }

--- a/kpe/src/pipeline.rs
+++ b/kpe/src/pipeline.rs
@@ -67,15 +67,15 @@ mod tests {
         .unwrap();
         let expected = [
             // quantized, non-quantized
-            "A",
+            "a",
             "b",
             "d",  // c
             "e.", // d
             "c",  // e.
-            "A b c d e.",
-            "A b c",
-            "A b",     // A b c d
-            "A b c d", // A b
+            "a b c d e.",
+            "a b c",
+            "a b",     // a b c d
+            "a b c d", // a b
             "b c d e.",
             "d e.",   // c d e.
             "c d e.", // d e.
@@ -100,7 +100,7 @@ mod tests {
         .with_lowercase(false)
         .build()
         .unwrap()
-        .run("a a a a a")
+        .run("A a A a A")
         .unwrap();
         let expected = ["a", "a a", "a a a", "a a a a", "a a a a a"];
         assert_eq!(actual.0, expected);

--- a/kpe/src/tokenizer/encoding.rs
+++ b/kpe/src/tokenizer/encoding.rs
@@ -82,7 +82,7 @@ impl<const KEY_PHRASE_SIZE: usize> Tokenizer<KEY_PHRASE_SIZE> {
 /// Decodes the tokenized words.
 ///
 /// Joins starting tokens with their continuing tokens. Everything which is not separated by
-/// whitespace is considered as continuation as well, e.g. punctuation.
+/// whitespace is considered as continuation as well, e.g. punctuation. All words are lowercased.
 fn decode_words(
     sequence: impl AsRef<str>,
     offsets: impl AsRef<[Offsets]>,
@@ -95,7 +95,7 @@ fn decode_words(
         (0, 0),
         |(word_start, word_end), &Offsets(token_start, token_end)| {
             if word_end < token_start {
-                words.push(sequence[word_start..word_end].into());
+                words.push(sequence[word_start..word_end].to_lowercase());
                 (token_start, token_end)
             } else {
                 (word_start, token_end)
@@ -115,7 +115,7 @@ fn decode_words(
                     (word_start, word_end),
                     |(word_start, word_end), &Offsets(token_start, token_end)| {
                         if word_end < token_start {
-                            words.push(sequence[word_start..word_end].into());
+                            words.push(sequence[word_start..word_end].to_lowercase());
                             ControlFlow::Break(())
                         } else {
                             ControlFlow::Continue((word_start, token_end))
@@ -123,10 +123,10 @@ fn decode_words(
                     },
                 )
             {
-                words.push(sequence[word_start..word_end].into());
+                words.push(sequence[word_start..word_end].to_lowercase());
             }
         } else {
-            words.push(sequence[word_start..word_end].into());
+            words.push(sequence[word_start..word_end].to_lowercase());
         }
     }
     words.shrink_to_fit();
@@ -324,9 +324,9 @@ mod tests {
         );
     }
 
-    const EXACT_WORDS: [&str; 4] = ["This", "embedding", "fits", "perfectly."];
-    const SHORT_WORDS: [&str; 4] = ["This", "is", "an", "embedding."];
-    const LONG_WORDS: [&str; 6] = ["This", "embedding", "is", "way", "too", "long."];
+    const EXACT_WORDS: [&str; 4] = ["this", "embedding", "fits", "perfectly."];
+    const SHORT_WORDS: [&str; 4] = ["this", "is", "an", "embedding."];
+    const LONG_WORDS: [&str; 6] = ["this", "embedding", "is", "way", "too", "long."];
 
     #[test]
     fn test_decode_words_exact() {
@@ -381,6 +381,6 @@ mod tests {
 
     #[test]
     fn test_valid_mask_empty() {
-        assert!(valid_mask(&[]).0.is_empty());
+        assert!(valid_mask(&[]).is_empty());
     }
 }

--- a/kpe/src/tokenizer/encoding.rs
+++ b/kpe/src/tokenizer/encoding.rs
@@ -57,14 +57,14 @@ impl TypeIds {
 pub struct ValidMask(pub Vec<bool>);
 
 impl ValidMask {
-    /// Gets the number of valid entries in the mask.
-    pub fn size(&self) -> usize {
+    /// Counts the number of valid entries in the mask.
+    pub fn count(&self) -> usize {
         self.iter().filter(|valid| **valid).count()
     }
 
     /// Checks if the valid mask is valid, i.e. at least `key_phrase_size` valid entries.
     pub fn is_valid(&self, key_phrase_size: usize) -> bool {
-        self.size() >= key_phrase_size
+        self.count() >= key_phrase_size
     }
 }
 

--- a/kpe/src/tokenizer/encoding.rs
+++ b/kpe/src/tokenizer/encoding.rs
@@ -9,34 +9,35 @@ use rubert_tokenizer::{Encoding as BertEncoding, Offsets};
 /// The token ids of the encoded sequence.
 ///
 /// The token ids are of shape `(1, token_size)`.
-#[derive(Clone, Deref, From)]
+#[derive(Clone, Debug, Deref, From)]
 pub struct TokenIds(pub Array2<i64>);
 
 /// The attention mask of the encoded sequence.
 ///
 /// The attention mask is of shape `(1, token_size)`.
-#[derive(Clone, Deref, From)]
+#[derive(Clone, Debug, Deref, From)]
 pub struct AttentionMask(pub Array2<i64>);
 
 /// The type ids of the encoded sequence.
 ///
 /// The type ids are of shape `(1, token_size)`.
-#[derive(Clone, Deref, From)]
+#[derive(Clone, Debug, Deref, From)]
 pub struct TypeIds(pub Array2<i64>);
 
 /// The starting tokens mask of the encoded sequence.
 ///
 /// The valid mask is of shape `(token_size,)`.
-#[derive(Clone, Deref, From)]
+#[derive(Clone, Debug, Deref, From)]
 pub struct ValidMask(pub Vec<bool>);
 
 /// The active words mask for each key phrase.
 ///
 /// The active mask is of shape `(key_phrase_choices, key_phrase_mentions)`.
-#[derive(Clone, Deref, From)]
+#[derive(Clone, Debug, Deref, From)]
 pub struct ActiveMask(pub Array2<bool>);
 
 /// The encoded sequence.
+#[derive(Clone, Debug)]
 pub struct Encoding {
     pub token_ids: TokenIds,
     pub attention_mask: AttentionMask,

--- a/kpe/src/tokenizer/key_phrase.rs
+++ b/kpe/src/tokenizer/key_phrase.rs
@@ -16,7 +16,7 @@ pub struct KeyPhrases<const KEY_PHRASE_SIZE: usize> {
 
 /// The ranked key phrases in descending order.
 #[derive(Clone, Debug, Deref, From)]
-pub struct RankedKeyPhrases(Vec<String>);
+pub struct RankedKeyPhrases(pub(crate) Vec<String>);
 
 impl<const KEY_PHRASE_SIZE: usize> KeyPhrases<KEY_PHRASE_SIZE> {
     /// Collects all potential key phrases from the words.

--- a/kpe/src/tokenizer/key_phrase.rs
+++ b/kpe/src/tokenizer/key_phrase.rs
@@ -75,6 +75,7 @@ impl<const KEY_PHRASE_SIZE: usize> KeyPhrases<KEY_PHRASE_SIZE> {
     /// Ranks the key phrases in descending order according to the scores.
     pub fn rank(self, scores: Scores) -> RankedKeyPhrases {
         debug_assert_eq!(self.choices.len(), scores.len());
+        debug_assert!(scores.is_valid());
         let min_score = self.min_score.as_ref();
         let mut key_phrases = self
             .choices

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -96,6 +96,12 @@ where
         if weights.is_empty() {
             return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into());
         }
+        if weights.iter().any(|w| w.is_nan() || w.is_infinite())
+            || bias.iter().any(|b| b.is_nan() || b.is_infinite())
+        {
+            return Err(LoadingLayerFailed::InvalidParams.into());
+        }
+
         if stride == 0 {
             return Err(ConvError::Stride);
         }

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -96,8 +96,7 @@ where
         if weights.is_empty() {
             return Err(ShapeError::from_kind(ErrorKind::IncompatibleShape).into());
         }
-        if weights.iter().any(|w| w.is_nan() || w.is_infinite())
-            || bias.iter().any(|b| b.is_nan() || b.is_infinite())
+        if !weights.iter().copied().all(f32::is_finite) || !bias.iter().copied().all(f32::is_finite)
         {
             return Err(LoadingLayerFailed::InvalidParams.into());
         }

--- a/layer/src/conv.rs
+++ b/layer/src/conv.rs
@@ -216,7 +216,7 @@ where
 
         let output_size = (padded_input_size - self.dilated_kernel_size) / self.stride + 1;
         if input.is_empty() {
-            return Ok(Array3::zeros([0, self.channel_out_size, output_size]));
+            return Ok(Array3::default([0, self.channel_out_size, output_size]));
         }
 
         if self.groups > 1 {
@@ -226,7 +226,7 @@ where
             unimplemented!("ATen/native/NaiveDilatedConvolution");
         }
 
-        let mut output = Array3::zeros([batch_size, self.channel_out_size, output_size]);
+        let mut output = Array3::default([batch_size, self.channel_out_size, output_size]);
         azip!((mut output in output.outer_iter_mut(), input in input.outer_iter()) {
             let input = self.unfold(input, output_size);
             output.assign(&self.weights.dot(&input));
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn test_conv1d_nonsingleton_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 1, 1)
             .unwrap()
@@ -283,7 +283,7 @@ mod tests {
     #[test]
     fn test_conv1d_singleton_kernel() {
         let weights = Array1::range(0., 6., 1.).into_shape((2, 3, 1)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 1, 1)
             .unwrap()
@@ -315,7 +315,7 @@ mod tests {
     #[test]
     fn test_conv1d_stride_with_nonsingleton_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 2, 0, 1, 1)
             .unwrap()
@@ -331,7 +331,7 @@ mod tests {
     #[test]
     fn test_conv1d_stride_with_singleton_kernel() {
         let weights = Array1::range(0., 6., 1.).into_shape((2, 3, 1)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 2, 0, 1, 1)
             .unwrap()
@@ -348,7 +348,7 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/cpu/Unfold2d")]
     fn test_conv1d_padding_with_nonsingleton_kernel() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 1, 1, 1)
             .unwrap()
@@ -371,7 +371,7 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/cpu/Unfold2d")]
     fn test_conv1d_padding_with_singleton_kernel() {
         let weights = Array1::range(0., 6., 1.).into_shape((2, 3, 1)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 1, 1, 1)
             .unwrap()
@@ -394,7 +394,7 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/NaiveDilatedConvolution")]
     fn test_conv1d_dilation() {
         let weights = Array1::range(0., 18., 1.).into_shape((2, 3, 3)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 30., 1.).into_shape((2, 3, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 2, 1)
             .unwrap()
@@ -408,7 +408,7 @@ mod tests {
     #[should_panic(expected = "not implemented: ATen/native/Convolution")]
     fn test_conv1d_groups() {
         let weights = Array1::range(0., 24., 1.).into_shape((2, 4, 3)).unwrap();
-        let bias = Array1::zeros(2);
+        let bias = Array1::default(2);
         let input = Array1::range(0., 80., 1.).into_shape((2, 8, 5)).unwrap();
         let output = Conv1D::new(weights, bias, Linear, 1, 0, 1, 2)
             .unwrap()

--- a/layer/src/dense.rs
+++ b/layer/src/dense.rs
@@ -42,8 +42,7 @@ where
         bias: Array1<f32>,
         activation_function: AF,
     ) -> Result<Self, LoadingLayerFailed> {
-        if weights.iter().any(|w| w.is_nan() || w.is_infinite())
-            || bias.iter().any(|b| b.is_nan() || b.is_infinite())
+        if !weights.iter().copied().all(f32::is_finite) || !bias.iter().copied().all(f32::is_finite)
         {
             return Err(LoadingLayerFailed::InvalidParams);
         }

--- a/layer/src/io.rs
+++ b/layer/src/io.rs
@@ -306,6 +306,9 @@ pub enum LoadingLayerFailed {
     /// Irretrivable parameters.
     #[displaydoc("{0}")]
     FailedToRetrieveParams(#[from] FailedToRetrieveParams),
+
+    /// Some parameters are invalid (e.g. nan, infinite, etc.)
+    InvalidParams,
 }
 
 #[cfg(test)]

--- a/layer/src/utils.rs
+++ b/layer/src/utils.rs
@@ -124,7 +124,7 @@ pub fn he_normal_weights_init(
 
     // Avoids panic due to invalid σ which can only happen with empty weight matrices.
     if nr_rows == 0 {
-        return Array2::zeros(dim);
+        return Array2::default(dim);
     }
 
     let std_dev = SQRT_2 / (nr_rows as f32).sqrt();

--- a/rubert-tokenizer/src/tokenizer.rs
+++ b/rubert-tokenizer/src/tokenizer.rs
@@ -49,4 +49,9 @@ impl<N> Tokenizer<N> {
             cleanup,
         )
     }
+
+    /// Gets the number of entries in the vocabulary.
+    pub fn vocab_size(&self) -> usize {
+        self.model.vocab.len()
+    }
 }

--- a/rubert/benches/matmul.rs
+++ b/rubert/benches/matmul.rs
@@ -22,7 +22,7 @@ fn bench_tract(manager: &mut Criterion, name: &str, model: impl AsRef<Path>) {
         .unwrap();
     manager.bench_function(name, |bencher| {
         bencher.iter(|| {
-            plan.run(black_box(tvec![Array2::<f32>::zeros((10, 128)).into()]))
+            plan.run(black_box(tvec![Array2::<f32>::default((10, 128)).into()]))
                 .unwrap();
         })
     });
@@ -43,7 +43,7 @@ fn bench_onnx(manager: &mut Criterion, name: &str, model: impl AsRef<Path>) {
     manager.bench_function(name, |bencher| {
         bencher.iter(|| {
             session
-                .run::<f32, f32, _>(black_box(vec![Array2::zeros((10, 128))]))
+                .run::<f32, f32, _>(black_box(vec![Array2::default((10, 128))]))
                 .unwrap();
         })
     });

--- a/rubert/examples/validate.rs
+++ b/rubert/examples/validate.rs
@@ -244,7 +244,7 @@ impl Validator {
         } - skip;
         let source = Pipeline::build(&config.tokenizer, &config.source);
         let target = Pipeline::build(&config.tokenizer, &config.target);
-        let errors = Array1::zeros(11); // #sentences and mean & std per error
+        let errors = Array1::default(11); // #sentences and mean & std per error
 
         Self {
             talks,
@@ -303,7 +303,7 @@ impl Validator {
     fn validate(&mut self) -> &mut Self {
         let mut reader = Reader::from_path(self.talks.as_path()).unwrap();
         let progress = ProgressBar::new(self.take as u64);
-        let mut errors = Array2::<f32>::zeros((330644, 5)); // total #sentences
+        let mut errors = Array2::<f32>::default((330644, 5)); // total #sentences
         let mut idx = 0;
 
         for record in reader.records().skip(self.skip).take(self.take) {

--- a/rubert/src/pooler.rs
+++ b/rubert/src/pooler.rs
@@ -117,7 +117,7 @@ impl AveragePooler {
         let average = if count > 0. {
             attention_mask.dot(&prediction.to_array_view()?.slice(s![0, .., ..])) / count
         } else {
-            Array1::zeros(prediction.shape()[2])
+            Array1::default(prediction.shape()[2])
         };
 
         Ok(average.into())

--- a/xayn-ai/src/ltr/features/mod.rs
+++ b/xayn-ai/src/ltr/features/mod.rs
@@ -458,7 +458,7 @@ pub(crate) fn build_features(
 /// Note that we follow the ordering of features as implemented in soundgarden,
 /// since the ListNet model has been trained on that.
 pub(crate) fn features_to_ndarray(feats_list: &[Features]) -> Array2<f32> {
-    let mut arr = Array2::zeros((feats_list.len(), 50));
+    let mut arr = Array2::default((feats_list.len(), 50));
 
     let click_mrr = &AtomFeat::MeanRecipRank(MrrOutcome::Click);
     let miss_mrr = &AtomFeat::MeanRecipRank(MrrOutcome::Miss);

--- a/xayn-ai/src/ltr/list_net/model.rs
+++ b/xayn-ai/src/ltr/list_net/model.rs
@@ -171,21 +171,21 @@ impl ListNet {
 
         let dense1 = Dense::new(
             he_normal_weights_init(&mut rng, (Self::INPUT_NR_FEATURES, 48)),
-            Array1::zeros((48,)),
+            Array1::default(48),
             Relu,
         )
         .unwrap();
 
         let dense2 = Dense::new(
             he_normal_weights_init(&mut rng, (48, 8)),
-            Array1::zeros((8,)),
+            Array1::default(8),
             Relu,
         )
         .unwrap();
 
         let scores = Dense::new(
             he_normal_weights_init(&mut rng, (8, 1)),
-            Array1::zeros((1,)),
+            Array1::default(1),
             Linear,
         )
         .unwrap();
@@ -195,7 +195,7 @@ impl ListNet {
                 &mut rng,
                 (Self::INPUT_NR_DOCUMENTS, Self::INPUT_NR_DOCUMENTS),
             ),
-            Array1::zeros((Self::INPUT_NR_DOCUMENTS,)),
+            Array1::default(Self::INPUT_NR_DOCUMENTS),
             Softmax::default(),
         )
         .unwrap();

--- a/xayn-ai/src/ltr/list_net/tests/inference.rs
+++ b/xayn-ai/src/ltr/list_net/tests/inference.rs
@@ -154,7 +154,7 @@ fn test_run_works_with_10_inputs() {
 #[test]
 fn test_running_list_net_with_no_inputs_works() {
     let list_net = &*LIST_NET;
-    let inputs = Array2::<f32>::zeros((0, 50));
+    let inputs = Array2::<f32>::default((0, 50));
     let outputs = list_net.run(inputs);
     assert!(outputs.is_empty());
 }


### PR DESCRIPTION
**References**

- [TY-2179]

**Summary**

- lowercase the key phrases during decoding: this reduces duplications and aligns with the original implementation, at the same time the tokenizer can still be configured to not lowercase the tokens to take advantage of case sensitive vocabularies and their corresponding embeddings
- update the decode and pipeline tests
- fix the cnn and classifier binparams: use the params from the bert joint model instead of the roberta joint model, already uploaded to the bucket
- replace `Array::zeros(shape)` with `Array::default(shape)`: this goes a different path and eventually calls `memcpy` instead of `memset` which seems to circumvent our qemu issue, performance wise this is pretty much the same
- add more debug assertions

to compare the kpe with the original implementation i took the test sequences from the research repo and ran them through the python code andthe rust code with the non-quantized model as well as the quantized model. the results are pretty similar and only vary slightly due to the quantization. i put the scores for better visibility of the differences, but they are not part of the output of the kpe, but only the key phrases are. below you can see the top 5 for each test sequence.

*"Russian chess grandmaster Ian Nepomniachtchi clinched victory at the Candidates Tournament on Monday, earning him the chance to challenge Norway Magnus Carlsen for the world title later this year."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"candidates tournament": 2.934950590133667` | `"candidates tournament": 2.9349513` | `"candidates tournament": 2.9128938` |
| `"ian nepomniachtchi": 2.929558277130127` | `"ian nepomniachtchi": 2.9295583` | `"ian nepomniachtchi": 2.6917644` |
| `"russian chess grandmaster": 2.0224971771240234` | `"russian chess grandmaster": 2.022496` | `"russian chess grandmaster": 1.7331984` |
| `"chess grandmaster": 1.3638781309127808` | `"chess grandmaster": 1.3638741` | `"chess grandmaster": 1.5507476` |
| `"chess": 0.9367392063140869` | `"chess": 0.93673766` | `"world title": 1.0421757` |

*"Paranoid schizophrenia is a psychotic disorder."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"paranoid schizophrenia": 3.4006059169769287` | `"paranoid schizophrenia": 3.4006069` | `"paranoid schizophrenia": 3.053503` |
| `"psychotic disorder.": 2.903540849685669` | `"psychotic disorder.": 2.9035397` | `"psychotic disorder.": 2.8526697` |
| `"schizophrenia": 1.9880062341690063` | `"schizophrenia": 1.9880033` | `"schizophrenia": 2.1258035` |
| `"paranoid": -0.1836133599281311` | `"paranoid": -0.18361469` | `"paranoid": 0.7293535` |
| `"disorder.": -0.2852359414100647` | `"disorder.": -0.28523594` | `"psychotic": -0.06573556` |

*"Berlin is the capital of Germany."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"berlin": 3.1970295906066895` | `"berlin": 3.19703` | `"berlin": 3.2181687` |
| `"germany.": 1.6476101875305176` | `"germany.": 1.6476078` | `"germany.": 1.7104346` |
| `"capital of germany.": 1.2701386213302612` | `"capital of germany.": 1.2701381` | `"capital of germany.": 1.3192337` |
| `"capital": 0.9426577687263489` | `"capital": 0.94265676` | `"capital": 1.0431908` |
| `"berlin is the capital": -2.0997655391693115` | `"berlin is the capital": -2.099763` | `"berlin is the capital": -1.8400929` |

*"Supervised learning, also known as supervised machine learning, is a subcategory of machine learning and artificial intelligence."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"supervised learning,": 4.123152256011963` | `"supervised learning,": 4.123152` | `"supervised learning,": 4.173371` |
| `"artificial intelligence.": 3.3956236839294434` | `"artificial intelligence.": 3.3956218` | `"artificial intelligence.": 3.2648902` |
| `"machine learning": 2.738740921020508` | `"machine learning": 2.7387404` | `"machine learning": 2.92315` |
| `"machine learning,": 2.257261276245117` | `"machine learning,": 2.2572598` | `"machine learning,": 2.399899` |
| `"supervised machine learning,": 1.8682597875595093` | `"supervised machine learning,": 1.868258` | `"supervised machine learning,": 1.7145393` |

*"State of the art definition is - the level of development (as of a device, procedure, process, technique, or science) reached at any particular time usually as a result of modern methods."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"definition": 3.355534791946411` | `"definition": 3.3555365` | `"definition": 3.2327096` |
| `"state of the art": 2.552528142929077` | `"state of the art": 2.552527` | `"state of the art": 2.331875` |
| `"modern methods.": 2.336472272872925` | `"modern methods.": 2.3364725` | `"modern methods.": 2.187481` |
| `"level of development": 1.5994861125946045` | `"level of development": 1.599487` | `"level of development": 1.7525568` |
| `"state of the art definition": 1.4022821187973022` | `"state of the art definition": 1.4022812` | `"art definition": 1.4388075` |

*"A challenging problem faced by researchers and developers of distributed real-time and embedded (DRE) systems is devising and implementing effective adaptive resource management strategies that can meet end-to-end quality of service (QoS) requirements in varying operational conditions."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"adaptive resource management": 2.5827958583831787` | `"adaptive resource management": 2.5827935` | `"adaptive resource management": 2.2490516` |
| `"quality of service": 2.3652701377868652` | `"quality of service": 2.3652692` | `"quality of service": 2.0012026` |
| `"adaptive resource management strategies": 1.763451099395752` | `"adaptive resource management strategies": 1.7634536` | `"resource management strategies": 1.7171625` |
| `"distributed real-time and embedded": 1.5346410274505615` | `"distributed real-time and embedded": 1.5346417` | `"resource management": 1.6924928` |
| `"resource management": 1.38322913646698` | `"resource management": 1.3832289` | `"adaptive resource management strategies": 1.5321714` |

*"The Taliban were one of the factions fighting in Afghanistan's civil war in the 1990s after the withdrawal of the Soviet Union. The group emerged in 1994 around the southern Afghan city of Kandahar. Their founder was Mullah Mohammad Omar, a local imam in the city, who led the militants until his death in 2013."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"taliban": 3.7115745544433594` | `"taliban": 3.7115746` | `"taliban": 3.466772` |
| `"afghanistan's civil war": 2.517509937286377` | `"afghanistan's civil war": 2.517508` | `"mullah mohammad omar,": 2.3020673` |
| `"kandahar.": 2.444540023803711` | `"kandahar.": 2.4445388` | `"civil war": 2.2738624` |
| `"mullah mohammad omar,": 2.4329581260681152` | `"mullah mohammad omar,": 2.43296` | `"afghanistan's civil war": 2.204691` |
| `"civil war": 2.35225772857666` | `"civil war": 2.3522582` | `"kandahar.": 2.068139` |

*"Blog Tokyo 2020 Olympics - LIVE BLOG - Women's marathon underway at start of busy Saturday Tokyo 2020 | Olympic Games. Next Games 04 - 20 Feb 2022."*:
| python | rust non-quantized| rust quantized |
| - | - | - |
| `"tokyo 2020 olympics": 3.256546974182129` | `"tokyo 2020 olympics": 3.256544` | `"tokyo 2020 olympics": 3.171133` |
| `"marathon": 2.969186305999756` | `"marathon": 2.9691875` | `"marathon": 2.5788279` |
| `"women's marathon": 1.2069082260131836` | `"women's marathon": 1.2069075` | `"women's marathon": 1.2984582` |
| `"blog": 0.6994484066963196` | `"blog": 0.6994498` | `"tokyo": 0.6820054` |
| `"olympic games.": 0.47504761815071106` | `"olympic games.": 0.47504336` | `"tokyo 2020": 0.60414904` |

**Todo**

- ~rebase once #310 and #316 are merged~


[TY-2179]: https://xainag.atlassian.net/browse/TY-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ