### PR TITLE
[Merged by Bors] - TY-2205 add coi weighting fields [0]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2392,6 +2392,7 @@ dependencies = [
  "derive_more",
  "displaydoc",
  "itertools",
+ "js-sys",
  "layer",
  "maplit",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2388,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "csv",
+ "derivative",
  "derive_more",
  "displaydoc",
  "itertools",

--- a/xayn-ai-ffi-c/src/reranker/ai.rs
+++ b/xayn-ai-ffi-c/src/reranker/ai.rs
@@ -1548,7 +1548,7 @@ mod tests {
         assert_eq!(
             error.message.as_ref().unwrap().as_str(),
             format!(
-                "Failed to deserialize the reranker database: Unsupported serialized data. Found version {} expected 2",
+                "Failed to deserialize the reranker database: Unsupported serialized data. Found version {} expected 3",
                 version,
             ),
         );
@@ -1660,7 +1660,7 @@ mod tests {
         assert_eq!(
             error.message.as_ref().unwrap().as_str(),
             format!(
-                "Failed to synchronize data: Unsupported serialized data. Found version {} expected 2.",
+                "Failed to synchronize data: Unsupported serialized data. Found version {} expected 3.",
                 version,
             ),
         );

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -28,6 +28,7 @@ rayon = { version = "1.5.1", optional = true }
 
 [dev-dependencies]
 csv = "1.1.6"
+derivative = "2.2.0"
 maplit = "1.0.2"
 mockall = "0.10.2"
 once_cell = "1.8.0"

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -26,6 +26,9 @@ uuid = { version = "0.8.2", features = ["serde", "wasm-bindgen", "v4"] }
 # multithreaded feature
 rayon = { version = "1.5.1", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.55"
+
 [dev-dependencies]
 csv = "1.1.6"
 derivative = "2.2.0"

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -16,7 +16,17 @@ const MERGE_THRESHOLD_DIST: f32 = 4.5;
 impl PositiveCoi {
     pub fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(&self.point, &other.point);
-        Self { id, point }
+        let view_count = self.view_count + other.view_count;
+        let view_time = self.view_time + other.view_time;
+        let last_time = self.last_time.max(other.last_time);
+
+        Self {
+            id,
+            point,
+            view_count,
+            view_time,
+            last_time,
+        }
     }
 }
 

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime};
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
-use crate::{coi::CoiId, embedding::utils::Embedding};
+use crate::{coi::CoiId, embedding::utils::Embedding, utils::system_time_now};
 
 #[obake::versioned]
 #[obake(version("0.0.0"))]
@@ -178,14 +178,14 @@ impl_coi_point! {
                 point,
                 view_count: 1,
                 view_time: viewed.unwrap_or_default(),
-                last_time: SystemTime::now(),
+                last_time: system_time_now(),
             }
         }
 
         fn update_view(self: &mut Self, viewed: Option<Duration>) {
             self.view_count += 1;
             self.view_time += viewed.unwrap_or_default();
-            self.last_time = SystemTime::now();
+            self.last_time = system_time_now();
         }
     },
 

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -120,7 +120,7 @@ impl CoiSystem {
                 coi.set_point(self.shift_coi_point(embedding, coi.point()));
                 coi.set_id(Uuid::new_v4().into());
             }
-            _ => cois.push(CP::new(Uuid::new_v4().into(), embedding.clone())),
+            _ => cois.push(CP::new(Uuid::new_v4().into(), embedding.clone(), None)),
         }
         cois
     }
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_shift_coi_point() {
-        let coi = PositiveCoi::new(CoiId::mocked(0), arr1(&[1., 1., 1.]).into());
+        let coi = PositiveCoi::new(CoiId::mocked(0), arr1(&[1., 1., 1.]).into(), None);
         let embedding = arr1(&[2., 3., 4.]).into();
 
         let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi.point);

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -119,6 +119,7 @@ impl CoiSystem {
             Some((coi, distance)) if distance < self.config.threshold => {
                 coi.set_point(self.shift_coi_point(embedding, coi.point()));
                 coi.set_id(Uuid::new_v4().into());
+                coi.update_view(None);
             }
             _ => cois.push(CP::new(Uuid::new_v4().into(), embedding.clone(), None)),
         }

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -103,7 +103,7 @@ pub(super) mod tests {
         points
             .iter()
             .enumerate()
-            .map(|(id, point)| CP::new(CoiId::mocked(id), arr1(point.as_init_slice()).into()))
+            .map(|(id, point)| CP::new(CoiId::mocked(id), arr1(point.as_init_slice()).into(), None))
             .collect()
     }
 

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -43,7 +43,8 @@ use crate::{
     utils::{nan_safe_f32_cmp, to_vec_of_ref_of},
 };
 
-const CURRENT_SCHEMA_VERSION: u8 = 2;
+/// The version number of the reranker de/serialization schema.
+const CURRENT_SCHEMA_VERSION: u8 = 3;
 
 /// The mode used to run reranking with.
 ///

--- a/xayn-ai/src/tests/mod.rs
+++ b/xayn-ai/src/tests/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use self::{
         pos_cois_from_words,
         pos_cois_from_words_v0,
         pos_cois_from_words_v1,
+        pos_cois_from_words_v2,
         pos_cois_from_words_with_ids,
     },
 };

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -5,7 +5,14 @@ use uuid::Uuid;
 
 use crate::{
     coi::{
-        point::{CoiPoint, NegativeCoi, PositiveCoi, PositiveCoi_v0_0_0, PositiveCoi_v0_1_0},
+        point::{
+            CoiPoint,
+            NegativeCoi,
+            PositiveCoi,
+            PositiveCoi_v0_0_0,
+            PositiveCoi_v0_1_0,
+            PositiveCoi_v0_2_0,
+        },
         CoiId,
     },
     data::{
@@ -111,6 +118,13 @@ pub(crate) fn pos_cois_from_words_v1(
     titles: &[&str],
     smbert: impl SMBertSystem,
 ) -> Vec<PositiveCoi_v0_1_0> {
+    cois_from_words(titles, smbert, 0)
+}
+
+pub(crate) fn pos_cois_from_words_v2(
+    titles: &[&str],
+    smbert: impl SMBertSystem,
+) -> Vec<PositiveCoi_v0_2_0> {
     cois_from_words(titles, smbert, 0)
 }
 

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -103,7 +103,7 @@ fn cois_from_words<CP: CoiPoint>(
         .unwrap()
         .into_iter()
         .enumerate()
-        .map(|(offset, doc)| CP::new(CoiId::mocked(start_id + offset), doc.smbert.embedding))
+        .map(|(offset, doc)| CP::new(CoiId::mocked(start_id + offset), doc.smbert.embedding, None))
         .collect()
 }
 

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -1,5 +1,9 @@
-use std::cmp::Ordering;
+#[cfg(target_arch = "wasm32")]
+use std::time::Duration;
+use std::{cmp::Ordering, time::SystemTime};
 
+#[cfg(target_arch = "wasm32")]
+use js_sys::Date;
 use serde::Serialize;
 
 use crate::Error;
@@ -83,6 +87,16 @@ pub(crate) fn serialize_with_version(data: &impl Serialize, version: u8) -> Resu
     bincode::serialize_into(&mut serialized, data)?;
 
     Ok(serialized)
+}
+
+/// Gets the current system time depending on the target architecture.
+#[inline]
+pub(crate) fn system_time_now() -> SystemTime {
+    #[cfg(target_arch = "wasm32")]
+    return SystemTime::UNIX_EPOCH + Duration::from_secs_f64(Date::now() / 1000.);
+
+    #[cfg(not(target_arch = "wasm32"))]
+    return SystemTime::now();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
**References**

- [TY-2205]

**Summary**

- add view statistics fields to `PositiveCoi` & update the version migration schemes
- update the `CoiPoint::new()` constructor with the required fields & move the constructor definitions to avoid code duplication
- add `CoiPoint::update_view()` to use the new fields in existing cois

**Note**

- in every call `viewed: None` is currently used, this will be changed in #331
- if you use rust-analyzer, then you should add the `derivative` crate to the `Cargo: Unset Test` setting option, otherwise you will get a false positive for `unresolved-import`
- on `wasm32` targets we don't have access to the current system time neither from `std::time` nor from other crates like `time` or `chrono`, hence we have to use the `wasm32` target specific time from `js-sys`


[TY-2205]: https://xainag.atlassian.net/browse/TY-2205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ