### PR TITLE
[Merged by Bors] - TY-2217 make viewed non-optional

### DIFF
--- a/dev-tool/src/call_data/generate.rs
+++ b/dev-tool/src/call_data/generate.rs
@@ -1,4 +1,5 @@
 #![cfg(not(tarpaulin))]
+
 use std::{
     cmp::min,
     collections::{HashMap, HashSet},
@@ -6,6 +7,7 @@ use std::{
     fs::File,
     io::BufReader,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use anyhow::{bail, Error};
@@ -390,7 +392,7 @@ fn gen_current_query_from_history(
                 query_words: query_words.clone(),
                 url: url.clone(),
                 domain: domain.clone(),
-                viewed: None,
+                viewed: Duration::ZERO,
             }
         })
         .collect()

--- a/xayn-ai-ffi-c/src/data/document.rs
+++ b/xayn-ai-ffi-c/src/data/document.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, slice};
+use std::{convert::TryInto, slice, time::Duration};
 
 use xayn_ai::Document;
 use xayn_ai_ffi::{CCode, Error};
@@ -136,7 +136,7 @@ impl<'a> CDocuments<'a> {
                         )
                     }?
                     .into();
-                    let viewed = None;
+                    let viewed = Duration::ZERO;
 
                     Ok(Document {
                         id,

--- a/xayn-ai-ffi-wasm/src/ai.rs
+++ b/xayn-ai-ffi-wasm/src/ai.rs
@@ -175,7 +175,7 @@ mod tests {
 
     use super::*;
 
-    use std::iter::repeat;
+    use std::{iter::repeat, time::Duration};
 
     use itertools::izip;
     use wasm_bindgen_test::wasm_bindgen_test;
@@ -337,7 +337,7 @@ mod tests {
                 query_words: doc.7,
                 url: doc.8,
                 domain: doc.9,
-                viewed: None,
+                viewed: Duration::ZERO,
             })
             .unwrap()
         })

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -71,12 +71,8 @@ pub(crate) struct NegativeCoi {
 }
 
 pub(crate) trait CoiPoint {
-    fn new(
-        id: CoiId,
-        point: Embedding,
-        key_phrases: BTreeSet<KeyPhrase>,
-        viewed: Option<Duration>,
-    ) -> Self;
+    fn new(id: CoiId, point: Embedding, key_phrases: BTreeSet<KeyPhrase>, viewed: Duration)
+        -> Self;
 
     fn id(&self) -> CoiId;
 
@@ -113,7 +109,7 @@ impl CoiPoint for PositiveCoi_v0_0_0 {
         id: CoiId,
         point: Embedding,
         _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Option<Duration>,
+        _viewed: Duration,
     ) -> Self {
         Self {
             id,
@@ -132,7 +128,7 @@ impl CoiPoint for PositiveCoi_v0_1_0 {
         id: CoiId,
         point: Embedding,
         _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Option<Duration>,
+        _viewed: Duration,
     ) -> Self {
         Self {
             id,
@@ -151,7 +147,7 @@ impl CoiPoint for PositiveCoi_v0_2_0 {
         id: CoiId,
         point: Embedding,
         _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Option<Duration>,
+        _viewed: Duration,
     ) -> Self {
         Self { id, point }
     }
@@ -164,7 +160,7 @@ impl CoiPoint for PositiveCoi {
         id: CoiId,
         point: Embedding,
         key_phrases: BTreeSet<KeyPhrase>,
-        viewed: Option<Duration>,
+        viewed: Duration,
     ) -> Self {
         Self {
             id,
@@ -182,7 +178,7 @@ impl CoiPoint for NegativeCoi {
         id: CoiId,
         point: Embedding,
         _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Option<Duration>,
+        _viewed: Duration,
     ) -> Self {
         Self { id, point }
     }

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -15,19 +15,17 @@ pub(crate) struct CoiStats {
 }
 
 impl CoiStats {
-    pub(crate) fn new(viewed: Option<Duration>) -> Self {
+    pub(crate) fn new(viewed: Duration) -> Self {
         Self {
             view_count: 1,
-            view_time: viewed.unwrap_or_default(),
+            view_time: viewed,
             last_view: system_time_now(),
         }
     }
 
-    pub(crate) fn update(&mut self, viewed: Option<Duration>) {
+    pub(crate) fn update(&mut self, viewed: Duration) {
         self.view_count += 1;
-        if let Some(viewed) = viewed {
-            self.view_time += viewed;
-        }
+        self.view_time += viewed;
         self.last_view = system_time_now();
     }
 
@@ -53,7 +51,7 @@ impl Default for CoiStats {
 pub(crate) trait CoiPointStats {
     fn stats(&self) -> CoiStats;
 
-    fn update_stats(&mut self, viewed: Option<Duration>);
+    fn update_stats(&mut self, viewed: Duration);
 }
 
 impl CoiPointStats for PositiveCoi {
@@ -61,7 +59,7 @@ impl CoiPointStats for PositiveCoi {
         self.stats
     }
 
-    fn update_stats(&mut self, viewed: Option<Duration>) {
+    fn update_stats(&mut self, viewed: Duration) {
         self.stats.update(viewed);
     }
 }
@@ -71,5 +69,5 @@ impl CoiPointStats for NegativeCoi {
         CoiStats::default()
     }
 
-    fn update_stats(&mut self, _viewed: Option<Duration>) {}
+    fn update_stats(&mut self, _viewed: Duration) {}
 }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -119,7 +119,7 @@ impl CoiSystem {
     fn update_coi<CP: CoiPoint + CoiPointStats>(
         &self,
         embedding: &Embedding,
-        viewed: Option<Duration>,
+        viewed: Duration,
         mut cois: Vec<CP>,
     ) -> Vec<CP> {
         match self.find_closest_coi_mut(embedding, &mut cois) {
@@ -417,7 +417,7 @@ mod tests {
     fn test_update_coi_add_point() {
         let mut cois = create_pos_cois(&[[30., 0., 0.], [0., 20., 0.], [0., 0., 40.]]);
         let embedding = arr1(&[1., 1., 1.]).into();
-        let viewed = Some(Duration::from_secs(10));
+        let viewed = Duration::from_secs(10);
 
         let config = Configuration::default();
         let threshold = config.threshold;
@@ -439,7 +439,7 @@ mod tests {
     fn test_update_coi_update_point() {
         let cois = create_pos_cois(&[[1., 1., 1.], [10., 10., 10.], [20., 20., 20.]]);
         let embedding = arr1(&[2., 3., 4.]).into();
-        let viewed = Some(Duration::from_secs(10));
+        let viewed = Duration::from_secs(10);
 
         let cois = CoiSystem::default().update_coi(&embedding, viewed, cois);
 
@@ -463,7 +463,7 @@ mod tests {
     fn test_update_coi_threshold_exclusive() {
         let cois = create_pos_cois(&[[0., 0., 0.]]);
         let embedding = arr1(&[0., 0., 12.]).into();
-        let viewed = Some(Duration::from_secs(10));
+        let viewed = Duration::from_secs(10);
 
         let cois = CoiSystem::default().update_coi(&embedding, viewed, cois);
 

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -100,8 +100,8 @@ pub(super) mod tests {
             self.coi.as_ref()
         }
 
-        fn viewed(&self) -> Option<Duration> {
-            Some(Duration::from_secs(10))
+        fn viewed(&self) -> Duration {
+            Duration::from_secs(10)
         }
     }
 
@@ -118,7 +118,7 @@ pub(super) mod tests {
                     CoiId::mocked(id),
                     arr1(point.as_init_slice()).into(),
                     BTreeSet::default(),
-                    Some(Duration::from_secs(10)),
+                    Duration::from_secs(10),
                 )
             })
             .collect()

--- a/xayn-ai/src/data/document.rs
+++ b/xayn-ai/src/data/document.rs
@@ -101,7 +101,7 @@ pub struct Document {
     /// Domain of the document
     pub domain: String,
     /// Time viewed of the document.
-    pub viewed: Option<Duration>,
+    pub viewed: Duration,
 }
 
 /// Represents a historical result from a query.

--- a/xayn-ai/src/data/document_data.rs
+++ b/xayn-ai/src/data/document_data.rs
@@ -27,7 +27,7 @@ pub(crate) struct DocumentContentComponent {
     pub(crate) query_words: String,
     pub(crate) url: String,
     pub(crate) domain: String,
-    pub(crate) viewed: Option<Duration>,
+    pub(crate) viewed: Duration,
 }
 
 // TODO: the test-derived impls are temporarily available from rubert::utils::test_utils
@@ -147,7 +147,7 @@ impl CoiSystemData for DocumentDataWithSMBert {
         None
     }
 
-    fn viewed(&self) -> Option<Duration> {
+    fn viewed(&self) -> Duration {
         self.document_content.viewed
     }
 }
@@ -282,7 +282,7 @@ impl CoiSystemData for DocumentDataWithRank {
         Some(&self.coi)
     }
 
-    fn viewed(&self) -> Option<Duration> {
+    fn viewed(&self) -> Duration {
         self.document_content.viewed
     }
 }

--- a/xayn-ai/src/reranker/systems.rs
+++ b/xayn-ai/src/reranker/systems.rs
@@ -46,7 +46,7 @@ pub(crate) trait CoiSystemData {
     fn id(&self) -> DocumentId;
     fn smbert(&self) -> &SMBertComponent;
     fn coi(&self) -> Option<&CoiComponent>;
-    fn viewed(&self) -> Option<Duration>;
+    fn viewed(&self) -> Duration;
 }
 
 #[cfg_attr(test, automock)]

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -108,7 +108,7 @@ fn cois_from_words<CP: CoiPoint>(
                 CoiId::mocked(start_id + offset),
                 doc.smbert.embedding,
                 BTreeSet::default(),
-                Some(Duration::from_secs(10)),
+                Duration::from_secs(10),
             )
         })
         .collect()


### PR DESCRIPTION
**References**

- follow up on [TY-2217]

**Summary**

- make `viewed` non-optional & use `Duration::ZERO` as a default


[TY-2217]: https://xainag.atlassian.net/browse/TY-2217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ