### PR TITLE
[Merged by Bors] - Extend assert_approx_eq macro for f64

### DIFF
--- a/xayn-ai-ffi-c/src/slice.rs
+++ b/xayn-ai-ffi-c/src/slice.rs
@@ -225,16 +225,14 @@ mod tests {
         }
     }
 
-    impl<'a, T> ApproxEqIter<'a> for &'a CBoxedSlice<T>
+    impl<'a, T> ApproxEqIter<'a, f32> for &'a CBoxedSlice<T>
     where
-        &'a T: ApproxEqIter<'a>,
+        &'a T: ApproxEqIter<'a, f32>,
     {
-        type LeafElement = <&'a T as ApproxEqIter<'a>>::LeafElement;
-
         fn indexed_iter_logical_order(
             self,
             prefix: Vec<usize>,
-        ) -> Box<dyn Iterator<Item = (Vec<usize>, Self::LeafElement)> + 'a> {
+        ) -> Box<dyn Iterator<Item = (Vec<usize>, f32)> + 'a> {
             self.as_slice().indexed_iter_logical_order(prefix)
         }
     }


### PR DESCRIPTION
**Summary**

extend the `assert_approx_eq!` macro for `f64`:
- change the associated type `LeafElement` of `ApproxEqIter` to a generic type: the compiler couldn't infer the correct input type from the associated type in case of multiple impls (even with additional type hints, because the associated type only governs the output type), it worked so far because there was only the single `f32` implementation
- cleanup: some documentation and additional macro hygiene


[TY-2207]: https://xainag.atlassian.net/browse/TY-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ