### PR TITLE
[Merged by Bors] - TY-2207 compute coi weights

### DIFF
--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use crate::{
     coi::{
-        point::{CoiPoint, CoiPointMerge, NegativeCoi, PositiveCoi},
+        point::{CoiPoint, NegativeCoi, PositiveCoi},
         CoiId,
     },
     embedding::utils::{l2_distance, mean},
@@ -13,26 +13,23 @@ use crate::{
 
 const MERGE_THRESHOLD_DIST: f32 = 4.5;
 
-impl PositiveCoi {
-    pub fn merge(self, other: Self, id: CoiId) -> Self {
-        let point = mean(&self.point, &other.point);
-        let view_count = self.view_count + other.view_count;
-        let view_time = self.view_time + other.view_time;
-        let last_time = self.last_time.max(other.last_time);
+pub(crate) trait CoiPointMerge {
+    fn merge(self, other: Self, id: CoiId) -> Self;
+}
 
-        Self {
-            id,
-            point,
-            view_count,
-            view_time,
-            last_time,
-        }
+impl CoiPointMerge for PositiveCoi {
+    fn merge(self, other: Self, id: CoiId) -> Self {
+        let point = mean(&self.point, &other.point);
+        let view = self.view.merge(other.view);
+
+        Self { id, point, view }
     }
 }
 
-impl NegativeCoi {
-    pub fn merge(self, other: Self, id: CoiId) -> Self {
+impl CoiPointMerge for NegativeCoi {
+    fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(&self.point, &other.point);
+
         Self { id, point }
     }
 }

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -20,9 +20,9 @@ pub(crate) trait CoiPointMerge {
 impl CoiPointMerge for PositiveCoi {
     fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(&self.point, &other.point);
-        let view = self.view.merge(other.view);
+        let stats = self.stats.merge(other.stats);
 
-        Self { id, point, view }
+        Self { id, point, stats }
     }
 }
 

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -6,12 +6,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::{coi::CoiId, embedding::utils::Embedding, utils::system_time_now};
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Copy, Deserialize, Serialize)]
 #[cfg_attr(test, derive(Debug))]
 pub(crate) struct CoiView {
-    count: usize,
-    time: Duration,
-    last: SystemTime,
+    pub(crate) count: usize,
+    pub(crate) time: Duration,
+    pub(crate) last: SystemTime,
 }
 
 impl CoiView {
@@ -137,8 +137,13 @@ macro_rules! impl_coi_point {
                     $new_body:block
 
                 $(
+                    fn view($view_this:ident: &Self $(,)?) -> CoiView
+                        $view_body:block
+                )?
+
+                $(
                     fn update_view(
-                        $this:ident: &mut Self,
+                        $update_this:ident: &mut Self,
                         $update_viewed:ident: Option<Duration> $(,)?
                     )
                         $update_body:block
@@ -170,7 +175,12 @@ macro_rules! impl_coi_point {
                 }
 
                 $(
-                    fn update_view($this: &mut Self, $update_viewed: Option<Duration>)
+                    fn view($view_this: &Self) -> CoiView
+                        $view_body
+                )?
+
+                $(
+                    fn update_view($update_this: &mut Self, $update_viewed: Option<Duration>)
                         $update_body
                 )?
             }
@@ -217,6 +227,10 @@ impl_coi_point! {
                 point,
                 view: CoiView::new(viewed),
             }
+        }
+
+        fn view(self: &Self) -> CoiView {
+            self.view
         }
 
         fn update_view(self: &mut Self, viewed: Option<Duration>) {

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -44,7 +44,7 @@ impl Default for CoiView {
     fn default() -> Self {
         Self {
             count: 1,
-            time: Duration::default(),
+            time: Duration::ZERO,
             last: SystemTime::UNIX_EPOCH,
         }
     }

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -112,137 +112,107 @@ pub(crate) struct NegativeCoi {
 
 pub(crate) trait CoiPoint {
     fn new(id: CoiId, point: Embedding, viewed: Option<Duration>) -> Self;
+
     fn id(&self) -> CoiId;
+
     fn set_id(&mut self, id: CoiId);
+
     fn point(&self) -> &Embedding;
+
     fn set_point(&mut self, embedding: Embedding);
+
     fn view(&self) -> CoiView {
         CoiView::default()
     }
+
     fn update_view(&mut self, viewed: Option<Duration>) {
         #![allow(unused_variables)]
     }
 }
 
-macro_rules! impl_coi_point {
-    (
-        $(
-            $(#[$attribute:meta])*
-            $type:ty {
-                fn new(
-                    $id:ident: CoiId,
-                    $point:ident: Embedding,
-                    $new_viewed:ident: Option<Duration> $(,)?
-                ) -> Self
-                    $new_body:block
+macro_rules! coi_point_default_impls {
+    () => {
+        fn id(&self) -> CoiId {
+            self.id
+        }
 
-                $(
-                    fn view($view_this:ident: &Self $(,)?) -> CoiView
-                        $view_body:block
-                )?
+        fn set_id(&mut self, id: CoiId) {
+            self.id = id;
+        }
 
-                $(
-                    fn update_view(
-                        $update_this:ident: &mut Self,
-                        $update_viewed:ident: Option<Duration> $(,)?
-                    )
-                        $update_body:block
-                )?
-            }
-        ),+ $(,)?
-    ) => {
-        $(
-            $(#[$attribute])*
-            impl CoiPoint for $type {
-                fn new($id: CoiId, $point: Embedding, $new_viewed: Option<Duration>) -> Self
-                    $new_body
+        fn point(&self) -> &Embedding {
+            &self.point
+        }
 
-
-                fn id(&self) -> CoiId {
-                    self.id
-                }
-
-                fn set_id(&mut self, id: CoiId) {
-                    self.id = id;
-                }
-
-                fn point(&self) -> &Embedding {
-                    &self.point
-                }
-
-                fn set_point(&mut self, embedding: Embedding) {
-                    self.point = embedding;
-                }
-
-                $(
-                    fn view($view_this: &Self) -> CoiView
-                        $view_body
-                )?
-
-                $(
-                    fn update_view($update_this: &mut Self, $update_viewed: Option<Duration>)
-                        $update_body
-                )?
-            }
-        )+
+        fn set_point(&mut self, embedding: Embedding) {
+            self.point = embedding;
+        }
     };
 }
 
-impl_coi_point! {
-    #[cfg(test)]
-    PositiveCoi_v0_0_0 {
-        fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
-            Self {
-                id,
-                point,
-                alpha: 1.,
-                beta: 1.,
-            }
+#[cfg(test)]
+impl CoiPoint for PositiveCoi_v0_0_0 {
+    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+        Self {
+            id,
+            point,
+            alpha: 1.,
+            beta: 1.,
         }
-    },
+    }
 
-    #[cfg(test)]
-    PositiveCoi_v0_1_0 {
-        fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
-            Self {
-                id,
-                point,
-                alpha: 1.,
-                beta: 1.,
-            }
-        }
-    },
+    coi_point_default_impls! {}
+}
 
-    #[cfg(test)]
-    PositiveCoi_v0_2_0 {
-        fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
-            Self { id, point }
+#[cfg(test)]
+impl CoiPoint for PositiveCoi_v0_1_0 {
+    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+        Self {
+            id,
+            point,
+            alpha: 1.,
+            beta: 1.,
         }
-    },
+    }
 
-    PositiveCoi {
-        fn new(id: CoiId, point: Embedding, viewed: Option<Duration>) -> Self {
-            Self {
-                id,
-                point,
-                view: CoiView::new(viewed),
-            }
-        }
+    coi_point_default_impls! {}
+}
 
-        fn view(self: &Self) -> CoiView {
-            self.view
-        }
+#[cfg(test)]
+impl CoiPoint for PositiveCoi_v0_2_0 {
+    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+        Self { id, point }
+    }
 
-        fn update_view(self: &mut Self, viewed: Option<Duration>) {
-            self.view.update(viewed);
-        }
-    },
+    coi_point_default_impls! {}
+}
 
-    NegativeCoi {
-        fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
-            Self { id, point }
+impl CoiPoint for PositiveCoi {
+    fn new(id: CoiId, point: Embedding, viewed: Option<Duration>) -> Self {
+        Self {
+            id,
+            point,
+            view: CoiView::new(viewed),
         }
-    },
+    }
+
+    coi_point_default_impls! {}
+
+    fn view(&self) -> CoiView {
+        self.view
+    }
+
+    fn update_view(&mut self, viewed: Option<Duration>) {
+        self.view.update(viewed);
+    }
+}
+
+impl CoiPoint for NegativeCoi {
+    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+        Self { id, point }
+    }
+
+    coi_point_default_impls! {}
 }
 
 // generic types can't be versioned, but aliasing and proper naming in the proc macro call works

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -177,7 +177,8 @@ impl CoiSystem {
             .as_secs_f32()
             + f32::EPSILON;
         let now = system_time_now();
-        let horizon = (-0.1 * horizon.as_secs_f32() / SECONDS_PER_DAY).exp();
+        const DAYS_SCALE: f32 = -0.1;
+        let horizon = (horizon.as_secs_f32() * DAYS_SCALE / SECONDS_PER_DAY).exp();
 
         cois.iter()
             .map(|coi| {
@@ -189,7 +190,8 @@ impl CoiSystem {
                 } = coi.stats();
                 let count = count as f32 / counts;
                 let time = time.as_secs_f32() / times;
-                let days = (-0.1 * now.duration_since(last).unwrap_or_default().as_secs_f32()
+                let days = (now.duration_since(last).unwrap_or_default().as_secs_f32()
+                    * DAYS_SCALE
                     / SECONDS_PER_DAY)
                     .exp();
                 let last = ((horizon - days) / (horizon - 1. - f32::EPSILON)).max(0.);

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -105,14 +105,13 @@ pub(super) mod tests {
         }
     }
 
-    fn create_cois<FI, CP>(points: &[FI]) -> Vec<CP>
-    where
-        FI: FixedInitializer<Elem = f32>,
-        CP: CoiPoint,
-    {
+    fn create_cois<FI: FixedInitializer<Elem = f32>, CP: CoiPoint>(points: &[FI]) -> Vec<CP> {
+        if FI::len() == 0 {
+            return Vec::new();
+        }
+
         points
             .iter()
-            .filter(|_| FI::len() != 0)
             .enumerate()
             .map(|(id, point)| {
                 CP::new(

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -105,9 +105,14 @@ pub(super) mod tests {
         }
     }
 
-    fn create_cois<CP: CoiPoint>(points: &[impl FixedInitializer<Elem = f32>]) -> Vec<CP> {
+    fn create_cois<FI, CP>(points: &[FI]) -> Vec<CP>
+    where
+        FI: FixedInitializer<Elem = f32>,
+        CP: CoiPoint,
+    {
         points
             .iter()
+            .filter(|_| FI::len() != 0)
             .enumerate()
             .map(|(id, point)| {
                 CP::new(

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -89,6 +89,9 @@ pub(crate) fn serialize_with_version(data: &impl Serialize, version: u8) -> Resu
     Ok(serialized)
 }
 
+/// The number of seconds per day (without leap seconds).
+pub(crate) const SECONDS_PER_DAY: f64 = 86400.;
+
 /// Gets the current system time depending on the target architecture.
 #[inline]
 pub(crate) fn system_time_now() -> SystemTime {

--- a/xayn-ai/src/utils.rs
+++ b/xayn-ai/src/utils.rs
@@ -90,7 +90,7 @@ pub(crate) fn serialize_with_version(data: &impl Serialize, version: u8) -> Resu
 }
 
 /// The number of seconds per day (without leap seconds).
-pub(crate) const SECONDS_PER_DAY: f64 = 86400.;
+pub(crate) const SECONDS_PER_DAY: f32 = 86400.;
 
 /// Gets the current system time depending on the target architecture.
 #[inline]


### PR DESCRIPTION
**References**

- [TY-2207]

**Summary**

implement coi weights computation:
- add a `view()` getter to `CoiPoint`
- impl coi weight computation and add tests: expected values are computed from the original python impl, `epsilon` is chosen a bit larger to account for a small time difference between `create_pos_cois()` and `compute_weights()`

cleanup:
- move view related fields into `CoiView` and impl constructors
- move `CoiPointMerge` to `coi::merge::` and remove redundant wrapper functions and macro
- simplify `CoiPoint` impl macro


[TY-2207]: https://xainag.atlassian.net/browse/TY-2207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ