### PR TITLE
[Merged by Bors] - TY-2205 add coi weighting fields [1]

### DIFF
--- a/dev-tool/src/call_data/generate.rs
+++ b/dev-tool/src/call_data/generate.rs
@@ -390,6 +390,7 @@ fn gen_current_query_from_history(
                 query_words: query_words.clone(),
                 url: url.clone(),
                 domain: domain.clone(),
+                viewed: None,
             }
         })
         .collect()

--- a/xayn-ai-ffi-c/src/data/document.rs
+++ b/xayn-ai-ffi-c/src/data/document.rs
@@ -136,6 +136,7 @@ impl<'a> CDocuments<'a> {
                         )
                     }?
                     .into();
+                    let viewed = None;
 
                     Ok(Document {
                         id,
@@ -148,6 +149,7 @@ impl<'a> CDocuments<'a> {
                         query_words,
                         url,
                         domain,
+                        viewed,
                     })
                 })
                 .collect(),

--- a/xayn-ai-ffi-wasm/src/ai.rs
+++ b/xayn-ai-ffi-wasm/src/ai.rs
@@ -337,6 +337,7 @@ mod tests {
                 query_words: doc.7,
                 url: doc.8,
                 domain: doc.9,
+                viewed: None,
             })
             .unwrap()
         })

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -396,7 +396,11 @@ mod tests {
 
     #[test]
     fn test_shift_coi_point() {
-        let coi = PositiveCoi::new(CoiId::mocked(0), arr1(&[1., 1., 1.]).into(), None);
+        let coi = PositiveCoi::new(
+            CoiId::mocked(0),
+            arr1(&[1., 1., 1.]).into(),
+            Some(Duration::from_secs(10)),
+        );
         let embedding = arr1(&[2., 3., 4.]).into();
 
         let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi.point);

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{ops::Deref, time::Duration};
 
 use displaydoc::Display;
 use thiserror::Error;
@@ -114,14 +114,19 @@ impl CoiSystem {
     /// Updates the CoIs based on the given embedding. If the embedding is close to the nearest centroid
     /// (within [`Configuration.threshold`]), the centroid's position gets updated,
     /// otherwise a new centroid is created.
-    fn update_coi<CP: CoiPoint>(&self, embedding: &Embedding, mut cois: Vec<CP>) -> Vec<CP> {
+    fn update_coi<CP: CoiPoint>(
+        &self,
+        embedding: &Embedding,
+        viewed: Option<Duration>,
+        mut cois: Vec<CP>,
+    ) -> Vec<CP> {
         match self.find_closest_coi_mut(embedding, &mut cois) {
             Some((coi, distance)) if distance < self.config.threshold => {
                 coi.set_point(self.shift_coi_point(embedding, coi.point()));
                 coi.set_id(Uuid::new_v4().into());
-                coi.update_view(None);
+                coi.update_view(viewed)
             }
-            _ => cois.push(CP::new(Uuid::new_v4().into(), embedding.clone(), None)),
+            _ => cois.push(CP::new(Uuid::new_v4().into(), embedding.clone(), viewed)),
         }
         cois
     }
@@ -129,7 +134,7 @@ impl CoiSystem {
     /// Updates the CoIs based on the embeddings of docs.
     fn update_cois<CP: CoiPoint>(&self, docs: &[&dyn CoiSystemData], cois: Vec<CP>) -> Vec<CP> {
         docs.iter().fold(cois, |cois, doc| {
-            self.update_coi(&doc.smbert().embedding, cois)
+            self.update_coi(&doc.smbert().embedding, doc.viewed(), cois)
         })
     }
 
@@ -249,6 +254,7 @@ mod tests {
             document_data::{
                 ContextComponent,
                 DocumentBaseComponent,
+                DocumentContentComponent,
                 DocumentDataWithRank,
                 LtrComponent,
                 QAMBertComponent,
@@ -271,6 +277,10 @@ mod tests {
                 document_base: DocumentBaseComponent {
                     id: DocumentId::from_u128(id as u128),
                     initial_ranking: id,
+                },
+                document_content: DocumentContentComponent {
+                    title: id.to_string(),
+                    ..DocumentContentComponent::default()
                 },
                 smbert: SMBertComponent {
                     embedding: arr1(embedding.as_init_slice()).into(),
@@ -352,6 +362,7 @@ mod tests {
     fn test_update_coi_add_point() {
         let mut cois = create_pos_cois(&[[30., 0., 0.], [0., 20., 0.], [0., 0., 40.]]);
         let embedding = arr1(&[1., 1., 1.]).into();
+        let viewed = Some(Duration::from_secs(10));
 
         let config = Configuration::default();
         let threshold = config.threshold;
@@ -365,7 +376,7 @@ mod tests {
         assert_approx_eq!(f32, distance, 26.747852);
         assert!(threshold < distance);
 
-        cois = coi_system.update_coi(&embedding, cois);
+        cois = coi_system.update_coi(&embedding, viewed, cois);
         assert_eq!(cois.len(), 4);
     }
 
@@ -373,8 +384,9 @@ mod tests {
     fn test_update_coi_update_point() {
         let cois = create_pos_cois(&[[1., 1., 1.], [10., 10., 10.], [20., 20., 20.]]);
         let embedding = arr1(&[2., 3., 4.]).into();
+        let viewed = Some(Duration::from_secs(10));
 
-        let cois = CoiSystem::default().update_coi(&embedding, cois);
+        let cois = CoiSystem::default().update_coi(&embedding, viewed, cois);
 
         assert_eq!(cois.len(), 3);
         assert_eq!(cois[0].point, arr1(&[1.1, 1.2, 1.3]));
@@ -396,8 +408,9 @@ mod tests {
     fn test_update_coi_threshold_exclusive() {
         let cois = create_pos_cois(&[[0., 0., 0.]]);
         let embedding = arr1(&[0., 0., 12.]).into();
+        let viewed = Some(Duration::from_secs(10));
 
-        let cois = CoiSystem::default().update_coi(&embedding, cois);
+        let cois = CoiSystem::default().update_coi(&embedding, viewed, cois);
 
         assert_eq!(cois.len(), 2);
         assert_eq!(cois[0].point, arr1(&[0., 0., 0.]));

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -109,7 +109,13 @@ pub(super) mod tests {
         points
             .iter()
             .enumerate()
-            .map(|(id, point)| CP::new(CoiId::mocked(id), arr1(point.as_init_slice()).into(), None))
+            .map(|(id, point)| {
+                CP::new(
+                    CoiId::mocked(id),
+                    arr1(point.as_init_slice()).into(),
+                    Some(Duration::from_secs(10)),
+                )
+            })
             .collect()
     }
 

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -61,6 +61,8 @@ fn document_relevance(history: &DocumentHistory) -> DocumentRelevance {
 
 #[cfg(test)]
 pub(super) mod tests {
+    use std::time::Duration;
+
     use ndarray::{arr1, FixedInitializer};
 
     use super::*;
@@ -96,6 +98,10 @@ pub(super) mod tests {
 
         fn coi(&self) -> Option<&CoiComponent> {
             self.coi.as_ref()
+        }
+
+        fn viewed(&self) -> Option<Duration> {
+            Some(Duration::from_secs(10))
         }
     }
 

--- a/xayn-ai/src/context.rs
+++ b/xayn-ai/src/context.rs
@@ -82,6 +82,7 @@ mod tests {
             document_data::{
                 CoiComponent,
                 DocumentBaseComponent,
+                DocumentContentComponent,
                 LtrComponent,
                 QAMBertComponent,
                 SMBertComponent,
@@ -113,6 +114,10 @@ mod tests {
                 document_base: DocumentBaseComponent {
                     id,
                     initial_ranking: 13,
+                },
+                document_content: DocumentContentComponent {
+                    title: id.to_string(),
+                    ..DocumentContentComponent::default()
                 },
                 smbert: SMBertComponent { embedding },
                 qambert: QAMBertComponent { similarity },

--- a/xayn-ai/src/data/document.rs
+++ b/xayn-ai/src/data/document.rs
@@ -1,6 +1,6 @@
-use derive_more::Display;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
+use derive_more::Display;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::convert::TryFrom;
@@ -100,6 +100,8 @@ pub struct Document {
     pub url: String,
     /// Domain of the document
     pub domain: String,
+    /// Time viewed of the document.
+    pub viewed: Option<Duration>,
 }
 
 /// Represents a historical result from a query.

--- a/xayn-ai/src/reranker/systems.rs
+++ b/xayn-ai/src/reranker/systems.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::{
     analytics::Analytics,
     coi::point::UserInterests,
@@ -44,6 +46,7 @@ pub(crate) trait CoiSystemData {
     fn id(&self) -> DocumentId;
     fn smbert(&self) -> &SMBertComponent;
     fn coi(&self) -> Option<&CoiComponent>;
+    fn viewed(&self) -> Option<Duration>;
 }
 
 #[cfg_attr(test, automock)]

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -177,6 +177,10 @@ pub(crate) fn data_with_rank(
                 id,
                 initial_ranking,
             },
+            document_content: DocumentContentComponent {
+                title: id.to_string(),
+                ..DocumentContentComponent::default()
+            },
             smbert: SMBertComponent { embedding },
             qambert: QAMBertComponent { similarity: 0.5 },
             coi: CoiComponent {

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use std::{ops::Range, time::Duration};
 
 use ndarray::arr1;
 use uuid::Uuid;
@@ -103,7 +103,13 @@ fn cois_from_words<CP: CoiPoint>(
         .unwrap()
         .into_iter()
         .enumerate()
-        .map(|(offset, doc)| CP::new(CoiId::mocked(start_id + offset), doc.smbert.embedding, None))
+        .map(|(offset, doc)| {
+            CP::new(
+                CoiId::mocked(start_id + offset),
+                doc.smbert.embedding,
+                Some(Duration::from_secs(10)),
+            )
+        })
         .collect()
 }
 


### PR DESCRIPTION
**References**

- [TY-2205]
- #330 

**Summary**

last two commits:
- add `viewed` field to `Document` & add a getter in `CoiSystemData`
- add `DocumentContentComponent` to the required document states in order to impl the getter
- use a default dummy of `viewed` in the ffi to avoid unnecessary impl work

**Todo**

 - ~rebase once #330 is merged~


[TY-2205]: https://xainag.atlassian.net/browse/TY-2205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ