### PR TITLE
[Merged by Bors] - TY-2208 update key phrases [0]

### DIFF
--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -19,7 +19,7 @@ pub(crate) trait CoiPointMerge {
 
 impl CoiPointMerge for PositiveCoi {
     fn merge(self, other: Self, id: CoiId) -> Self {
-        let point = mean(&self.point, &other.point);
+        let point = mean(self.point.view(), other.point.view()).into();
         let stats = self.stats.merge(other.stats);
 
         Self { id, point, stats }
@@ -28,7 +28,7 @@ impl CoiPointMerge for PositiveCoi {
 
 impl CoiPointMerge for NegativeCoi {
     fn merge(self, other: Self, id: CoiId) -> Self {
-        let point = mean(&self.point, &other.point);
+        let point = mean(self.point.view(), other.point.view()).into();
 
         Self { id, point }
     }
@@ -108,7 +108,7 @@ impl<C: CoiPoint> Coiple<C> {
 
 /// Computes the l2 distance between two CoI points.
 fn dist<C: CoiPoint>(coi1: &C, coi2: &C) -> f32 {
-    l2_distance(coi1.point(), coi2.point())
+    l2_distance(coi1.point().view(), coi2.point().view())
 }
 
 /// Reduces the given collection of CoIs by successively merging the pair in closest

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -58,7 +58,7 @@ impl CoiSystem {
 
         let mut distances = cois
             .iter()
-            .map(|coi| l2_distance(embedding, coi.point()))
+            .map(|coi| l2_distance(embedding.view(), coi.point().view()))
             .enumerate()
             .collect::<Vec<_>>();
         distances.sort_by(|(_, this), (_, other)| this.partial_cmp(other).unwrap());
@@ -365,7 +365,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "vectors must consist of real values only")]
+    #[should_panic(expected = "vector must consist of real values only")]
     fn test_find_closest_coi_index_all_nan() {
         let cois = create_pos_cois(&[[1., 2., 3.]]);
         let embedding = arr1(&[NAN, NAN, NAN]).into();
@@ -373,7 +373,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "vectors must consist of real values only")]
+    #[should_panic(expected = "vector must consist of real values only")]
     fn test_find_closest_coi_index_single_nan() {
         let cois = create_pos_cois(&[[1., 2., 3.]]);
         let embedding = arr1(&[1., NAN, 2.]).into();
@@ -537,7 +537,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "vectors must consist of real values only")]
+    #[should_panic(expected = "vector must consist of real values only")]
     fn test_compute_coi_all_nan() {
         let positive = create_pos_cois(&[[3., 2., 1.], [1., 2., 3.]]);
         let negative = create_neg_cois(&[[4., 5., 6.]]);
@@ -547,7 +547,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "vectors must consist of real values only")]
+    #[should_panic(expected = "vector must consist of real values only")]
     fn test_compute_coi_single_nan() {
         let positive = create_pos_cois(&[[3., 2., 1.], [1., 2., 3.]]);
         let negative = create_neg_cois(&[[4., 5., 6.]]);

--- a/xayn-ai/src/embedding/qambert.rs
+++ b/xayn-ai/src/embedding/qambert.rs
@@ -36,7 +36,7 @@ impl QAMBertSystem for QAMBert {
 
                     self.run(&data)
                         .map(|embedding| {
-                            let similarity = l2_distance(&query, &embedding);
+                            let similarity = l2_distance(query.view(), embedding.view());
                             DocumentDataWithQAMBert::from_document(
                                 document,
                                 QAMBertComponent { similarity },

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -59,23 +59,24 @@ where
 pub fn pairwise_cosine_similarity<'a, I, S>(iter: I) -> Array2<f32>
 where
     I: IntoIterator<Item = &'a ArrayBase<S, Ix1>>,
-    I::IntoIter: Clone,
+    I::IntoIter: Clone + ExactSizeIterator,
     S: Data<Elem = f32> + 'a,
 {
     let iter = iter.into_iter();
+    let size = iter.len();
+
     let norms = iter.clone().map(|a| l2_norm(a.view())).collect::<Vec<_>>();
-    let size = iter.clone().count();
     let mut similarities = Array2::ones((size, size));
-    iter.clone().enumerate().for_each(|(i, a)| {
+    for (i, a) in iter.clone().enumerate() {
         if norms[i] != 0. {
-            iter.clone().enumerate().skip(i + 1).for_each(|(j, b)| {
+            for (j, b) in iter.clone().enumerate().skip(i + 1) {
                 if norms[j] != 0. {
                     similarities[[i, j]] = a.dot(b) / norms[i] / norms[j];
                     similarities[[j, i]] = similarities[[i, j]];
                 }
-            });
+            }
         }
-    });
+    }
 
     similarities
 }

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -5,49 +5,75 @@ use rubert::Embedding1;
 
 pub(crate) type Embedding = Embedding1;
 
+/// Computes the l2 norm (euclidean metric) of a vector.
+///
+/// # Panics
+/// Panics if the vector doesn't consist solely of real values.
+pub fn l2_norm<A, S>(a: &A) -> f32
+where
+    A: Deref<Target = ArrayBase<S, Ix1>>,
+    S: Data<Elem = f32>,
+{
+    let norm = a.dot(a.deref()).sqrt();
+    assert!(
+        norm.is_finite(),
+        "vector must consist of real values only, but got:\n{:?}",
+        a.deref(),
+    );
+
+    norm
+}
+
 /// Computes the l2 norm (euclidean metric) of the difference of two vectors.
 ///
 /// # Panics
-/// Panics if the vectors didn't consist of all real values.
+/// Panics if the vectors don't consist solely of real values or their shapes don't match.
 pub fn l2_distance<A, B, S>(a: &A, b: &B) -> f32
 where
     A: Deref<Target = ArrayBase<S, Ix1>>,
     B: Deref<Target = ArrayBase<S, Ix1>>,
     S: Data<Elem = f32>,
 {
-    let difference = a.deref() - b.deref();
-    let distance = difference.dot(&difference).sqrt();
-
-    if distance.is_nan() || distance.is_infinite() {
-        panic!(
-            "vectors must consist of real values only, but got\na: {:?}\nb: {:?}",
-            a.deref(),
-            b.deref(),
-        );
-    }
-
-    distance
+    l2_norm(&Embedding::from(a.deref() - b.deref()))
 }
 
 /// Computes the arithmetic mean of two vectors.
 ///
 /// # Panics
-/// Panics if the vectors do not consist solely of real values.
-pub fn mean<A, S>(a: &A, b: &A) -> Embedding
+/// Panics if the vectors don't consist solely of real values or their shapes don't match.
+pub fn mean<A, B, S>(a: &A, b: &B) -> Embedding
 where
     A: Deref<Target = ArrayBase<S, Ix1>>,
+    B: Deref<Target = ArrayBase<S, Ix1>>,
     S: Data<Elem = f32>,
 {
     let mean = 0.5 * (a.deref() + b.deref());
-    if mean.iter().any(|elt| elt.is_nan() || elt.is_infinite()) {
-        panic!(
-            "vectors must consist of real values only, but got\na: {:?}\nb: {:?}",
-            a.deref(),
-            b.deref(),
-        );
-    }
+    assert!(
+        mean.iter().copied().all(f32::is_finite),
+        "vectors must consist of real values only, but got\na: {:?}\nb: {:?}",
+        a.deref(),
+        b.deref(),
+    );
 
     mean.into()
+}
+
+/// Computes the cosine similarity of two vectors.
+///
+/// # Panics
+/// Panics if the vectors don't consist solely of real values or their shapes don't match.
+pub fn cosine_similarity<A, B, S>(a: &A, b: &B) -> f32
+where
+    A: Deref<Target = ArrayBase<S, Ix1>>,
+    B: Deref<Target = ArrayBase<S, Ix1>>,
+    S: Data<Elem = f32>,
+{
+    let norm_a = l2_norm(a);
+    let norm_b = l2_norm(b);
+
+    (norm_a != 0. && norm_b != 0.)
+        .then(|| a.dot(b.deref()) / norm_a / norm_b)
+        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -58,33 +84,52 @@ mod tests {
     use test_utils::assert_approx_eq;
 
     #[test]
+    fn test_l2_norm() {
+        let a = Embedding::from(arr1(&[1., 2., 3.]));
+        assert_approx_eq!(f32, l2_norm(&a), 3.7416575);
+    }
+
+    #[test]
+    #[should_panic(expected = "vector must consist of real values only, but got")]
+    fn test_l2_norm_nan() {
+        let a = Embedding::from(arr1(&[1., f32::NAN, 3.]));
+        l2_norm(&a);
+    }
+
+    #[test]
+    #[should_panic(expected = "vector must consist of real values only, but got")]
+    fn test_l2_norm_inf() {
+        let a = Embedding::from(arr1(&[1., f32::INFINITY, 3.]));
+        l2_norm(&a);
+    }
+
+    #[test]
+    #[should_panic(expected = "vector must consist of real values only, but got")]
+    fn test_l2_norm_neginf() {
+        let a = Embedding::from(arr1(&[1., f32::NEG_INFINITY, 3.]));
+        l2_norm(&a);
+    }
+
+    #[test]
     fn test_l2_distance() {
-        let a: Embedding = arr1(&[1., 2., 3.]).into();
-        let b: Embedding = arr1(&[4., 5., 6.]).into();
+        let a = Embedding::from(arr1(&[1., 2., 3.]));
+        let b = Embedding::from(arr1(&[4., 5., 6.]));
         assert_approx_eq!(f32, l2_distance(&a, &b), 5.196152);
     }
 
     #[test]
-    #[should_panic(expected = "vectors must consist of real values only, but got")]
-    fn test_l2_distance_nan() {
+    fn test_mean() {
         let a: Embedding = arr1(&[1., 2., 3.]).into();
-        let b: Embedding = arr1(&[4., f32::NAN, 6.]).into();
-        l2_distance(&a, &b);
+        let b: Embedding = arr1(&[4., 5., 6.]).into();
+        let m = mean(&a, &b);
+        let c = arr1(&[2.5, 3.5, 4.5]);
+        assert_approx_eq!(f32, m.deref(), c);
     }
 
     #[test]
-    #[should_panic(expected = "vectors must consist of real values only, but got")]
-    fn test_l2_distance_inf() {
-        let a: Embedding = arr1(&[1., 2., 3.]).into();
-        let b: Embedding = arr1(&[4., f32::INFINITY, 6.]).into();
-        l2_distance(&a, &b);
-    }
-
-    #[test]
-    #[should_panic(expected = "vectors must consist of real values only, but got")]
-    fn test_l2_distance_neginf() {
-        let a: Embedding = arr1(&[1., 2., 3.]).into();
-        let b: Embedding = arr1(&[4., f32::NEG_INFINITY, 6.]).into();
-        l2_distance(&a, &b);
+    fn test_cosine_similarity() {
+        let a = Embedding::from(arr1(&[1., 2., 3.]));
+        let b = Embedding::from(arr1(&[4., 5., 6.]));
+        assert_approx_eq!(f32, cosine_similarity(&a, &b), 0.97463185);
     }
 }

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -53,6 +53,8 @@ where
 
 /// Computes the pairwise cosine similarities of vectors.
 ///
+/// Zero vectors are chosen to be similar to all other vectors, i.e. a similarity of 1.
+///
 /// # Panics
 /// Panics if the vectors don't consist solely of real values or their shapes don't match.
 #[allow(dead_code)]
@@ -82,6 +84,8 @@ where
 }
 
 /// Computes the cosine similarity of two vectors.
+///
+/// Zero vectors are chosen to be similar to all other vectors, i.e. a similarity of 1.
 ///
 /// # Panics
 /// Panics if the vectors don't consist solely of real values or their shapes don't match.


### PR DESCRIPTION
**References**

- [TY-2208]

**Summary**

- add `cosine_similarity()` and `pairwise_cosine_similarity()` utilities which will be used in the keyphrase selection
- use `ArrayBase` instead of `&Deref<ArrayBase>` in the utility function signatures: `ArrayBase` doesn't implement neither `AsRef` nor `Deref` because they are intended to be `view()`ed for a reference; as long as the utilities are just single standing functions the `Deref` approach works but it is much more ergonomic to combine utility functions with the `ArrayBase` approach


[TY-2208]: https://xainag.atlassian.net/browse/TY-2208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ