### PR TITLE
[Merged by Bors] - DEVOPS-599 Using the latest tag for the reusable WF

### DIFF
--- a/.github/workflows/bors_ci.yml
+++ b/.github/workflows/bors_ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: cargo fetch
 
   dev-ci:
-    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@49cefaead3a29817658e7e19d1ea028070aa1f3b
+    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@master
 
   test-android-libs:
     name: test-android-libs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
 
   dev-ci:
-    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@49cefaead3a29817658e7e19d1ea028070aa1f3b
+    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@latest
 
   # this is an helper that needs all the real leafs of the workflow.
   # It makes easier notify_staging_failure because we only need to check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
 
   dev-ci:
-    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@latest
+    uses: xaynetwork/xayn_ai/.github/workflows/ci_reusable_wf.yml@master
 
   # this is an helper that needs all the real leafs of the workflow.
   # It makes easier notify_staging_failure because we only need to check


### PR DESCRIPTION
This tries to avoid having to change the reference from the reusable workflow everytime a change is implemented to it. 