### PR TITLE
[Merged by Bors] - TY-2208 update key phrases [2]

### DIFF
--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1.0.52"
 bincode = "1.3.3"
 derivative = "2.2.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["deref", "display", "from"] }
 displaydoc = "0.2.3"
 itertools = "0.10.3"
 kpe = { path = "../kpe" }

--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -1,5 +1,6 @@
 use std::num::NonZeroUsize;
 
+#[derive(Clone, Copy)]
 pub(crate) struct Configuration {
     /// The shift factor by how much a Coi is shifted towards a new point.
     pub shift_factor: f32,

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -535,4 +535,112 @@ mod tests {
             0.,
         );
     }
+
+    #[test]
+    fn test_select_key_phrases_positive_similarity() {
+        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = IntoIterator::into_iter([
+            KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
+            KeyPhrase::new("phrase", arr1(&[1., 1., 1.])).unwrap(),
+        ])
+        .collect::<BTreeSet<_>>();
+        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
+        let candidates = key_phrases
+            .iter()
+            .skip(1)
+            .map(|key_phrase| key_phrase.words().to_string())
+            .collect::<Vec<_>>();
+        let smbert = |words: &str| {
+            key_phrases
+                .iter()
+                .find_map(|key_phrase| {
+                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone().into()))
+                })
+                .unwrap()
+        };
+        select_key_phrases(&mut coi[0], &candidates, smbert, 3, 0.9);
+        assert_eq!(coi[0].key_phrases(), &key_phrases);
+        assert_approx_eq!(
+            f32,
+            coi[0].key_phrases().get("key").unwrap().relevance(),
+            1.,
+        );
+        assert_approx_eq!(
+            f32,
+            coi[0].key_phrases().get("phrase").unwrap().relevance(),
+            0.8164967,
+        );
+    }
+
+    #[test]
+    fn test_select_key_phrases_negative_similarity() {
+        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = IntoIterator::into_iter([
+            KeyPhrase::new("key", arr1(&[-1., 1., 0.])).unwrap(),
+            KeyPhrase::new("phrase", arr1(&[-1., 1., 1.])).unwrap(),
+        ])
+        .collect::<BTreeSet<_>>();
+        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
+        let candidates = key_phrases
+            .iter()
+            .skip(1)
+            .map(|key_phrase| key_phrase.words().to_string())
+            .collect::<Vec<_>>();
+        let smbert = |words: &str| {
+            key_phrases
+                .iter()
+                .find_map(|key_phrase| {
+                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone().into()))
+                })
+                .unwrap()
+        };
+        select_key_phrases(&mut coi[0], &candidates, smbert, 3, 0.9);
+        assert_eq!(coi[0].key_phrases(), &key_phrases);
+        assert_approx_eq!(
+            f32,
+            coi[0].key_phrases().get("key").unwrap().relevance(),
+            0.,
+        );
+        assert_approx_eq!(
+            f32,
+            coi[0].key_phrases().get("phrase").unwrap().relevance(),
+            0.,
+        );
+    }
+
+    #[test]
+    fn test_select_key_phrases_mixed_similarity() {
+        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = IntoIterator::into_iter([
+            KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
+            KeyPhrase::new("phrase", arr1(&[-1., 1., 1.])).unwrap(),
+        ])
+        .collect::<BTreeSet<_>>();
+        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
+        let candidates = key_phrases
+            .iter()
+            .skip(1)
+            .map(|key_phrase| key_phrase.words().to_string())
+            .collect::<Vec<_>>();
+        let smbert = |words: &str| {
+            key_phrases
+                .iter()
+                .find_map(|key_phrase| {
+                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone().into()))
+                })
+                .unwrap()
+        };
+        select_key_phrases(&mut coi[0], &candidates, smbert, 3, 0.9);
+        assert_eq!(coi[0].key_phrases(), &key_phrases);
+        assert_approx_eq!(
+            f32,
+            coi[0].key_phrases().get("key").unwrap().relevance(),
+            1.,
+        );
+        assert_approx_eq!(
+            f32,
+            coi[0].key_phrases().get("phrase").unwrap().relevance(),
+            0.,
+        );
+    }
 }

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -363,24 +363,6 @@ mod tests {
     }
 
     #[test]
-    fn test_select_key_phrases_one() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases =
-            IntoIterator::into_iter([KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap()])
-                .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.clone());
-        let candidates = &[];
-        let smbert = |_: &str| unreachable!();
-        coi[0].select_key_phrases(candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            1.,
-        );
-    }
-
-    #[test]
     fn test_select_key_phrases_no_candidates() {
         let mut coi = create_pos_cois(&[[1., 0., 0.]]);
         let key_phrases = IntoIterator::into_iter([

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -9,7 +9,7 @@ mod utils;
 pub(crate) use config::Configuration;
 pub(crate) use merge::reduce_cois;
 #[cfg(test)]
-pub(crate) use system::CoiSystemError;
+pub(crate) use system::{compute_coi, update_user_interests, CoiSystemError};
 pub(crate) use system::{CoiSystem, NeutralCoiSystem};
 
 use derive_more::From;

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -13,7 +13,7 @@ use crate::{
         CoiId,
     },
     data::document_data::{CoiComponent, DocumentDataWithCoi, DocumentDataWithSMBert},
-    embedding::utils::Embedding,
+    embedding::{smbert::SMBert, utils::Embedding},
     reranker::systems::{self, CoiSystemData},
     DocumentHistory,
     Error,
@@ -29,18 +29,13 @@ pub(crate) enum CoiSystemError {
 
 pub(crate) struct CoiSystem {
     config: Configuration,
-}
-
-impl Default for CoiSystem {
-    fn default() -> Self {
-        Self::new(Configuration::default())
-    }
+    smbert: SMBert,
 }
 
 impl CoiSystem {
     /// Creates a new centre of interest system.
-    pub(crate) fn new(config: Configuration) -> Self {
-        Self { config }
+    pub(crate) fn new(config: Configuration, smbert: SMBert) -> Self {
+        Self { config, smbert }
     }
 }
 
@@ -93,7 +88,7 @@ fn compute_coi_for_embedding(
     })
 }
 
-fn compute_coi(
+pub(crate) fn compute_coi(
     documents: &[DocumentDataWithSMBert],
     user_interests: &UserInterests,
     neighbors: usize,
@@ -161,7 +156,7 @@ fn update_cois<CP: CoiPoint + CoiPointStats>(
     })
 }
 
-fn update_user_interests(
+pub(crate) fn update_user_interests(
     history: &[DocumentHistory],
     documents: &[&dyn CoiSystemData],
     mut user_interests: UserInterests,

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -85,6 +85,7 @@ pub(super) mod tests {
         id: DocumentId,
         smbert: SMBertComponent,
         coi: Option<CoiComponent>,
+        viewed: Duration,
     }
 
     impl CoiSystemData for MockCoiDoc {
@@ -101,7 +102,7 @@ pub(super) mod tests {
         }
 
         fn viewed(&self) -> Duration {
-            Duration::from_secs(10)
+            self.viewed
         }
     }
 

--- a/xayn-ai/src/embedding/smbert.rs
+++ b/xayn-ai/src/embedding/smbert.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use derive_more::{Deref, From};
 use ndarray::arr1;
 #[cfg(feature = "multithreaded")]
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -7,7 +10,9 @@ use crate::{
     error::Error,
     reranker::systems::SMBertSystem,
 };
-use rubert::SMBert;
+
+#[derive(Clone, Deref, From)]
+pub struct SMBert(Arc<rubert::SMBert>);
 
 impl SMBertSystem for SMBert {
     fn compute_embedding(

--- a/xayn-ai/src/ranker/mod.rs
+++ b/xayn-ai/src/ranker/mod.rs
@@ -1,11 +1,10 @@
 pub(crate) mod public;
 
 use kpe::Pipeline as KPE;
-use rubert::SMBert;
 
 use crate::{
     coi::{point::UserInterests, CoiSystem},
-    embedding::utils::Embedding,
+    embedding::{smbert::SMBert, utils::Embedding},
     error::Error,
 };
 

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -85,15 +85,8 @@ pub(crate) fn mocked_qambert_system() -> MockQAMBertSystem {
 }
 
 fn mocked_coi_system() -> MockCoiSystem {
-    let CoiConfig {
-        shift_factor,
-        threshold,
-        neighbors,
-        max_key_phrases,
-        gamma,
-        ..
-    } = CoiConfig::default();
-    let neighbors = neighbors.get();
+    let config = CoiConfig::default();
+    let neighbors = config.neighbors.get();
 
     let mut system = MockCoiSystem::new();
     system
@@ -108,12 +101,8 @@ fn mocked_coi_system() -> MockCoiSystem {
                 history,
                 documents,
                 user_interests,
-                neighbors,
-                threshold,
-                shift_factor,
                 |_| unreachable!(),
-                max_key_phrases,
-                gamma,
+                config,
             )
         });
     system

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -89,6 +89,8 @@ fn mocked_coi_system() -> MockCoiSystem {
         shift_factor,
         threshold,
         neighbors,
+        max_key_phrases,
+        gamma,
         ..
     } = CoiConfig::default();
     let neighbors = neighbors.get();
@@ -109,6 +111,9 @@ fn mocked_coi_system() -> MockCoiSystem {
                 neighbors,
                 threshold,
                 shift_factor,
+                |_| unreachable!(),
+                max_key_phrases,
+                gamma,
             )
         });
     system


### PR DESCRIPTION
**References**

- [TY-2208]
- #348
- #361
- #371

**Summary**

- make `SMBert` available to `CoiSystem` & replace the smbert closure
- mock `SMBert` in the coi tests & adjust reranker builder
- add more key phrase selection tests


[TY-2208]: https://xainag.atlassian.net/browse/TY-2208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ