### PR TITLE
[Merged by Bors] - DEVOPS-603 Adding the output of the linux-lib

### DIFF
--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -3,9 +3,9 @@ name: Reusable Dev CI
 on:
   workflow_call:
     outputs:
-    cache-key-linux-lib:
-      description: Cache key from the build-linux-lib job
-      value: ${{ jobs.build-linux-lib.outputs.cache-key }}  
+      cache-key-linux-lib:
+        description: Cache key from the build-linux-lib job
+        value: ${{ jobs.build-linux-lib.outputs.cache-key }}
 
 env:
   RUST_STABLE: 1.55

--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -2,6 +2,10 @@ name: Reusable Dev CI
 
 on:
   workflow_call:
+    outputs:
+    cache-key-linux-lib:
+      description: Cache key from the build-linux-lib job
+      value: ${{ jobs.build-linux-lib.outputs.cache-key }}  
 
 env:
   RUST_STABLE: 1.55
@@ -9,7 +13,6 @@ env:
   FLUTTER_VERSION: '2.5.3'
   DART_WORKSPACE: ${{ github.workspace }}/bindings/dart
   CARGO_INCREMENTAL: 0
-
 
 jobs:
   cargo-registry-cache:


### PR DESCRIPTION
The bors_ci needs cache-key that is generated during the run of the build-linux-lib job. This PR is to change the workflow reuse to export the output. 