### PR TITLE
[Merged by Bors] - FIX: flutter example benchmark visibility

### DIFF
--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -200,3 +200,32 @@ class Outcome {
     return resultList;
   }
 }
+
+enum _BenchmarkStatsKind {
+  none,
+  pending,
+  ready,
+}
+
+class BenchmarkStats {
+  final _BenchmarkStatsKind _kind;
+  final Stats<num>? _ready;
+
+  BenchmarkStats.none()
+      : _kind = _BenchmarkStatsKind.none,
+        _ready = null;
+
+  BenchmarkStats.ready(this._ready) : _kind = _BenchmarkStatsKind.ready;
+
+  @override
+  String toString() {
+    switch (_kind) {
+      case _BenchmarkStatsKind.none:
+        return '-- no benchmark stats --';
+      case _BenchmarkStatsKind.pending:
+        return '';
+      case _BenchmarkStatsKind.ready:
+        return 'Min: ${_ready!.min} Median: ${_ready!.median} Max: ${_ready!.max} Avg: ${_ready!.average} Std: ${_ready!.standardDeviation}';
+    }
+  }
+}

--- a/bindings/dart/example/lib/logic.dart
+++ b/bindings/dart/example/lib/logic.dart
@@ -205,41 +205,36 @@ class Outcome {
   }
 }
 
-enum _BenchmarkStatsKind {
-  none,
-  pending,
-  ready,
+abstract class BenchmarkStats {
+  static BenchmarkStats none() => _BenchmarkStatsNone();
+
+  static BenchmarkStats pending(int iter) => _BenchmarkStatsPending(iter);
+
+  static BenchmarkStats ready(Stats<num> stats) => _BenchmarkStatsReady(stats);
 }
 
-class BenchmarkStats {
-  final _BenchmarkStatsKind _kind;
-  final int? _pending;
-  final Stats<num>? _ready;
-
-  BenchmarkStats.none()
-      : _kind = _BenchmarkStatsKind.none,
-        _pending = null,
-        _ready = null;
-
-  BenchmarkStats.pending(int iteration)
-      : _kind = _BenchmarkStatsKind.pending,
-        _pending = iteration,
-        _ready = null;
-
-  BenchmarkStats.ready(Stats<num> stats)
-      : _kind = _BenchmarkStatsKind.ready,
-        _pending = null,
-        _ready = stats;
+class _BenchmarkStatsNone extends BenchmarkStats {
+  _BenchmarkStatsNone();
 
   @override
-  String toString() {
-    switch (_kind) {
-      case _BenchmarkStatsKind.none:
-        return '-- no benchmark stats yet --';
-      case _BenchmarkStatsKind.pending:
-        return 'Running warmup/benchmark: ${_pending!}';
-      case _BenchmarkStatsKind.ready:
-        return 'Min: ${_ready!.min} Median: ${_ready!.median} Max: ${_ready!.max} Avg: ${_ready!.average} Std: ${_ready!.standardDeviation}';
-    }
-  }
+  String toString() => '-- no benchmark stats yet --';
+}
+
+class _BenchmarkStatsPending extends BenchmarkStats {
+  final int _iter;
+
+  _BenchmarkStatsPending(this._iter);
+
+  @override
+  String toString() => 'Running warmup/benchmark: $_iter';
+}
+
+class _BenchmarkStatsReady extends BenchmarkStats {
+  final Stats<num> _stats;
+
+  _BenchmarkStatsReady(this._stats);
+
+  @override
+  String toString() =>
+      'Min: ${_stats.min} Median: ${_stats.median} Max: ${_stats.max} Avg: ${_stats.average} Std: ${_stats.standardDeviation}';
 }

--- a/bindings/dart/example/lib/main.dart
+++ b/bindings/dart/example/lib/main.dart
@@ -27,7 +27,6 @@ import 'package:flutter/material.dart'
         Widget,
         debugPrint,
         runApp;
-
 import 'package:flutter/services.dart' show rootBundle;
 
 import 'package:xayn_ai_ffi_dart_example/debug/print.dart'
@@ -205,11 +204,12 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> benchRerank() async {
-    final stats = await _logic!.benchmark();
-
-    setState(() {
-      _lastBenchmarkStats = BenchmarkStats.ready(stats);
-    });
+    final setPending = (int i) async {
+      setState(() => _lastBenchmarkStats = BenchmarkStats.pending(i));
+      await Future<void>.delayed(const Duration(microseconds: 1));
+    };
+    final stats = await _logic!.benchmark(setPending);
+    setState(() => _lastBenchmarkStats = BenchmarkStats.ready(stats));
   }
 
   Future<void> resetAi() async {

--- a/bindings/dart/example/lib/main.dart
+++ b/bindings/dart/example/lib/main.dart
@@ -29,12 +29,12 @@ import 'package:flutter/material.dart'
         runApp;
 
 import 'package:flutter/services.dart' show rootBundle;
-import 'package:stats/stats.dart' show Stats;
 
 import 'package:xayn_ai_ffi_dart_example/debug/print.dart'
     if (dart.library.io) 'package:xayn_ai_ffi_dart_example/debug/mobile/print.dart'
     show debugPrintLongText;
-import 'package:xayn_ai_ffi_dart_example/logic.dart' show Logic, Outcome;
+import 'package:xayn_ai_ffi_dart_example/logic.dart'
+    show BenchmarkStats, Logic, Outcome;
 
 void main() {
   runApp(MaterialApp(title: 'XaynAi Test/Example App', home: MyApp()));
@@ -49,7 +49,7 @@ class _MyAppState extends State<MyApp> {
   // We cannot use `late`. If we did and loading it takes long enough
   // for the application to be rendered then this can cause an exception.
   Logic? _logic;
-  Stats<num>? _lastBenchmarkStats;
+  BenchmarkStats _lastBenchmarkStats = BenchmarkStats.none();
   List<Outcome>? _lastResults;
 
   @override
@@ -112,23 +112,7 @@ class _MyAppState extends State<MyApp> {
         ));
   }
 
-  Widget benchmarkView() {
-    final stats = _lastBenchmarkStats;
-
-    if (stats == null) {
-      return Center(
-        child: Text('-- no benchmark stats --'),
-      );
-    }
-
-    final min = stats.min;
-    final median = stats.median;
-    final max = stats.max;
-    final avg = stats.average;
-    final std = stats.standardDeviation;
-
-    return Text('Min: $min Median: $median Max: $max Avg: $avg Std: $std');
-  }
+  Widget benchmarkView() => Center(child: Text(_lastBenchmarkStats.toString()));
 
   Widget resultsView() {
     final results = _lastResults;
@@ -224,14 +208,14 @@ class _MyAppState extends State<MyApp> {
     final stats = await _logic!.benchmark();
 
     setState(() {
-      _lastBenchmarkStats = stats;
+      _lastBenchmarkStats = BenchmarkStats.ready(stats);
     });
   }
 
   Future<void> resetAi() async {
     await _logic!.resetXaynAiState();
     setState(() {
-      _lastBenchmarkStats = null;
+      _lastBenchmarkStats = BenchmarkStats.none();
       _lastResults = null;
     });
   }


### PR DESCRIPTION
**Summary**

- wrap the benchmark stats in a "stateful enum": cleanup and less logic in the main file
- add a progressing counter for the benchmark: improves the visual feedback in the flutter example app next to the console output

**Note**

- we need a tiny delay in the `setPending` callback after `setState` to give the interface time to actually refresh, the delay shouldn't be needed as this is the whole pupose of `setState`, but i tried different sync and async approaches and none of them worked without an additional delay
