### PR TITLE
[Merged by Bors] - Remove cargo-check. Allow jobs to run earlier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
 
   dev-ci:
-    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@master
+    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@speedup_ci
 
   # this is an helper that needs all the real leafs of the workflow.
   # It makes easier notify_staging_failure because we only need to check

--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -16,7 +16,6 @@ env:
 
 jobs:
   cargo-format:
-    name: cargo-format
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -39,7 +38,6 @@ jobs:
         run: cargo fmt --all -- --check
 
   cargo-sort:
-    name: cargo-sort
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -52,34 +50,7 @@ jobs:
       - name: cargo sort
         run: cargo sort --grouped --workspace --check
 
-  cargo-check:
-    name: cargo-check
-    runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
-
-      - name: Install ${{ env.RUST_STABLE }} toolchain
-        id: rust-toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_STABLE }}
-          default: true
-
-      - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # 1.3
-
-      - name: cargo check
-        env:
-          RUSTFLAGS: "-D warnings"
-        run: |
-          cargo check --all-targets
-          cargo check --all-targets --all-features
-
   cargo-clippy:
-    name: cargo-clippy
-    needs: cargo-check
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
@@ -101,14 +72,38 @@ jobs:
         run: |
           cargo clippy --all-targets -- --deny warnings
           cargo clippy --all-targets --all-features -- --deny warnings
-          
+
   cargo-test:
-    name: cargo-test
-    needs: cargo-check
+    runs-on: ubuntu-20.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+      - name: Install ${{ env.RUST_STABLE }} toolchain
+        id: rust-toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_STABLE }}
+          default: true
+
+      - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # 1.3
+
+      - name: Download data
+        run: sh download_data.sh
+
+      - name: Run tests
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: |
+          # compilations options must be kept in sync with cargo-tarpaulin and build-linux-lib
+          cargo test --all-features
+
+  cargo-more-test:
+    needs: cargo-test
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-    outputs:
-      cache-key: ${{ steps.cache-key.outputs.key }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
@@ -135,7 +130,6 @@ jobs:
           cargo test --all-features --doc
 
   cargo-tarpaulin:
-    name: cargo-tarpaulin
     needs: cargo-test
     runs-on: ubuntu-20.04
     timeout-minutes: 30
@@ -160,10 +154,10 @@ jobs:
         uses: actions-rs/tarpaulin@044a1e5bdace8dd2f727b1af63c1d9a1d3572068 # v0.1.3
         with:
           version: '0.16.0'
+          # compilations options must be kept in sync with cargo-test
           args: '-v --all-features --force-clean --lib --ignore-tests --fail-under 70 --workspace --exclude xayn-ai-ffi-wasm --exclude dev-tool --timeout 300'
 
   build-linux-lib:
-    name: build-linux-lib
     needs: cargo-test
     runs-on: ubuntu-20.04
     outputs:
@@ -184,7 +178,13 @@ jobs:
       - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # 1.3
 
       - name: Build linux lib
-        run: cargo build
+        # We have to use the same RUSTFLAGS that are used in the test
+        # job in order to be able to reuse the cache. If we do not do this,
+        # the compiler will recompile all the libraries from scratch.
+        env:
+          RUSTFLAGS: "-D warnings"
+        # compilations options must be kept in sync with cargo-test
+        run: cargo build --all-features
 
       - name: Generate lib artifacts key
         id: cache-key
@@ -203,7 +203,6 @@ jobs:
             ${{ env.DART_WORKSPACE }}/ios/Classes/XaynAiFfiDart.h
 
   flutter-format:
-    name: flutter-format
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -220,8 +219,6 @@ jobs:
         run: flutter format --set-exit-if-changed .
 
   flutter-checks:
-    name: flutter-checks
-    needs: build-linux-lib
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -13,6 +13,8 @@ env:
   FLUTTER_VERSION: '2.5.3'
   DART_WORKSPACE: ${{ github.workspace }}/bindings/dart
   CARGO_INCREMENTAL: 0
+  # flags to use for test, tarpaulin and to build the linux library
+  COMMON_CARGO_TEST_FLAGS: --all-features
 
 jobs:
   cargo-format:
@@ -31,7 +33,6 @@ jobs:
           default: true
 
       - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # 1.3
-
 
       # cargo fmt does not create any artifacts, therefore we don't need to cache the target folder
       - name: cargo fmt
@@ -96,9 +97,8 @@ jobs:
       - name: Run tests
         env:
           RUSTFLAGS: "-D warnings"
-        run: |
-          # compilations options must be kept in sync with cargo-tarpaulin and build-linux-lib
-          cargo test --all-features
+        # compilations options must be kept in sync with cargo-tarpaulin and build-linux-lib
+        run: cargo test ${{ env.COMMON_CARGO_TEST_FLAGS }}
 
   cargo-more-test:
     needs: cargo-test
@@ -155,7 +155,7 @@ jobs:
         with:
           version: '0.16.0'
           # compilations options must be kept in sync with cargo-test
-          args: '-v --all-features --force-clean --lib --ignore-tests --fail-under 70 --workspace --exclude xayn-ai-ffi-wasm --exclude dev-tool --timeout 300'
+          args: '${{ env.COMMON_CARGO_TEST_FLAGS }} -v --force-clean --lib --ignore-tests --fail-under 70 --workspace --exclude xayn-ai-ffi-wasm --exclude dev-tool --timeout 300'
 
   build-linux-lib:
     needs: cargo-test
@@ -178,13 +178,8 @@ jobs:
       - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641 # 1.3
 
       - name: Build linux lib
-        # We have to use the same RUSTFLAGS that are used in the test
-        # job in order to be able to reuse the cache. If we do not do this,
-        # the compiler will recompile all the libraries from scratch.
-        env:
-          RUSTFLAGS: "-D warnings"
         # compilations options must be kept in sync with cargo-test
-        run: cargo build --all-features
+        run: cargo build ${{ env.COMMON_CARGO_FLAG_TESTS }}
 
       - name: Generate lib artifacts key
         id: cache-key
@@ -219,6 +214,7 @@ jobs:
         run: flutter format --set-exit-if-changed .
 
   flutter-checks:
+    needs: build-linux-lib
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/ci_reusable_wf.yml
+++ b/.github/workflows/ci_reusable_wf.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Build linux lib
         # compilations options must be kept in sync with cargo-test
-        run: cargo build ${{ env.COMMON_CARGO_FLAG_TESTS }}
+        run: cargo build ${{ env.COMMON_CARGO_TEST_FLAGS }}
 
       - name: Generate lib artifacts key
         id: cache-key


### PR DESCRIPTION
This PR aims to speed up the ci allowing some job to run earlier.

* Remove cargo-check. Compilation errors will be present in cargo-clippy and cargo-test
* Split cargo-test in two:
  * cargo-test that runs only `cargo test --all-features` 
  * cargo-more-test that runs other tests with --all-target and also --doc.
the jobs `cargo-tarpaulin` and `build-linux-lib` now depends only on `cargo-test`.