### PR TITLE
[Merged by Bors] - FIX: ci timeout

### DIFF
--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -180,7 +180,7 @@ jobs:
     name: cargo-test
     needs: [cargo-registry-cache, cargo-check]
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     outputs:
       cache-key: ${{ steps.cache-key.outputs.key }}
     steps:


### PR DESCRIPTION
**Summary**

- increase the timeout of the `cargo-test` job to 30 minutes: github is quite slow lately and the ci times out frequently
