### PR TITLE
[Merged by Bors] - TY-2206 add key phrases to coi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,6 +2386,7 @@ dependencies = [
  "itertools",
  "js-sys",
  "layer",
+ "lazy_static",
  "maplit",
  "mockall",
  "ndarray",

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.51"
 bincode = "1.3.3"
+derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
 displaydoc = "0.2.3"
 itertools = "0.10.3"
@@ -31,7 +32,6 @@ js-sys = "0.3.55"
 
 [dev-dependencies]
 csv = "1.1.6"
-derivative = "2.2.0"
 maplit = "1.0.2"
 mockall = "0.11.0"
 once_cell = "1.8.0"

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -12,6 +12,7 @@ derive_more = { version = "0.99.17", default-features = false, features = ["from
 displaydoc = "0.2.3"
 itertools = "0.10.3"
 layer = { path = "../layer" }
+lazy_static = "1.4.0"
 # to be kept in sync with rubert
 ndarray = "=0.15.3"
 # TODO: use version 1.0.5 once it is released

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -19,7 +19,12 @@ pub(crate) struct KeyPhrase {
 
 impl KeyPhrase {
     #[allow(dead_code)]
-    pub(crate) fn new(words: String, point: Embedding) -> Result<Self, CoiError> {
+    pub(crate) fn new(
+        words: impl Into<String>,
+        point: impl Into<Embedding>,
+    ) -> Result<Self, CoiError> {
+        let words = words.into();
+        let point = point.into();
         if !words.is_empty() && point.iter().copied().all(f32::is_finite) {
             Ok(Self { words, point })
         } else {

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -1,0 +1,87 @@
+use std::mem::swap;
+
+use derive_more::Deref;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    coi::{
+        point::{NegativeCoi, PositiveCoi},
+        CoiError,
+    },
+    embedding::utils::Embedding,
+};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct KeyPhrase {
+    words: String,
+    point: Embedding,
+}
+
+impl KeyPhrase {
+    #[allow(dead_code)]
+    pub(crate) fn new(words: String, point: Embedding) -> Result<Self, CoiError> {
+        if !words.is_empty() && point.iter().copied().all(f32::is_finite) {
+            Ok(Self { words, point })
+        } else {
+            Err(CoiError::InvalidKeyPhrase)
+        }
+    }
+}
+
+// invariant: must be unique
+// note: can't use neither HashMap nor sort & dedup because the underlying ArrayBase doesn't
+// implement any of Eq, Hash, PartialOrd and Ord
+#[derive(Clone, Debug, Default, Deref, Deserialize, PartialEq, Serialize)]
+pub(crate) struct KeyPhrases(Vec<KeyPhrase>);
+
+impl KeyPhrases {
+    #[allow(dead_code)]
+    pub(crate) fn new(key_phrases: Vec<KeyPhrase>) -> Result<Self, CoiError> {
+        for (i, this) in key_phrases.iter().enumerate() {
+            for other in key_phrases[i + 1..].iter() {
+                if this == other {
+                    return Err(CoiError::DuplicateKeyPhrases);
+                }
+            }
+        }
+
+        Ok(Self(key_phrases))
+    }
+}
+
+impl IntoIterator for KeyPhrases {
+    type Item = KeyPhrase;
+    type IntoIter = <Vec<KeyPhrase> as IntoIterator>::IntoIter;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+pub(crate) trait CoiPointKeyPhrases {
+    fn key_phrases(&self) -> &[KeyPhrase];
+
+    fn swap_key_phrases(&mut self, candidates: KeyPhrases) -> KeyPhrases;
+}
+
+impl CoiPointKeyPhrases for PositiveCoi {
+    fn key_phrases(&self) -> &[KeyPhrase] {
+        self.key_phrases.as_slice()
+    }
+
+    fn swap_key_phrases(&mut self, mut candidates: KeyPhrases) -> KeyPhrases {
+        swap(&mut self.key_phrases, &mut candidates);
+        candidates
+    }
+}
+
+impl CoiPointKeyPhrases for NegativeCoi {
+    fn key_phrases(&self) -> &[KeyPhrase] {
+        &[]
+    }
+
+    fn swap_key_phrases(&mut self, _candidates: KeyPhrases) -> KeyPhrases {
+        KeyPhrases::default()
+    }
+}

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -1,6 +1,7 @@
-use std::mem::swap;
+use std::{collections::HashSet, mem::swap};
 
-use derive_more::Deref;
+use derivative::Derivative;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -11,10 +12,17 @@ use crate::{
     embedding::utils::Embedding,
 };
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
+#[derivative(Eq, Hash, PartialEq)]
 pub(crate) struct KeyPhrase {
     words: String,
+    #[derivative(Hash = "ignore", PartialEq = "ignore")]
     point: Embedding,
+}
+
+lazy_static! {
+    // TODO: temporary workaround, remove once positive and negative cois have been split properly
+    static ref EMPTY_KEY_PHRASES: HashSet<KeyPhrase> = HashSet::new();
 }
 
 impl KeyPhrase {
@@ -43,60 +51,29 @@ impl KeyPhrase {
     }
 }
 
-// invariant: must be unique
-// note: can't use neither HashMap nor sort & dedup because the underlying ArrayBase doesn't
-// implement any of Eq, Hash, PartialOrd and Ord
-#[derive(Clone, Debug, Default, Deref, Deserialize, PartialEq, Serialize)]
-pub(crate) struct KeyPhrases(Vec<KeyPhrase>);
-
-impl KeyPhrases {
-    #[allow(dead_code)]
-    pub(crate) fn new(key_phrases: Vec<KeyPhrase>) -> Result<Self, CoiError> {
-        for (i, this) in key_phrases.iter().enumerate() {
-            for other in key_phrases[i + 1..].iter() {
-                if this == other {
-                    return Err(CoiError::DuplicateKeyPhrases);
-                }
-            }
-        }
-
-        Ok(Self(key_phrases))
-    }
-}
-
-impl IntoIterator for KeyPhrases {
-    type Item = KeyPhrase;
-    type IntoIter = <Vec<KeyPhrase> as IntoIterator>::IntoIter;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
 pub(crate) trait CoiPointKeyPhrases {
-    fn key_phrases(&self) -> &[KeyPhrase];
+    fn key_phrases(&self) -> &HashSet<KeyPhrase>;
 
-    fn swap_key_phrases(&mut self, candidates: KeyPhrases) -> KeyPhrases;
+    fn swap_key_phrases(&mut self, candidates: HashSet<KeyPhrase>) -> HashSet<KeyPhrase>;
 }
 
 impl CoiPointKeyPhrases for PositiveCoi {
-    fn key_phrases(&self) -> &[KeyPhrase] {
-        self.key_phrases.as_slice()
+    fn key_phrases(&self) -> &HashSet<KeyPhrase> {
+        &self.key_phrases
     }
 
-    fn swap_key_phrases(&mut self, mut candidates: KeyPhrases) -> KeyPhrases {
+    fn swap_key_phrases(&mut self, mut candidates: HashSet<KeyPhrase>) -> HashSet<KeyPhrase> {
         swap(&mut self.key_phrases, &mut candidates);
         candidates
     }
 }
 
 impl CoiPointKeyPhrases for NegativeCoi {
-    fn key_phrases(&self) -> &[KeyPhrase] {
-        &[]
+    fn key_phrases(&self) -> &HashSet<KeyPhrase> {
+        &EMPTY_KEY_PHRASES
     }
 
-    fn swap_key_phrases(&mut self, _candidates: KeyPhrases) -> KeyPhrases {
-        KeyPhrases::default()
+    fn swap_key_phrases(&mut self, _candidates: HashSet<KeyPhrase>) -> HashSet<KeyPhrase> {
+        HashSet::default()
     }
 }

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -26,6 +26,16 @@ impl KeyPhrase {
             Err(CoiError::InvalidKeyPhrase)
         }
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn words(&self) -> &str {
+        &self.words
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn point(&self) -> &Embedding {
+        &self.point
+    }
 }
 
 // invariant: must be unique

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, mem::swap};
+use std::{collections::BTreeSet, mem::swap};
 
 use derivative::Derivative;
 use lazy_static::lazy_static;
@@ -13,16 +13,16 @@ use crate::{
 };
 
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
-#[derivative(Eq, Hash, PartialEq)]
+#[derivative(Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct KeyPhrase {
     words: String,
-    #[derivative(Hash = "ignore", PartialEq = "ignore")]
+    #[derivative(Ord = "ignore", PartialEq = "ignore", PartialOrd = "ignore")]
     point: Embedding,
 }
 
 lazy_static! {
     // TODO: temporary workaround, remove once positive and negative cois have been split properly
-    static ref EMPTY_KEY_PHRASES: HashSet<KeyPhrase> = HashSet::new();
+    static ref EMPTY_KEY_PHRASES: BTreeSet<KeyPhrase> = BTreeSet::new();
 }
 
 impl KeyPhrase {
@@ -52,28 +52,28 @@ impl KeyPhrase {
 }
 
 pub(crate) trait CoiPointKeyPhrases {
-    fn key_phrases(&self) -> &HashSet<KeyPhrase>;
+    fn key_phrases(&self) -> &BTreeSet<KeyPhrase>;
 
-    fn swap_key_phrases(&mut self, candidates: HashSet<KeyPhrase>) -> HashSet<KeyPhrase>;
+    fn swap_key_phrases(&mut self, candidates: BTreeSet<KeyPhrase>) -> BTreeSet<KeyPhrase>;
 }
 
 impl CoiPointKeyPhrases for PositiveCoi {
-    fn key_phrases(&self) -> &HashSet<KeyPhrase> {
+    fn key_phrases(&self) -> &BTreeSet<KeyPhrase> {
         &self.key_phrases
     }
 
-    fn swap_key_phrases(&mut self, mut candidates: HashSet<KeyPhrase>) -> HashSet<KeyPhrase> {
+    fn swap_key_phrases(&mut self, mut candidates: BTreeSet<KeyPhrase>) -> BTreeSet<KeyPhrase> {
         swap(&mut self.key_phrases, &mut candidates);
         candidates
     }
 }
 
 impl CoiPointKeyPhrases for NegativeCoi {
-    fn key_phrases(&self) -> &HashSet<KeyPhrase> {
+    fn key_phrases(&self) -> &BTreeSet<KeyPhrase> {
         &EMPTY_KEY_PHRASES
     }
 
-    fn swap_key_phrases(&mut self, _candidates: HashSet<KeyPhrase>) -> HashSet<KeyPhrase> {
-        HashSet::default()
+    fn swap_key_phrases(&mut self, _candidates: BTreeSet<KeyPhrase>) -> BTreeSet<KeyPhrase> {
+        BTreeSet::default()
     }
 }

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -13,16 +13,22 @@ use crate::{
 
 const MERGE_THRESHOLD_DIST: f32 = 4.5;
 
-pub(crate) trait CoiPointMerge {
+pub(crate) trait CoiPointMerge: CoiPoint {
     fn merge(self, other: Self, id: CoiId) -> Self;
 }
 
 impl CoiPointMerge for PositiveCoi {
     fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(self.point.view(), other.point.view()).into();
+        let key_phrases = self.key_phrases; // TODO: update with other.key_phrases
         let stats = self.stats.merge(other.stats);
 
-        Self { id, point, stats }
+        Self {
+            id,
+            point,
+            key_phrases,
+            stats,
+        }
     }
 }
 

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -39,6 +39,4 @@ impl CoiId {
 pub(crate) enum CoiError {
     /// The key phrase is invalid (ie. either empty words or non-finite point)
     InvalidKeyPhrase,
-    /// The key phrases are not unique
-    DuplicateKeyPhrases,
 }

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -1,6 +1,8 @@
 mod config;
+pub(crate) mod key_phrase;
 mod merge;
 pub(crate) mod point;
+mod stats;
 mod system;
 mod utils;
 
@@ -11,7 +13,9 @@ pub(crate) use system::CoiSystemError;
 pub(crate) use system::{CoiSystem, NeutralCoiSystem};
 
 use derive_more::From;
+use displaydoc::Display;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use uuid::Uuid;
 
 #[cfg(test)]
@@ -29,4 +33,12 @@ impl CoiId {
     pub(crate) const fn mocked(sub_id: usize) -> Self {
         Self(mock_uuid(sub_id))
     }
+}
+
+#[derive(Debug, Display, Error)]
+pub(crate) enum CoiError {
+    /// The key phrase is invalid (ie. either empty words or non-finite point)
+    InvalidKeyPhrase,
+    /// The key phrases are not unique
+    DuplicateKeyPhrases,
 }

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -63,6 +63,8 @@ pub(crate) struct PositiveCoi {
     #[obake(cfg(">=0.0"))]
     pub(crate) point: Embedding,
     #[obake(cfg(">=0.3"))]
+    pub(crate) key_phrases: Vec<String>,
+    #[obake(cfg(">=0.3"))]
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
     pub(crate) stats: CoiStats,
 
@@ -98,6 +100,7 @@ impl From<PositiveCoi_v0_2_0> for PositiveCoi {
         Self {
             id: coi.id,
             point: coi.point,
+            key_phrases: Vec::default(),
             stats: CoiStats::default(),
         }
     }
@@ -111,7 +114,8 @@ pub(crate) struct NegativeCoi {
 }
 
 pub(crate) trait CoiPoint {
-    fn new(id: CoiId, point: Embedding, viewed: Option<Duration>) -> Self;
+    fn new(id: CoiId, point: Embedding, key_phrases: Vec<String>, viewed: Option<Duration>)
+        -> Self;
 
     fn id(&self) -> CoiId;
 
@@ -120,6 +124,14 @@ pub(crate) trait CoiPoint {
     fn point(&self) -> &Embedding;
 
     fn set_point(&mut self, embedding: Embedding);
+
+    fn key_phrases(&self) -> &[String] {
+        &[]
+    }
+
+    fn update_key_phrases(&mut self, candidates: &[String]) {
+        #![allow(unused_variables)]
+    }
 
     fn stats(&self) -> CoiStats {
         CoiStats::default()
@@ -152,7 +164,12 @@ macro_rules! coi_point_default_impls {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_0_0 {
-    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+    fn new(
+        id: CoiId,
+        point: Embedding,
+        _key_phrases: Vec<String>,
+        _viewed: Option<Duration>,
+    ) -> Self {
         Self {
             id,
             point,
@@ -166,7 +183,12 @@ impl CoiPoint for PositiveCoi_v0_0_0 {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_1_0 {
-    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+    fn new(
+        id: CoiId,
+        point: Embedding,
+        _key_phrases: Vec<String>,
+        _viewed: Option<Duration>,
+    ) -> Self {
         Self {
             id,
             point,
@@ -180,7 +202,12 @@ impl CoiPoint for PositiveCoi_v0_1_0 {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_2_0 {
-    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+    fn new(
+        id: CoiId,
+        point: Embedding,
+        _key_phrases: Vec<String>,
+        _viewed: Option<Duration>,
+    ) -> Self {
         Self { id, point }
     }
 
@@ -188,15 +215,27 @@ impl CoiPoint for PositiveCoi_v0_2_0 {
 }
 
 impl CoiPoint for PositiveCoi {
-    fn new(id: CoiId, point: Embedding, viewed: Option<Duration>) -> Self {
+    fn new(
+        id: CoiId,
+        point: Embedding,
+        key_phrases: Vec<String>,
+        viewed: Option<Duration>,
+    ) -> Self {
         Self {
             id,
             point,
+            key_phrases,
             stats: CoiStats::new(viewed),
         }
     }
 
     coi_point_default_impls! {}
+
+    fn key_phrases(&self) -> &[String] {
+        self.key_phrases.as_slice()
+    }
+
+    // TODO: update key phrases
 
     fn stats(&self) -> CoiStats {
         self.stats
@@ -208,7 +247,12 @@ impl CoiPoint for PositiveCoi {
 }
 
 impl CoiPoint for NegativeCoi {
-    fn new(id: CoiId, point: Embedding, _viewed: Option<Duration>) -> Self {
+    fn new(
+        id: CoiId,
+        point: Embedding,
+        _key_phrases: Vec<String>,
+        _viewed: Option<Duration>,
+    ) -> Self {
         Self { id, point }
     }
 

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Duration};
+use std::{collections::BTreeSet, time::Duration};
 
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
@@ -21,7 +21,7 @@ pub(crate) struct PositiveCoi {
     #[obake(cfg(">=0.0"))]
     pub(super) point: Embedding,
     #[obake(cfg(">=0.3"))]
-    pub(super) key_phrases: HashSet<KeyPhrase>,
+    pub(super) key_phrases: BTreeSet<KeyPhrase>,
     #[obake(cfg(">=0.3"))]
     #[derivative(PartialEq = "ignore")]
     pub(super) stats: CoiStats,
@@ -58,7 +58,7 @@ impl From<PositiveCoi_v0_2_0> for PositiveCoi {
         Self {
             id: coi.id,
             point: coi.point,
-            key_phrases: HashSet::default(),
+            key_phrases: BTreeSet::default(),
             stats: CoiStats::default(),
         }
     }
@@ -74,7 +74,7 @@ pub(crate) trait CoiPoint {
     fn new(
         id: CoiId,
         point: Embedding,
-        key_phrases: HashSet<KeyPhrase>,
+        key_phrases: BTreeSet<KeyPhrase>,
         viewed: Option<Duration>,
     ) -> Self;
 
@@ -112,7 +112,7 @@ impl CoiPoint for PositiveCoi_v0_0_0 {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: HashSet<KeyPhrase>,
+        _key_phrases: BTreeSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self {
@@ -131,7 +131,7 @@ impl CoiPoint for PositiveCoi_v0_1_0 {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: HashSet<KeyPhrase>,
+        _key_phrases: BTreeSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self {
@@ -150,7 +150,7 @@ impl CoiPoint for PositiveCoi_v0_2_0 {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: HashSet<KeyPhrase>,
+        _key_phrases: BTreeSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self { id, point }
@@ -163,7 +163,7 @@ impl CoiPoint for PositiveCoi {
     fn new(
         id: CoiId,
         point: Embedding,
-        key_phrases: HashSet<KeyPhrase>,
+        key_phrases: BTreeSet<KeyPhrase>,
         viewed: Option<Duration>,
     ) -> Self {
         Self {
@@ -181,7 +181,7 @@ impl CoiPoint for NegativeCoi {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: HashSet<KeyPhrase>,
+        _key_phrases: BTreeSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self { id, point }

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -151,23 +151,18 @@ pub(crate) trait CoiPoint {
     fn point(&self) -> &Embedding;
 
     fn set_point(&mut self, embedding: Embedding);
+}
 
-    fn key_phrases(&self) -> &[KeyPhrase] {
-        &[]
-    }
+pub(crate) trait CoiPointKeyPhrases {
+    fn key_phrases(&self) -> &[KeyPhrase];
 
-    fn swap_key_phrases(&mut self, candidates: Vec<KeyPhrase>) -> Vec<KeyPhrase> {
-        #![allow(unused_variables)]
-        Vec::new()
-    }
+    fn swap_key_phrases(&mut self, candidates: Vec<KeyPhrase>) -> Vec<KeyPhrase>;
+}
 
-    fn stats(&self) -> CoiStats {
-        CoiStats::default()
-    }
+pub(crate) trait CoiPointStats {
+    fn stats(&self) -> CoiStats;
 
-    fn update_stats(&mut self, viewed: Option<Duration>) {
-        #![allow(unused_variables)]
-    }
+    fn update_stats(&mut self, viewed: Option<Duration>);
 }
 
 macro_rules! coi_point_default_impls {
@@ -260,7 +255,9 @@ impl CoiPoint for PositiveCoi {
     }
 
     coi_point_default_impls! {}
+}
 
+impl CoiPointKeyPhrases for PositiveCoi {
     fn key_phrases(&self) -> &[KeyPhrase] {
         self.key_phrases.as_slice()
     }
@@ -271,7 +268,9 @@ impl CoiPoint for PositiveCoi {
         swap(&mut self.key_phrases, &mut candidates);
         candidates
     }
+}
 
+impl CoiPointStats for PositiveCoi {
     fn stats(&self) -> CoiStats {
         self.stats
     }
@@ -292,6 +291,24 @@ impl CoiPoint for NegativeCoi {
     }
 
     coi_point_default_impls! {}
+}
+
+impl CoiPointKeyPhrases for NegativeCoi {
+    fn key_phrases(&self) -> &[KeyPhrase] {
+        &[]
+    }
+
+    fn swap_key_phrases(&mut self, _candidates: Vec<KeyPhrase>) -> Vec<KeyPhrase> {
+        Vec::new()
+    }
+}
+
+impl CoiPointStats for NegativeCoi {
+    fn stats(&self) -> CoiStats {
+        CoiStats::default()
+    }
+
+    fn update_stats(&mut self, _viewed: Option<Duration>) {}
 }
 
 // generic types can't be versioned, but aliasing and proper naming in the proc macro call works

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -60,7 +60,6 @@ pub(crate) struct KeyPhrase {
     pub(super) point: Embedding,
 }
 
-#[allow(dead_code)]
 impl KeyPhrase {
     pub(super) fn is_valid(&self) -> bool {
         !self.words.is_empty() && self.point.iter().copied().all(f32::is_finite)
@@ -250,6 +249,8 @@ impl CoiPoint for PositiveCoi {
         key_phrases: Vec<KeyPhrase>,
         viewed: Option<Duration>,
     ) -> Self {
+        debug_assert!(key_phrases.iter().all(KeyPhrase::is_valid));
+        debug_assert!(KeyPhrase::is_unique(&key_phrases));
         Self {
             id,
             point,
@@ -265,6 +266,8 @@ impl CoiPoint for PositiveCoi {
     }
 
     fn swap_key_phrases(&mut self, mut candidates: Vec<KeyPhrase>) -> Vec<KeyPhrase> {
+        debug_assert!(candidates.iter().all(KeyPhrase::is_valid));
+        debug_assert!(KeyPhrase::is_unique(&candidates));
         swap(&mut self.key_phrases, &mut candidates);
         candidates
     }

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -53,11 +53,25 @@ impl Default for CoiStats {
     }
 }
 
-#[derive(Clone, Deserialize, Serialize)]
-#[cfg_attr(test, derive(Debug, PartialEq))]
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(test, derive(Debug))]
 pub(crate) struct KeyPhrase {
-    pub(crate) words: String,
-    pub(crate) point: Embedding,
+    pub(super) words: String,
+    pub(super) point: Embedding,
+}
+
+#[allow(dead_code)]
+impl KeyPhrase {
+    pub(super) fn is_valid(&self) -> bool {
+        !self.words.is_empty() && self.point.iter().copied().all(f32::is_finite)
+    }
+
+    pub(super) fn is_unique(key_phrases: &[KeyPhrase]) -> bool {
+        key_phrases
+            .iter()
+            .enumerate()
+            .all(|(idx, this)| key_phrases.iter().skip(idx + 1).all(|other| this != other))
+    }
 }
 
 #[obake::versioned]
@@ -69,20 +83,20 @@ pub(crate) struct KeyPhrase {
 #[cfg_attr(test, derive(Debug, Derivative), derivative(PartialEq))]
 pub(crate) struct PositiveCoi {
     #[obake(cfg(">=0.0"))]
-    pub(crate) id: CoiId,
+    pub(super) id: CoiId,
     #[obake(cfg(">=0.0"))]
-    pub(crate) point: Embedding,
+    pub(super) point: Embedding,
     #[obake(cfg(">=0.3"))]
-    pub(crate) key_phrases: Vec<KeyPhrase>, // invariant: key phrases must be unique
+    pub(super) key_phrases: Vec<KeyPhrase>, // invariant: key phrases must be unique
     #[obake(cfg(">=0.3"))]
     #[cfg_attr(test, derivative(PartialEq = "ignore"))]
-    pub(crate) stats: CoiStats,
+    pub(super) stats: CoiStats,
 
     // removed fields go below this line
     #[obake(cfg(">=0.0, <0.2"))]
-    pub(crate) alpha: f32,
+    pub(super) alpha: f32,
     #[obake(cfg(">=0.0, <0.2"))]
-    pub(crate) beta: f32,
+    pub(super) beta: f32,
 }
 
 impl From<PositiveCoi_v0_0_0> for PositiveCoi_v0_1_0 {

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -1,10 +1,10 @@
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    coi::{key_phrase::KeyPhrases, stats::CoiStats, CoiId},
+    coi::{key_phrase::KeyPhrase, stats::CoiStats, CoiId},
     embedding::utils::Embedding,
 };
 
@@ -21,7 +21,7 @@ pub(crate) struct PositiveCoi {
     #[obake(cfg(">=0.0"))]
     pub(super) point: Embedding,
     #[obake(cfg(">=0.3"))]
-    pub(super) key_phrases: KeyPhrases,
+    pub(super) key_phrases: HashSet<KeyPhrase>,
     #[obake(cfg(">=0.3"))]
     #[derivative(PartialEq = "ignore")]
     pub(super) stats: CoiStats,
@@ -58,7 +58,7 @@ impl From<PositiveCoi_v0_2_0> for PositiveCoi {
         Self {
             id: coi.id,
             point: coi.point,
-            key_phrases: KeyPhrases::default(),
+            key_phrases: HashSet::default(),
             stats: CoiStats::default(),
         }
     }
@@ -71,7 +71,12 @@ pub(crate) struct NegativeCoi {
 }
 
 pub(crate) trait CoiPoint {
-    fn new(id: CoiId, point: Embedding, key_phrases: KeyPhrases, viewed: Option<Duration>) -> Self;
+    fn new(
+        id: CoiId,
+        point: Embedding,
+        key_phrases: HashSet<KeyPhrase>,
+        viewed: Option<Duration>,
+    ) -> Self;
 
     fn id(&self) -> CoiId;
 
@@ -107,7 +112,7 @@ impl CoiPoint for PositiveCoi_v0_0_0 {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: KeyPhrases,
+        _key_phrases: HashSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self {
@@ -126,7 +131,7 @@ impl CoiPoint for PositiveCoi_v0_1_0 {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: KeyPhrases,
+        _key_phrases: HashSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self {
@@ -145,7 +150,7 @@ impl CoiPoint for PositiveCoi_v0_2_0 {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: KeyPhrases,
+        _key_phrases: HashSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self { id, point }
@@ -155,7 +160,12 @@ impl CoiPoint for PositiveCoi_v0_2_0 {
 }
 
 impl CoiPoint for PositiveCoi {
-    fn new(id: CoiId, point: Embedding, key_phrases: KeyPhrases, viewed: Option<Duration>) -> Self {
+    fn new(
+        id: CoiId,
+        point: Embedding,
+        key_phrases: HashSet<KeyPhrase>,
+        viewed: Option<Duration>,
+    ) -> Self {
         Self {
             id,
             point,
@@ -171,7 +181,7 @@ impl CoiPoint for NegativeCoi {
     fn new(
         id: CoiId,
         point: Embedding,
-        _key_phrases: KeyPhrases,
+        _key_phrases: HashSet<KeyPhrase>,
         _viewed: Option<Duration>,
     ) -> Self {
         Self { id, point }

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -1,0 +1,75 @@
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    coi::point::{NegativeCoi, PositiveCoi},
+    utils::system_time_now,
+};
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub(crate) struct CoiStats {
+    pub(crate) view_count: usize,
+    pub(crate) view_time: Duration,
+    pub(crate) last_view: SystemTime,
+}
+
+impl CoiStats {
+    pub(crate) fn new(viewed: Option<Duration>) -> Self {
+        Self {
+            view_count: 1,
+            view_time: viewed.unwrap_or_default(),
+            last_view: system_time_now(),
+        }
+    }
+
+    pub(crate) fn update(&mut self, viewed: Option<Duration>) {
+        self.view_count += 1;
+        if let Some(viewed) = viewed {
+            self.view_time += viewed;
+        }
+        self.last_view = system_time_now();
+    }
+
+    pub(crate) fn merge(self, other: Self) -> Self {
+        Self {
+            view_count: self.view_count + other.view_count,
+            view_time: self.view_time + other.view_time,
+            last_view: self.last_view.max(other.last_view),
+        }
+    }
+}
+
+impl Default for CoiStats {
+    fn default() -> Self {
+        Self {
+            view_count: 1,
+            view_time: Duration::ZERO,
+            last_view: SystemTime::UNIX_EPOCH,
+        }
+    }
+}
+
+pub(crate) trait CoiPointStats {
+    fn stats(&self) -> CoiStats;
+
+    fn update_stats(&mut self, viewed: Option<Duration>);
+}
+
+impl CoiPointStats for PositiveCoi {
+    fn stats(&self) -> CoiStats {
+        self.stats
+    }
+
+    fn update_stats(&mut self, viewed: Option<Duration>) {
+        self.stats.update(viewed);
+    }
+}
+
+impl CoiPointStats for NegativeCoi {
+    fn stats(&self) -> CoiStats {
+        CoiStats::default()
+    }
+
+    fn update_stats(&mut self, _viewed: Option<Duration>) {}
+}

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -125,9 +125,15 @@ impl CoiSystem {
             Some((coi, distance)) if distance < self.config.threshold => {
                 coi.set_point(self.shift_coi_point(embedding, coi.point()));
                 coi.set_id(Uuid::new_v4().into());
-                coi.update_stats(viewed)
+                // TODO: update key phrases
+                coi.update_stats(viewed);
             }
-            _ => cois.push(CP::new(Uuid::new_v4().into(), embedding.clone(), viewed)),
+            _ => cois.push(CP::new(
+                Uuid::new_v4().into(),
+                embedding.clone(),
+                Vec::new(), // TODO: set key phrases
+                viewed,
+            )),
         }
         cois
     }
@@ -436,14 +442,10 @@ mod tests {
 
     #[test]
     fn test_shift_coi_point() {
-        let coi = PositiveCoi::new(
-            CoiId::mocked(0),
-            arr1(&[1., 1., 1.]).into(),
-            Some(Duration::from_secs(10)),
-        );
+        let coi_point = arr1(&[1., 1., 1.]).into();
         let embedding = arr1(&[2., 3., 4.]).into();
 
-        let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi.point);
+        let updated_coi = CoiSystem::default().shift_coi_point(&embedding, &coi_point);
 
         assert_eq!(updated_coi, arr1(&[1.1, 1.2, 1.3]));
     }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, time::Duration};
+use std::{collections::HashSet, ops::Deref, time::Duration};
 
 use displaydoc::Display;
 use thiserror::Error;
@@ -7,7 +7,6 @@ use uuid::Uuid;
 use crate::{
     coi::{
         config::Configuration,
-        key_phrase::KeyPhrases,
         point::{CoiPoint, UserInterests},
         stats::{CoiPointStats, CoiStats},
         utils::{classify_documents_based_on_user_feedback, collect_matching_documents},
@@ -133,7 +132,7 @@ impl CoiSystem {
             _ => cois.push(CP::new(
                 Uuid::new_v4().into(),
                 embedding.clone(),
-                KeyPhrases::default(), // TODO: set key phrases
+                HashSet::default(), // TODO: set key phrases
                 viewed,
             )),
         }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::{
     coi::{
         config::Configuration,
-        point::{CoiPoint, CoiPointStats, CoiStats, UserInterests},
+        point::{CoiPoint, CoiPointStats, CoiStats, KeyPhrases, UserInterests},
         utils::{classify_documents_based_on_user_feedback, collect_matching_documents},
         CoiId,
     },
@@ -131,7 +131,7 @@ impl CoiSystem {
             _ => cois.push(CP::new(
                 Uuid::new_v4().into(),
                 embedding.clone(),
-                Vec::new(), // TODO: set key phrases
+                KeyPhrases::default(), // TODO: set key phrases
                 viewed,
             )),
         }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, ops::Deref, time::Duration};
+use std::{collections::BTreeSet, ops::Deref, time::Duration};
 
 use displaydoc::Display;
 use thiserror::Error;
@@ -132,7 +132,7 @@ impl CoiSystem {
             _ => cois.push(CP::new(
                 Uuid::new_v4().into(),
                 embedding.clone(),
-                HashSet::default(), // TODO: set key phrases
+                BTreeSet::default(), // TODO: set key phrases
                 viewed,
             )),
         }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -7,7 +7,9 @@ use uuid::Uuid;
 use crate::{
     coi::{
         config::Configuration,
-        point::{CoiPoint, CoiPointStats, CoiStats, KeyPhrases, UserInterests},
+        key_phrase::KeyPhrases,
+        point::{CoiPoint, UserInterests},
+        stats::{CoiPointStats, CoiStats},
         utils::{classify_documents_based_on_user_feedback, collect_matching_documents},
         CoiId,
     },

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -61,14 +61,13 @@ fn document_relevance(history: &DocumentHistory) -> DocumentRelevance {
 
 #[cfg(test)]
 pub(super) mod tests {
-    use std::time::Duration;
+    use std::{collections::HashSet, time::Duration};
 
     use ndarray::{arr1, FixedInitializer};
 
     use super::*;
     use crate::{
         coi::{
-            key_phrase::KeyPhrases,
             point::{CoiPoint, NegativeCoi, PositiveCoi},
             CoiId,
         },
@@ -118,7 +117,7 @@ pub(super) mod tests {
                 CP::new(
                     CoiId::mocked(id),
                     arr1(point.as_init_slice()).into(),
-                    KeyPhrases::default(),
+                    HashSet::default(),
                     Some(Duration::from_secs(10)),
                 )
             })

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -68,7 +68,7 @@ pub(super) mod tests {
     use super::*;
     use crate::{
         coi::{
-            point::{CoiPoint, NegativeCoi, PositiveCoi},
+            point::{CoiPoint, KeyPhrases, NegativeCoi, PositiveCoi},
             CoiId,
         },
         data::document_data::{
@@ -117,7 +117,7 @@ pub(super) mod tests {
                 CP::new(
                     CoiId::mocked(id),
                     arr1(point.as_init_slice()).into(),
-                    Vec::new(),
+                    KeyPhrases::default(),
                     Some(Duration::from_secs(10)),
                 )
             })

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -68,7 +68,8 @@ pub(super) mod tests {
     use super::*;
     use crate::{
         coi::{
-            point::{CoiPoint, KeyPhrases, NegativeCoi, PositiveCoi},
+            key_phrase::KeyPhrases,
+            point::{CoiPoint, NegativeCoi, PositiveCoi},
             CoiId,
         },
         data::document_data::{

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -117,7 +117,7 @@ pub(super) mod tests {
                 CP::new(
                     CoiId::mocked(id),
                     arr1(point.as_init_slice()).into(),
-                    vec!["key phrase".into()],
+                    Vec::new(),
                     Some(Duration::from_secs(10)),
                 )
             })

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -117,6 +117,7 @@ pub(super) mod tests {
                 CP::new(
                     CoiId::mocked(id),
                     arr1(point.as_init_slice()).into(),
+                    vec!["key phrase".into()],
                     Some(Duration::from_secs(10)),
                 )
             })

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -61,7 +61,7 @@ fn document_relevance(history: &DocumentHistory) -> DocumentRelevance {
 
 #[cfg(test)]
 pub(super) mod tests {
-    use std::{collections::HashSet, time::Duration};
+    use std::{collections::BTreeSet, time::Duration};
 
     use ndarray::{arr1, FixedInitializer};
 
@@ -117,7 +117,7 @@ pub(super) mod tests {
                 CP::new(
                     CoiId::mocked(id),
                     arr1(point.as_init_slice()).into(),
-                    HashSet::default(),
+                    BTreeSet::default(),
                     Some(Duration::from_secs(10)),
                 )
             })

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -58,16 +58,15 @@ where
 /// # Panics
 /// Panics if the vectors don't consist solely of real values or their shapes don't match.
 ///
-/// # Safety
-/// Only use this with [`TrustedLen`] iterators. The bound can't be named currently, because the
-/// trait is nightly-gated. [`ExactSizeIterator`] isn't a feasible replacement, because it isn't
-/// implemented for [`Chain`]ed iterators for example.
+/// Only use this with [`TrustedLen`] iterators, otherwise indexing may panic. The bound can't be
+/// named currently, because the trait is nightly-gated. [`ExactSizeIterator`] isn't a feasible and
+/// trusted replacement, for example it isn't implemented for [`Chain`]ed iterators.
 ///
 /// [`TrustedLen`]: std::iter::TrustedLen
 /// [`ExactSizeIterator`]: std::iter::ExactSizeIterator
 /// [`Chain`]: std::iter::Chain
 #[allow(dead_code)]
-pub unsafe fn pairwise_cosine_similarity<I, S>(iter: I) -> Array2<f32>
+pub fn pairwise_cosine_similarity<I, S>(iter: I) -> Array2<f32>
 where
     I: IntoIterator<Item = ArrayBase<S, Ix1>>,
     I::IntoIter: Clone,
@@ -103,10 +102,7 @@ pub fn cosine_similarity<S>(a: ArrayBase<S, Ix1>, b: ArrayBase<S, Ix1>) -> f32
 where
     S: Data<Elem = f32>,
 {
-    unsafe {
-        // Safety: array::IntoIter implements TrustedLen
-        pairwise_cosine_similarity([a.view(), b.view()])[[0, 1]]
-    }
+    pairwise_cosine_similarity([a.view(), b.view()])[[0, 1]]
 }
 
 #[cfg(test)]
@@ -161,10 +157,7 @@ mod tests {
     fn test_cosine_similarity_empty() {
         assert_approx_eq!(
             f32,
-            unsafe {
-                // Safety: array::IntoIter implements TrustedLen
-                pairwise_cosine_similarity([] as [Array1<f32>; 0])
-            },
+            pairwise_cosine_similarity([] as [Array1<f32>; 0]),
             arr2(&[[]]),
         );
     }
@@ -173,10 +166,7 @@ mod tests {
     fn test_cosine_similarity_single() {
         assert_approx_eq!(
             f32,
-            unsafe {
-                // Safety: array::IntoIter implements TrustedLen
-                pairwise_cosine_similarity([arr1(&[1., 2., 3.])])
-            },
+            pairwise_cosine_similarity([arr1(&[1., 2., 3.])]),
             arr2(&[[1.]]),
         );
     }
@@ -185,10 +175,7 @@ mod tests {
     fn test_cosine_similarity_pair() {
         assert_approx_eq!(
             f32,
-            unsafe {
-                // Safety: array::IntoIter implements TrustedLen
-                pairwise_cosine_similarity([arr1(&[1., 2., 3.]), arr1(&[4., 5., 6.])])
-            },
+            pairwise_cosine_similarity([arr1(&[1., 2., 3.]), arr1(&[4., 5., 6.])]),
             arr2(&[[1., 0.97463185], [0.97463185, 1.]]),
         );
     }

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -66,6 +66,7 @@ where
 /// [`TrustedLen`]: std::iter::TrustedLen
 /// [`ExactSizeIterator`]: std::iter::ExactSizeIterator
 /// [`Chain`]: std::iter::Chain
+#[allow(dead_code)]
 pub unsafe fn pairwise_cosine_similarity<I, S>(iter: I) -> Array2<f32>
 where
     I: IntoIterator<Item = ArrayBase<S, Ix1>>,
@@ -97,6 +98,7 @@ where
 ///
 /// # Panics
 /// Panics if the vectors don't consist solely of real values or their shapes don't match.
+#[allow(dead_code)]
 pub fn cosine_similarity<S>(a: ArrayBase<S, Ix1>, b: ArrayBase<S, Ix1>) -> f32
 where
     S: Data<Elem = f32>,

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -5,9 +5,9 @@ use uuid::Uuid;
 
 use crate::{
     coi::{
+        key_phrase::KeyPhrases,
         point::{
             CoiPoint,
-            KeyPhrases,
             NegativeCoi,
             PositiveCoi,
             PositiveCoi_v0_0_0,

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, ops::Range, time::Duration};
+use std::{collections::BTreeSet, ops::Range, time::Duration};
 
 use ndarray::arr1;
 use uuid::Uuid;
@@ -107,7 +107,7 @@ fn cois_from_words<CP: CoiPoint>(
             CP::new(
                 CoiId::mocked(start_id + offset),
                 doc.smbert.embedding,
-                HashSet::default(),
+                BTreeSet::default(),
                 Some(Duration::from_secs(10)),
             )
         })

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -1,11 +1,10 @@
-use std::{ops::Range, time::Duration};
+use std::{collections::HashSet, ops::Range, time::Duration};
 
 use ndarray::arr1;
 use uuid::Uuid;
 
 use crate::{
     coi::{
-        key_phrase::KeyPhrases,
         point::{
             CoiPoint,
             NegativeCoi,
@@ -108,7 +107,7 @@ fn cois_from_words<CP: CoiPoint>(
             CP::new(
                 CoiId::mocked(start_id + offset),
                 doc.smbert.embedding,
-                KeyPhrases::default(),
+                HashSet::default(),
                 Some(Duration::from_secs(10)),
             )
         })

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -107,7 +107,7 @@ fn cois_from_words<CP: CoiPoint>(
             CP::new(
                 CoiId::mocked(start_id + offset),
                 doc.smbert.embedding,
-                vec!["key phrase".into()],
+                Vec::new(),
                 Some(Duration::from_secs(10)),
             )
         })

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -107,6 +107,7 @@ fn cois_from_words<CP: CoiPoint>(
             CP::new(
                 CoiId::mocked(start_id + offset),
                 doc.smbert.embedding,
+                vec!["key phrase".into()],
                 Some(Duration::from_secs(10)),
             )
         })

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -7,6 +7,7 @@ use crate::{
     coi::{
         point::{
             CoiPoint,
+            KeyPhrases,
             NegativeCoi,
             PositiveCoi,
             PositiveCoi_v0_0_0,
@@ -107,7 +108,7 @@ fn cois_from_words<CP: CoiPoint>(
             CP::new(
                 CoiId::mocked(start_id + offset),
                 doc.smbert.embedding,
-                Vec::new(),
+                KeyPhrases::default(),
                 Some(Duration::from_secs(10)),
             )
         })


### PR DESCRIPTION
**References**

- [TY-2206]

**Summary**

- add `KeyPhrase` wrapper to hold key phrases and their embeddings in a coi
- add key phrases to `PositiveCoi`: ~the uniqueness invariant can't be enforced for example by a `HashSet` because `KeyPhrase` can't implement `Eq + Hash` and also not by sort & dedup because `KeyPhrase` can't implement `PartialOrd`/`Ord`~ the uniqueness is enforced only over the words of the key phrases, this is under the assumption that smbert gives a unique embedding for each unique key phrase and if we ever change the smbert we would need migration stategies anyways
- update `CoiPoint` setters/getters for key phrases, split out `CoiPointKeyPhrases` and `CoiPointStats`
- modify the bounds on `pairwise_cosine_similarity()`: follow up on #339
- add placeholders for key phrase updates: to be implemented in a follow up pr

[TY-2206]: https://xainag.atlassian.net/browse/TY-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ