### PR TITLE
[Merged by Bors] - TY-2209 top key phrases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,7 +2411,6 @@ dependencies = [
  "js-sys",
  "kpe",
  "layer",
- "lazy_static",
  "maplit",
  "mockall",
  "ndarray",

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -8,12 +8,11 @@ edition = "2018"
 anyhow = "1.0.52"
 bincode = "1.3.3"
 derivative = "2.2.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["deref", "display", "from"] }
+derive_more = { version = "0.99.17", default-features = false, features = ["deref", "display", "from", "into"] }
 displaydoc = "0.2.3"
 itertools = "0.10.3"
 kpe = { path = "../kpe" }
 layer = { path = "../layer" }
-lazy_static = "1.4.0"
 # to be kept in sync with rubert
 ndarray = "=0.15.3"
 # TODO: use version 1.0.5 once it is released

--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -1,4 +1,6 @@
-use std::num::NonZeroUsize;
+use std::{num::NonZeroUsize, time::Duration};
+
+use crate::utils::SECONDS_PER_DAY;
 
 #[derive(Clone, Copy)]
 pub(crate) struct Configuration {
@@ -8,6 +10,9 @@ pub(crate) struct Configuration {
     pub threshold: f32,
     /// The positive number of neighbors for the k-nearest-neighbors distance.
     pub neighbors: NonZeroUsize,
+    /// The time since the last view after which a coi becomes irrelevant.
+    #[allow(dead_code)]
+    pub horizon: Duration,
     /// The maximum number of key phrases picked during the coi key phrase selection. A coi may have
     /// more key phrases than this, eg because of merging.
     #[allow(dead_code)]
@@ -23,6 +28,7 @@ impl Default for Configuration {
             shift_factor: 0.1,
             threshold: 12.0,
             neighbors: NonZeroUsize::new(4).unwrap(),
+            horizon: Duration::from_secs(SECONDS_PER_DAY as u64 * 30),
             max_key_phrases: 3,
             gamma: 0.9,
         }

--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -2,7 +2,7 @@ use std::{num::NonZeroUsize, time::Duration};
 
 use crate::utils::SECONDS_PER_DAY;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub(crate) struct Configuration {
     /// The shift factor by how much a Coi is shifted towards a new point.
     pub shift_factor: f32,
@@ -20,6 +20,8 @@ pub(crate) struct Configuration {
     /// The weighting between coi and pairwise candidate similarites in the key phrase selection.
     #[allow(dead_code)]
     pub gamma: f32,
+    /// The penalty for less relevant key phrases in the top key phrase selection.
+    pub penalty: Vec<f32>,
 }
 
 impl Default for Configuration {
@@ -31,6 +33,7 @@ impl Default for Configuration {
             horizon: Duration::from_secs(SECONDS_PER_DAY as u64 * 30),
             max_key_phrases: 3,
             gamma: 0.9,
+            penalty: vec![1., 0.75, 0.66],
         }
     }
 }

--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -20,7 +20,9 @@ pub(crate) struct Configuration {
     /// The weighting between coi and pairwise candidate similarites in the key phrase selection.
     #[allow(dead_code)]
     pub gamma: f32,
-    /// The penalty for less relevant key phrases in the top key phrase selection.
+    /// The penalty for less relevant key phrases of a coi in increasing order (ie. lowest penalty
+    /// for the most relevant key phrase first and highest penalty for the least relevant key phrase
+    /// last).
     pub penalty: Vec<f32>,
 }
 

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -1,21 +1,16 @@
-use std::{
-    borrow::{Borrow, Cow},
-    collections::BTreeSet,
-    convert::identity,
-    iter::once,
-};
+use std::{borrow::Borrow, collections::BTreeSet, convert::identity, iter::once, time::Duration};
 
 use derivative::Derivative;
-use lazy_static::lazy_static;
 use ndarray::{s, Array1, Array2, ArrayBase, Axis, Data, Ix, Ix2};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     coi::{
-        config::Configuration,
         point::{CoiPoint, NegativeCoi, PositiveCoi},
-        stats::{compute_relevances, CoiPointStats},
+        relevance::{Relevance, RelevanceMaps},
+        stats::CoiPointStats,
         CoiError,
+        CoiId,
     },
     embedding::utils::{pairwise_cosine_similarity, ArcEmbedding, Embedding},
     error::Error,
@@ -27,13 +22,6 @@ pub(crate) struct KeyPhrase {
     words: String,
     #[derivative(Ord = "ignore", PartialEq = "ignore", PartialOrd = "ignore")]
     point: ArcEmbedding,
-    #[derivative(Ord = "ignore", PartialEq = "ignore", PartialOrd = "ignore")]
-    relevance: f32,
-}
-
-lazy_static! {
-    // TODO: temporary workaround, remove once positive and negative cois have been split properly
-    static ref EMPTY_KEY_PHRASES: BTreeSet<KeyPhrase> = BTreeSet::new();
 }
 
 impl KeyPhrase {
@@ -43,7 +31,6 @@ impl KeyPhrase {
     ) -> Result<Self, CoiError> {
         let words = words.into();
         let point = point.into();
-        let relevance = 0.;
 
         if words.is_empty() || point.is_empty() {
             return Err(CoiError::EmptyKeyPhrase);
@@ -52,31 +39,16 @@ impl KeyPhrase {
             return Err(CoiError::NonFiniteKeyPhrase(point));
         }
 
-        Ok(Self {
-            words,
-            point,
-            relevance,
-        })
+        Ok(Self { words, point })
     }
 
-    pub(crate) fn with_relevance(self, relevance: f32) -> Result<Self, CoiError> {
-        if (0. ..=1.).contains(&relevance) {
-            Ok(Self { relevance, ..self })
-        } else {
-            Err(CoiError::NonNormalizedKeyPhrase(relevance))
-        }
-    }
-
+    #[cfg(test)]
     pub(crate) fn words(&self) -> &str {
         &self.words
     }
 
     pub(crate) fn point(&self) -> &ArcEmbedding {
         &self.point
-    }
-
-    pub(crate) fn relevance(&self) -> f32 {
-        self.relevance
     }
 }
 
@@ -92,13 +64,22 @@ impl Borrow<str> for KeyPhrase {
     }
 }
 
+impl PartialEq<&str> for KeyPhrase {
+    fn eq(&self, other: &&str) -> bool {
+        self.words.eq(other)
+    }
+}
+
+impl PartialEq<KeyPhrase> for &str {
+    fn eq(&self, other: &KeyPhrase) -> bool {
+        other.words.eq(self)
+    }
+}
+
 pub(crate) trait CoiPointKeyPhrases {
-    fn key_phrases(&self) -> &BTreeSet<KeyPhrase>;
-
-    fn set_key_phrases(&mut self, key_phrases: BTreeSet<KeyPhrase>);
-
     fn select_key_phrases<F>(
-        &mut self,
+        &self,
+        relevance_maps: &mut RelevanceMaps,
         candidates: &[String],
         smbert: F,
         max_key_phrases: usize,
@@ -109,20 +90,9 @@ pub(crate) trait CoiPointKeyPhrases {
 }
 
 impl CoiPointKeyPhrases for PositiveCoi {
-    fn key_phrases(&self) -> &BTreeSet<KeyPhrase> {
-        &self.key_phrases
-    }
-
-    fn set_key_phrases(&mut self, key_phrases: BTreeSet<KeyPhrase>) {
-        self.key_phrases = key_phrases;
-    }
-
-    /// Selects the most relevant key phrases for the coi.
-    ///
-    /// The most relevant key phrases are selected from the set of key phrases of the coi and the
-    /// candidates. The computed relevances are a relative score from the interval `[0, 1]`.
     fn select_key_phrases<F>(
-        &mut self,
+        &self,
+        relevance_maps: &mut RelevanceMaps,
         candidates: &[String],
         smbert: F,
         max_key_phrases: usize,
@@ -131,22 +101,14 @@ impl CoiPointKeyPhrases for PositiveCoi {
         Self: CoiPoint,
         F: Fn(&str) -> Result<Embedding, Error>,
     {
-        let candidates = unique_candidates(self, candidates, smbert);
-        let (similarity, normalized) = similarities(self, &candidates);
-        let selected = is_selected(normalized, max_key_phrases, gamma);
-        select(self, candidates, selected, similarity);
+        relevance_maps.select_key_phrases(self, candidates, smbert, max_key_phrases, gamma);
     }
 }
 
 impl CoiPointKeyPhrases for NegativeCoi {
-    fn key_phrases(&self) -> &BTreeSet<KeyPhrase> {
-        &EMPTY_KEY_PHRASES
-    }
-
-    fn set_key_phrases(&mut self, _key_phrases: BTreeSet<KeyPhrase>) {}
-
     fn select_key_phrases<F>(
-        &mut self,
+        &self,
+        _relevance_maps: &mut RelevanceMaps,
         _candidates: &[String],
         _smbert: F,
         _max_key_phrases: usize,
@@ -158,24 +120,135 @@ impl CoiPointKeyPhrases for NegativeCoi {
     }
 }
 
-/// Filters the unique candidates wrt the existing key phrases.
-fn unique_candidates<CP, F>(coi: &CP, candidates: &[String], smbert: F) -> BTreeSet<KeyPhrase>
-where
-    CP: CoiPoint + CoiPointKeyPhrases,
-    F: Fn(&str) -> Result<Embedding, Error>,
-{
-    candidates
-        .iter()
-        .filter_map(|words| {
-            (!coi.key_phrases().contains(words))
-                .then(|| {
-                    smbert(words)
-                        .ok()
-                        .and_then(|point| KeyPhrase::new(words, point).ok())
-                })
-                .flatten()
-        })
-        .collect()
+impl RelevanceMaps {
+    /// Unites the key phrases and candidates of the coi.
+    fn unique<F>(&mut self, coi_id: CoiId, candidates: &[String], smbert: F) -> BTreeSet<KeyPhrase>
+    where
+        F: Fn(&str) -> Result<Embedding, Error>,
+    {
+        let mut key_phrases = self
+            .remove_relevances(coi_id)
+            .map(|relevances| {
+                relevances
+                    .into_iter()
+                    .map(|relevance| {
+                        self.remove_key_phrases(relevance, coi_id)
+                            .unwrap_or_default()
+                    })
+                    .flatten()
+                    .collect::<BTreeSet<_>>()
+            })
+            .unwrap_or_default();
+
+        for candidate in candidates {
+            if !key_phrases.contains(candidate) {
+                if let Ok(Ok(candidate)) =
+                    smbert(candidate).map(|point| KeyPhrase::new(candidate, point))
+                {
+                    key_phrases.insert(candidate);
+                }
+            }
+        }
+
+        key_phrases
+    }
+
+    /// Selects the determined key phrases.
+    fn select(
+        &mut self,
+        coi_id: CoiId,
+        key_phrases: BTreeSet<KeyPhrase>,
+        selected: Vec<bool>,
+        similarity: Array2<f32>,
+    ) {
+        let relevances = selected
+            .iter()
+            .zip(similarity.slice(s![.., -1]))
+            .filter_map(|(is_selected, similarity)| is_selected.then(|| similarity))
+            .copied();
+        let max = relevances.clone().reduce(f32::max).unwrap_or_default();
+        let relevances = relevances.map(|relevance| {
+            (relevance > 0.)
+                .then(|| Relevance::new((relevance / max).max(0.).min(1.)).unwrap(/* finite by construction */))
+                .unwrap_or_default()
+        });
+
+        for (key_phrase, relevance) in selected
+            .iter()
+            .zip(key_phrases)
+            .filter_map(|(is_selected, key_phrase)| is_selected.then(|| key_phrase))
+            .zip(relevances)
+        {
+            self.insert_relevance(coi_id, relevance);
+            self.insert_key_phrase(relevance, coi_id, key_phrase);
+        }
+    }
+
+    /// Selects the most relevant key phrases for the coi.
+    ///
+    /// The most relevant key phrases are selected from the set of key phrases of the coi and the
+    /// candidates. The computed relevances are a relative score from the interval `[0, 1]`.
+    fn select_key_phrases<CP, F>(
+        &mut self,
+        coi: &CP,
+        candidates: &[String],
+        smbert: F,
+        max_key_phrases: usize,
+        gamma: f32,
+    ) where
+        CP: CoiPoint,
+        F: Fn(&str) -> Result<Embedding, Error>,
+    {
+        let key_phrases = self.unique(coi.id(), candidates, smbert);
+        let (similarity, normalized) = similarities(&key_phrases, coi.point());
+        let selected = is_selected(normalized, max_key_phrases, gamma);
+        self.select(coi.id(), key_phrases, selected, similarity);
+    }
+
+    /// Selects the top key phrases from the cois, sorted in descending relevance.
+    ///
+    /// The selected key phrases and their relevances are removed from the maps of this system.
+    #[allow(dead_code)]
+    pub(super) fn select_top_key_phrases<CP: CoiPoint + CoiPointStats>(
+        &mut self,
+        cois: &[CP],
+        top: usize,
+        horizon: Duration,
+        penalty: &[f32],
+    ) -> Vec<KeyPhrase> {
+        self.compute_relevances(cois, horizon, penalty);
+        // TODO: refactor once pop_last() etc are stabilized for BTreeMap
+        let (relevance_to_coi, key_phrases) = self
+            .iter_key_phrases()
+            .map(|(relevance, coi_id, key_phrases)| {
+                key_phrases
+                    .iter()
+                    .map(move |key_phrase| ((relevance, coi_id), key_phrase.clone()))
+            })
+            .flatten()
+            .rev()
+            .take(top)
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+
+        for ((relevance, coi_id), key_phrase) in
+            relevance_to_coi.into_iter().zip(key_phrases.iter())
+        {
+            if let Some(key_phrases) = self.get_mut_key_phrases(relevance, coi_id) {
+                key_phrases.retain(|this| this != key_phrase);
+                if key_phrases.is_empty() {
+                    self.remove_key_phrases(relevance, coi_id);
+                    if let Some(relevances) = self.get_mut_relevances(coi_id) {
+                        relevances.remove(&relevance);
+                        if relevances.is_empty() {
+                            self.remove_relevances(coi_id);
+                        }
+                    }
+                }
+            }
+        }
+
+        key_phrases
+    }
 }
 
 /// Reduces the matrix along the axis while skipping the diagonal elements.
@@ -223,25 +296,20 @@ where
         .map(|(arg, _)| arg)
 }
 
-/// Computes the pairwise similarity and their normalizations of the key phrases.
+/// Computes the pairwise similarity matrix and its normalization of the key phrases.
 ///
-/// The matrices are of shape `(key_phrases_len + candidates_len, key_phrases_len +
-/// candidates_len + 1)` with the following blockwise layout:
-/// ```text
-/// [[sim(kp, kp),   sim(kp, cand),   sim(kp, coi)  ],
-///  [sim(cand, kp), sim(cand, cand), sim(cand, coi)]]
-/// ```
-fn similarities<CP>(coi: &CP, candidates: &BTreeSet<KeyPhrase>) -> (Array2<f32>, Array2<f32>)
-where
-    CP: CoiPoint + CoiPointKeyPhrases,
-{
-    let len = coi.key_phrases().len() + candidates.len();
+/// The matrices are of shape `(key_phrases_len, key_phrases_len + 1)` where the last column
+/// holds the similarities between the key phrases and the coi point.
+fn similarities(
+    key_phrases: &BTreeSet<KeyPhrase>,
+    coi_point: &Embedding,
+) -> (Array2<f32>, Array2<f32>) {
+    let len = key_phrases.len();
     let similarity = pairwise_cosine_similarity(
-        coi.key_phrases()
+        key_phrases
             .iter()
-            .chain(candidates.iter())
             .map(|key_phrase| key_phrase.point().view())
-            .chain(once(coi.point().view())),
+            .chain(once(coi_point.view())),
     )
     .slice_move(s![..len, ..]);
     debug_assert!(similarity.iter().copied().all(f32::is_finite));
@@ -270,10 +338,7 @@ where
 }
 
 /// Determines which key phrases should be selected.
-fn is_selected<S>(normalized: ArrayBase<S, Ix2>, max_key_phrases: usize, gamma: f32) -> Vec<bool>
-where
-    S: Data<Elem = f32>,
-{
+fn is_selected(normalized: Array2<f32>, max_key_phrases: usize, gamma: f32) -> Vec<bool> {
     let len = normalized.len_of(Axis(0));
     if len <= max_key_phrases {
         return vec![true; len];
@@ -290,13 +355,13 @@ where
                     f32::MIN
                 } else {
                     let max = selected
-                            .iter()
-                            .zip(normalized)
-                            .filter_map(|(is_selected, normalized)| {
-                                is_selected.then(|| *normalized)
-                            })
-                            .reduce(f32::max)
-                            .unwrap(/* at least one key phrase is selected */);
+                        .iter()
+                        .zip(normalized)
+                        .filter_map(|(is_selected, normalized)| {
+                            is_selected.then(|| *normalized)
+                        })
+                        .reduce(f32::max)
+                        .unwrap(/* at least one key phrase is selected */);
                     gamma * normalized.slice(s![-1]).into_scalar() - (1. - gamma) * max
                 }
             },
@@ -307,142 +372,99 @@ where
     selected
 }
 
-/// Selects the determined key phrases.
-fn select<CP, S>(
-    coi: &mut CP,
-    candidates: BTreeSet<KeyPhrase>,
-    selected: Vec<bool>,
-    similarity: ArrayBase<S, Ix2>,
-) where
-    CP: CoiPoint + CoiPointKeyPhrases,
-    S: Data<Elem = f32>,
-{
-    let relevance = selected
-        .iter()
-        .zip(similarity.slice(s![.., -1]))
-        .filter_map(|(is_selected, similarity)| is_selected.then(|| similarity))
-        .copied();
-    let max = relevance.clone().reduce(f32::max).unwrap_or_default();
-    let relevance = relevance.map(|relevance| {
-        (relevance > 0.)
-            .then(|| (relevance / max).clamp(0., 1.))
-            .unwrap_or_default()
-    });
-
-    let key_phrases = selected
-        .iter()
-        .zip(
-            coi.key_phrases()
-                .iter()
-                .map(Cow::Borrowed)
-                .chain(candidates.into_iter().map(Cow::Owned)),
-        )
-        .filter_map(|(is_selected, key_phrase)| is_selected.then(|| key_phrase.into_owned()))
-        .zip(relevance)
-        .filter_map(|(key_phrase, relevance)| key_phrase.with_relevance(relevance).ok())
-        .collect();
-    coi.set_key_phrases(key_phrases);
-}
-
-/// Selects the top key phrases from the cois.
-#[allow(dead_code)]
-fn select_top_key_phrases<CP, F>(
-    cois: &mut [CP],
-    top: usize,
-    smbert: F,
-    config: &Configuration,
-) -> Vec<String>
-where
-    CP: CoiPoint + CoiPointKeyPhrases + CoiPointStats,
-    F: Copy + Fn(&str) -> Result<Embedding, Error>,
-{
-    if top == 0 {
-        return Vec::new();
-    }
-
-    let relevances = compute_relevances(cois, config.horizon);
-    let mut relevant_key_phrases = cois
-        .iter_mut()
-        .zip(relevances)
-        .map(|(coi, relevance)| {
-            coi.select_key_phrases(&[], smbert, config.max_key_phrases, config.gamma);
-            let mut key_phrases = coi
-                .key_phrases()
-                .iter()
-                .map(|key_phrase| (key_phrase.words(), key_phrase.relevance()))
-                .collect::<Vec<_>>();
-            key_phrases.sort_unstable_by(|(_, this), (_, other)| {
-                this.partial_cmp(other).unwrap(/* relevance is never nan */).reverse()
-            });
-            key_phrases.into_iter().zip(config.penalty.iter()).map(
-                move |((key_phrase, _), &penalty)| {
-                    (key_phrase, (relevance * penalty).max(f32::MIN))
-                },
-            )
-        })
-        .flatten()
-        .collect::<Vec<_>>();
-    relevant_key_phrases.sort_unstable_by(|(_, this), (_, other)| this.partial_cmp(other).unwrap(/* penalized relevance is never nan */).reverse());
-    relevant_key_phrases
-        .iter()
-        .map(|(key_phrase, _)| key_phrase.to_string())
-        .take(top)
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
+    use itertools::izip;
     use ndarray::arr1;
 
-    use crate::coi::utils::tests::create_pos_cois;
+    use crate::coi::{config::Configuration, utils::tests::create_pos_cois};
     use test_utils::assert_approx_eq;
 
     use super::*;
 
     #[test]
     fn test_select_key_phrases_empty() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
+        let mut maps = RelevanceMaps::default();
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
         let candidates = &[];
         let smbert = |_: &str| unreachable!();
-        coi[0].select_key_phrases(candidates, smbert, 3, 0.9);
-        assert!(coi[0].key_phrases().is_empty());
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
+        );
+        assert!(maps.relevances_is_empty());
+        assert!(maps.key_phrases_is_empty());
+    }
+
+    impl RelevanceMaps {
+        fn new<const N: usize>(
+            ids: [CoiId; N],
+            relevances: [f32; N],
+            key_phrases: Vec<KeyPhrase>,
+        ) -> Self {
+            assert!(IntoIterator::into_iter(relevances).all(f32::is_finite));
+            assert_eq!(key_phrases.len(), N);
+
+            let mut maps = Self::default();
+            for (coi_id, relevance, key_phrase) in izip!(ids, relevances, key_phrases) {
+                let relevance = Relevance::new(relevance).unwrap();
+                maps.insert_relevance(coi_id, relevance);
+                maps.insert_key_phrase(relevance, coi_id, key_phrase);
+            }
+
+            maps
+        }
     }
 
     #[test]
     fn test_select_key_phrases_no_candidates() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[1., 1., 1.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.clone());
+        ];
+        let mut maps = RelevanceMaps::new([cois[0].id; 2], [0.; 2], key_phrases.to_vec());
         let candidates = &[];
         let smbert = |_: &str| unreachable!();
-        coi[0].select_key_phrases(candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            1.,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.8164967,
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.8164967, 1.]);
+        assert_eq!(maps.key_phrases_len(), 2);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[1..],
         );
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[..1],
+        );
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_key_phrases_only_candidates() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[1., 1., 1.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
+        ];
+        let mut maps = RelevanceMaps::default();
         let candidates = key_phrases
             .iter()
             .map(|key_phrase| key_phrase.words().to_string())
@@ -455,34 +477,42 @@ mod tests {
                 })
                 .unwrap()
         };
-        coi[0].select_key_phrases(&candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            1.,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            &candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.8164967,
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.8164967, 1.]);
+        assert_eq!(maps.key_phrases_len(), 2);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[1..],
         );
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[..1],
+        );
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_key_phrases_max() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let mut key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[2., 1., 1.])).unwrap(),
             KeyPhrase::new("test", arr1(&[1., 1., 1.])).unwrap(),
             KeyPhrase::new("words", arr1(&[2., 1., 0.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.iter().cloned().take(2).collect());
-        let candidates = key_phrases
+        ];
+        let mut maps = RelevanceMaps::new([cois[0].id; 2], [0.; 2], key_phrases[..2].to_vec());
+        let candidates = key_phrases[2..]
             .iter()
-            .skip(2)
             .map(|key_phrase| key_phrase.words().to_string())
             .collect::<Vec<_>>();
         let smbert = |words: &str| {
@@ -493,38 +523,44 @@ mod tests {
                 })
                 .unwrap()
         };
-        coi[0].select_key_phrases(&candidates, smbert, 3, 0.9);
-        assert!(key_phrases.remove("test"));
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            0.7905694,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            &candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.91287094,
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.7905694, 0.91287094, 1.]);
+        assert_eq!(maps.key_phrases_len(), 3);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[..1],
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("words").unwrap().relevance(),
-            1.,
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[1..2],
         );
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[3..],
+        );
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_key_phrases_duplicate() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[1., 1., 1.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
-        let candidates = key_phrases
+        ];
+        let mut maps = RelevanceMaps::new([cois[0].id], [0.], key_phrases[..1].to_vec());
+        let candidates = key_phrases[1..]
             .iter()
-            .skip(1)
             .map(|key_phrase| key_phrase.words().to_string())
             .cycle()
             .take(2)
@@ -537,32 +573,40 @@ mod tests {
                 })
                 .unwrap()
         };
-        coi[0].select_key_phrases(&candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            1.,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            &candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.8164967,
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.8164967, 1.]);
+        assert_eq!(maps.key_phrases_len(), 2);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[1..],
         );
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[..1],
+        );
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_key_phrases_orthogonal() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[0., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[0., 0., 1.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
-        let candidates = key_phrases
+        ];
+        let mut maps = RelevanceMaps::new([cois[0].id], [0.], key_phrases[..1].to_vec());
+        let candidates = key_phrases[1..]
             .iter()
-            .skip(1)
             .map(|key_phrase| key_phrase.words().to_string())
             .collect::<Vec<_>>();
         let smbert = |words: &str| {
@@ -573,32 +617,33 @@ mod tests {
                 })
                 .unwrap()
         };
-        coi[0].select_key_phrases(&candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            0.,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            &candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.,
-        );
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.]);
+        assert_eq!(maps.key_phrases_len(), 1);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(maps[(relevances.next().unwrap(), cois[0].id)], key_phrases);
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_key_phrases_positive_similarity() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[1., 1., 1.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
-        let candidates = key_phrases
+        ];
+        let mut maps = RelevanceMaps::new([cois[0].id], [0.], key_phrases[..1].to_vec());
+        let candidates = key_phrases[1..]
             .iter()
-            .skip(1)
             .map(|key_phrase| key_phrase.words().to_string())
             .collect::<Vec<_>>();
         let smbert = |words: &str| {
@@ -609,32 +654,40 @@ mod tests {
                 })
                 .unwrap()
         };
-        coi[0].select_key_phrases(&candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            1.,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            &candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.8164967,
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.8164967, 1.]);
+        assert_eq!(maps.key_phrases_len(), 2);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[1..],
         );
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[..1],
+        );
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_key_phrases_negative_similarity() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[-1., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[-1., 1., 1.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
-        let candidates = key_phrases
+        ];
+        let mut maps = RelevanceMaps::new([cois[0].id], [0.], key_phrases[..1].to_vec());
+        let candidates = key_phrases[1..]
             .iter()
-            .skip(1)
             .map(|key_phrase| key_phrase.words().to_string())
             .collect::<Vec<_>>();
         let smbert = |words: &str| {
@@ -645,32 +698,33 @@ mod tests {
                 })
                 .unwrap()
         };
-        coi[0].select_key_phrases(&candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            0.,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            &candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.,
-        );
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.]);
+        assert_eq!(maps.key_phrases_len(), 1);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(maps[(relevances.next().unwrap(), cois[0].id)], key_phrases);
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_key_phrases_mixed_similarity() {
-        let mut coi = create_pos_cois(&[[1., 0., 0.]]);
-        let key_phrases = IntoIterator::into_iter([
+        let cois = create_pos_cois(&[[1., 0., 0.]]);
+        let key_phrases = [
             KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap(),
             KeyPhrase::new("phrase", arr1(&[-1., 1., 1.])).unwrap(),
-        ])
-        .collect::<BTreeSet<_>>();
-        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
-        let candidates = key_phrases
+        ];
+        let mut maps = RelevanceMaps::new([cois[0].id], [0.], key_phrases[..1].to_vec());
+        let candidates = key_phrases[1..]
             .iter()
-            .skip(1)
             .map(|key_phrase| key_phrase.words().to_string())
             .collect::<Vec<_>>();
         let smbert = |words: &str| {
@@ -681,107 +735,112 @@ mod tests {
                 })
                 .unwrap()
         };
-        coi[0].select_key_phrases(&candidates, smbert, 3, 0.9);
-        assert_eq!(coi[0].key_phrases(), &key_phrases);
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("key").unwrap().relevance(),
-            1.,
+        let config = Configuration::default();
+
+        maps.select_key_phrases(
+            &cois[0],
+            &candidates,
+            smbert,
+            config.max_key_phrases,
+            config.gamma,
         );
-        assert_approx_eq!(
-            f32,
-            coi[0].key_phrases().get("phrase").unwrap().relevance(),
-            0.,
+        assert_eq!(maps.relevances_len(), 1);
+        assert_approx_eq!(f32, maps[cois[0].id], [0., 1.]);
+        assert_eq!(maps.key_phrases_len(), 2);
+        let mut relevances = maps[cois[0].id].iter().copied();
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[1..],
         );
+        assert_eq!(
+            maps[(relevances.next().unwrap(), cois[0].id)],
+            key_phrases[..1],
+        );
+        assert!(relevances.next().is_none());
     }
 
     #[test]
     fn test_select_top_key_phrases_empty_cois() {
-        let mut cois = create_pos_cois(&[] as &[[f32; 0]]);
-        let smbert = |_: &str| unreachable!();
+        let cois = create_pos_cois(&[] as &[[f32; 0]]);
+        let mut maps = RelevanceMaps::default();
         let config = Configuration::default();
-        let top_key_phrases = select_top_key_phrases(&mut cois, usize::MAX, smbert, &config);
+
+        let top_key_phrases =
+            maps.select_top_key_phrases(&cois, usize::MAX, config.horizon, &config.penalty);
         assert!(top_key_phrases.is_empty());
+        assert!(maps.relevances_is_empty());
+        assert!(maps.key_phrases_is_empty());
     }
 
     #[test]
     fn test_select_top_key_phrases_empty_key_phrases() {
-        let mut cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
-        let smbert = |_: &str| unreachable!();
+        let cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
+        let mut maps = RelevanceMaps::default();
         let config = Configuration::default();
-        let top_key_phrases = select_top_key_phrases(&mut cois, usize::MAX, smbert, &config);
+
+        let top_key_phrases =
+            maps.select_top_key_phrases(&cois, usize::MAX, config.horizon, &config.penalty);
         assert!(top_key_phrases.is_empty());
+        assert_eq!(maps.relevances_len(), 3);
+        assert!(maps.key_phrases_is_empty());
     }
 
     #[test]
     fn test_select_top_key_phrases_zero() {
-        let mut cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
-        cois[0].set_key_phrases(
-            IntoIterator::into_iter([
-                KeyPhrase::new("key", arr1(&[1., 1., 1.])).unwrap(),
-                KeyPhrase::new("phrase", arr1(&[2., 1., 1.])).unwrap(),
-                KeyPhrase::new("words", arr1(&[3., 1., 1.])).unwrap(),
-            ])
-            .collect(),
+        let cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
+        let key_phrases = [
+            KeyPhrase::new("key", arr1(&[1., 1., 1.])).unwrap(),
+            KeyPhrase::new("phrase", arr1(&[2., 1., 1.])).unwrap(),
+            KeyPhrase::new("words", arr1(&[3., 1., 1.])).unwrap(),
+        ];
+        let mut maps = RelevanceMaps::new(
+            [cois[0].id, cois[1].id, cois[2].id],
+            [0.; 3],
+            key_phrases.into(),
         );
-        cois[1].set_key_phrases(
-            IntoIterator::into_iter([
-                KeyPhrase::new("and", arr1(&[1., 4., 1.])).unwrap(),
-                KeyPhrase::new("more", arr1(&[1., 5., 1.])).unwrap(),
-                KeyPhrase::new("stuff", arr1(&[1., 6., 1.])).unwrap(),
-            ])
-            .collect(),
-        );
-        cois[2].set_key_phrases(
-            IntoIterator::into_iter([
-                KeyPhrase::new("still", arr1(&[1., 1., 7.])).unwrap(),
-                KeyPhrase::new("not", arr1(&[1., 1., 8.])).unwrap(),
-                KeyPhrase::new("enough", arr1(&[1., 1., 9.])).unwrap(),
-            ])
-            .collect(),
-        );
-        let smbert = |_: &str| unreachable!();
         let config = Configuration::default();
-        let top_key_phrases = select_top_key_phrases(&mut cois, 0, smbert, &config);
+
+        let top_key_phrases =
+            maps.select_top_key_phrases(&cois, 0, config.horizon, &config.penalty);
         assert!(top_key_phrases.is_empty());
+        assert_eq!(maps.relevances_len(), 3);
+        assert_eq!(maps.key_phrases_len(), 3);
     }
 
     #[test]
     fn test_select_top_key_phrases_all() {
         let mut cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
-        cois[0].set_key_phrases(
-            IntoIterator::into_iter([
-                KeyPhrase::new("key", arr1(&[1., 1., 1.])).unwrap(),
-                KeyPhrase::new("phrase", arr1(&[2., 1., 1.])).unwrap(),
-                KeyPhrase::new("words", arr1(&[3., 1., 1.])).unwrap(),
-            ])
-            .collect(),
-        );
         cois[0].update_stats(Duration::from_secs(1));
-        cois[1].set_key_phrases(
-            IntoIterator::into_iter([
-                KeyPhrase::new("and", arr1(&[1., 4., 1.])).unwrap(),
-                KeyPhrase::new("more", arr1(&[1., 5., 1.])).unwrap(),
-                KeyPhrase::new("stuff", arr1(&[1., 6., 1.])).unwrap(),
-            ])
-            .collect(),
-        );
         cois[1].update_stats(Duration::from_secs(2));
-        cois[2].set_key_phrases(
-            IntoIterator::into_iter([
-                KeyPhrase::new("still", arr1(&[1., 1., 7.])).unwrap(),
-                KeyPhrase::new("not", arr1(&[1., 1., 8.])).unwrap(),
-                KeyPhrase::new("enough", arr1(&[1., 1., 9.])).unwrap(),
-            ])
-            .collect(),
-        );
         cois[2].update_stats(Duration::from_secs(3));
-        let smbert = |_: &str| todo!();
+        let key_phrases = [
+            KeyPhrase::new("key", arr1(&[1., 1., 1.])).unwrap(),
+            KeyPhrase::new("phrase", arr1(&[2., 1., 1.])).unwrap(),
+            KeyPhrase::new("words", arr1(&[3., 1., 1.])).unwrap(),
+            KeyPhrase::new("and", arr1(&[1., 4., 1.])).unwrap(),
+            KeyPhrase::new("more", arr1(&[1., 5., 1.])).unwrap(),
+            KeyPhrase::new("stuff", arr1(&[1., 6., 1.])).unwrap(),
+            KeyPhrase::new("still", arr1(&[1., 1., 7.])).unwrap(),
+            KeyPhrase::new("not", arr1(&[1., 1., 8.])).unwrap(),
+            KeyPhrase::new("enough", arr1(&[1., 1., 9.])).unwrap(),
+        ];
+        let mut maps = RelevanceMaps::new(
+            [
+                cois[0].id, cois[0].id, cois[0].id, cois[1].id, cois[1].id, cois[1].id, cois[2].id,
+                cois[2].id, cois[2].id,
+            ],
+            [0.; 9],
+            key_phrases.into(),
+        );
         let config = Configuration::default();
-        let top_key_phrases = select_top_key_phrases(&mut cois, usize::MAX, smbert, &config);
+
+        let top_key_phrases =
+            maps.select_top_key_phrases(&cois, usize::MAX, config.horizon, &config.penalty);
         assert_eq!(
             top_key_phrases,
             ["enough", "stuff", "words", "not", "more", "phrase", "still", "and", "key"],
-        )
+        );
+        assert!(maps.relevances_is_empty());
+        assert!(maps.key_phrases_is_empty());
     }
 }

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -58,21 +58,9 @@ impl Borrow<String> for KeyPhrase {
     }
 }
 
-impl Borrow<str> for KeyPhrase {
-    fn borrow(&self) -> &str {
-        self.words.as_str()
-    }
-}
-
 impl PartialEq<&str> for KeyPhrase {
     fn eq(&self, other: &&str) -> bool {
         self.words.eq(other)
-    }
-}
-
-impl PartialEq<KeyPhrase> for &str {
-    fn eq(&self, other: &KeyPhrase) -> bool {
-        other.words.eq(self)
     }
 }
 

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -76,7 +76,7 @@ impl PartialEq<KeyPhrase> for &str {
     }
 }
 
-pub(crate) trait CoiPointKeyPhrases {
+pub(crate) trait CoiPointKeyPhrases: CoiPoint {
     fn select_key_phrases<F>(
         &self,
         relevances: &mut Relevances,
@@ -85,7 +85,6 @@ pub(crate) trait CoiPointKeyPhrases {
         max_key_phrases: usize,
         gamma: f32,
     ) where
-        Self: CoiPoint,
         F: Fn(&str) -> Result<Embedding, Error>;
 }
 

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -20,19 +20,9 @@ pub(crate) trait CoiPointMerge: CoiPoint {
 impl CoiPointMerge for PositiveCoi {
     fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(self.point.view(), other.point.view()).into();
-        let key_phrases = self
-            .key_phrases
-            .into_iter()
-            .chain(other.key_phrases)
-            .collect();
         let stats = self.stats.merge(other.stats);
 
-        Self {
-            id,
-            point,
-            key_phrases,
-            stats,
-        }
+        Self { id, point, stats }
     }
 }
 

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -22,6 +22,11 @@ impl CoiPointMerge for PositiveCoi {
         let point = mean(self.point.view(), other.point.view()).into();
         let stats = self.stats.merge(other.stats);
 
+        // NOTE: the key phrases are currently not merged. if the new id is equal to one of the old
+        // ids, then then key phrases of the new coi will be the same as in that old coi. if the new
+        // id is different, then the new coi will have no key phrases. all key phrases from old cois
+        // with unused ids will stay forever in the coi system's relevances maps.
+
         Self { id, point, stats }
     }
 }

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -9,7 +9,7 @@ mod utils;
 
 #[cfg(test)]
 pub(crate) use self::{
-    relevance::RelevanceMaps,
+    relevance::Relevances,
     system::{compute_coi, update_user_interests, CoiSystemError},
 };
 pub(crate) use config::Configuration;

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -2,14 +2,18 @@ mod config;
 pub(crate) mod key_phrase;
 mod merge;
 pub(crate) mod point;
+mod relevance;
 mod stats;
 mod system;
 mod utils;
 
+#[cfg(test)]
+pub(crate) use self::{
+    relevance::RelevanceMaps,
+    system::{compute_coi, update_user_interests, CoiSystemError},
+};
 pub(crate) use config::Configuration;
 pub(crate) use merge::reduce_cois;
-#[cfg(test)]
-pub(crate) use system::{compute_coi, update_user_interests, CoiSystemError};
 pub(crate) use system::{CoiSystem, NeutralCoiSystem};
 
 use derive_more::From;
@@ -43,6 +47,6 @@ pub(crate) enum CoiError {
     EmptyKeyPhrase,
     /// A key phrase has non-finite embedding values: {0:#?}
     NonFiniteKeyPhrase(ArcEmbedding),
-    /// A key phrase has a non-normalized relevance score: {0}
-    NonNormalizedKeyPhrase(f32),
+    /// A computed relevance score isn't finite.
+    NonFiniteRelevance,
 }

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -1,10 +1,10 @@
-use std::{collections::BTreeSet, time::Duration};
+use std::time::Duration;
 
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    coi::{key_phrase::KeyPhrase, stats::CoiStats, CoiId},
+    coi::{stats::CoiStats, CoiId},
     embedding::utils::{l2_distance, Embedding},
 };
 
@@ -20,8 +20,6 @@ pub(crate) struct PositiveCoi {
     pub(super) id: CoiId,
     #[obake(cfg(">=0.0"))]
     pub(super) point: Embedding,
-    #[obake(cfg(">=0.3"))]
-    pub(super) key_phrases: BTreeSet<KeyPhrase>,
     #[obake(cfg(">=0.3"))]
     #[derivative(PartialEq = "ignore")]
     pub(super) stats: CoiStats,
@@ -58,7 +56,6 @@ impl From<PositiveCoi_v0_2_0> for PositiveCoi {
         Self {
             id: coi.id,
             point: coi.point,
-            key_phrases: BTreeSet::default(),
             stats: CoiStats::default(),
         }
     }
@@ -71,8 +68,7 @@ pub(crate) struct NegativeCoi {
 }
 
 pub(crate) trait CoiPoint {
-    fn new(id: CoiId, point: Embedding, key_phrases: BTreeSet<KeyPhrase>, viewed: Duration)
-        -> Self;
+    fn new(id: CoiId, point: Embedding, viewed: Duration) -> Self;
 
     fn id(&self) -> CoiId;
 
@@ -105,12 +101,7 @@ macro_rules! coi_point_default_impls {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_0_0 {
-    fn new(
-        id: CoiId,
-        point: Embedding,
-        _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Duration,
-    ) -> Self {
+    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
         Self {
             id,
             point,
@@ -124,12 +115,7 @@ impl CoiPoint for PositiveCoi_v0_0_0 {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_1_0 {
-    fn new(
-        id: CoiId,
-        point: Embedding,
-        _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Duration,
-    ) -> Self {
+    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
         Self {
             id,
             point,
@@ -143,12 +129,7 @@ impl CoiPoint for PositiveCoi_v0_1_0 {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_2_0 {
-    fn new(
-        id: CoiId,
-        point: Embedding,
-        _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Duration,
-    ) -> Self {
+    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
         Self { id, point }
     }
 
@@ -156,16 +137,10 @@ impl CoiPoint for PositiveCoi_v0_2_0 {
 }
 
 impl CoiPoint for PositiveCoi {
-    fn new(
-        id: CoiId,
-        point: Embedding,
-        key_phrases: BTreeSet<KeyPhrase>,
-        viewed: Duration,
-    ) -> Self {
+    fn new(id: CoiId, point: Embedding, viewed: Duration) -> Self {
         Self {
             id,
             point,
-            key_phrases,
             stats: CoiStats::new(viewed),
         }
     }
@@ -174,12 +149,7 @@ impl CoiPoint for PositiveCoi {
 }
 
 impl CoiPoint for NegativeCoi {
-    fn new(
-        id: CoiId,
-        point: Embedding,
-        _key_phrases: BTreeSet<KeyPhrase>,
-        _viewed: Duration,
-    ) -> Self {
+    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
         Self { id, point }
     }
 

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -45,7 +45,7 @@ pub(crate) struct Relevances {
 
 impl Relevances {
     /// Iterates over all tuples in ascending relevance.
-    pub fn iter(
+    pub(super) fn iter(
         &self,
     ) -> impl Iterator<Item = (CoiId, Relevance, &KeyPhrase)> + DoubleEndedIterator {
         self.relevance_to_key_phrase
@@ -59,7 +59,7 @@ impl Relevances {
     }
 
     /// Inserts the tuple.
-    pub fn insert(&mut self, coi_id: CoiId, relevance: Relevance, key_phrase: KeyPhrase) {
+    pub(super) fn insert(&mut self, coi_id: CoiId, relevance: Relevance, key_phrase: KeyPhrase) {
         self.coi_to_relevance
             .entry(coi_id)
             .or_default()
@@ -71,7 +71,7 @@ impl Relevances {
     }
 
     /// Removes all tuples with the given id.
-    pub fn remove(&mut self, coi_id: CoiId) -> Option<BTreeSet<KeyPhrase>> {
+    pub(super) fn remove(&mut self, coi_id: CoiId) -> Option<BTreeSet<KeyPhrase>> {
         self.coi_to_relevance
             .remove(&coi_id)
             .map(|relevances| {
@@ -90,7 +90,7 @@ impl Relevances {
     }
 
     /// Removes the tuple and cleans up empty entries afterwards.
-    pub fn clean(&mut self, coi_id: CoiId, relevance: Relevance, key_phrase: &KeyPhrase) {
+    pub(super) fn clean(&mut self, coi_id: CoiId, relevance: Relevance, key_phrase: &KeyPhrase) {
         if let Some(key_phrases) = self.relevance_to_key_phrase.get_mut(&(relevance, coi_id)) {
             key_phrases.retain(|this| this != key_phrase);
             if key_phrases.is_empty() {
@@ -106,7 +106,7 @@ impl Relevances {
     }
 
     /// Replaces the relevances in the tuples with the given id.
-    pub fn replace(&mut self, coi_id: CoiId, mut relevances: Vec<Relevance>) {
+    pub(super) fn replace(&mut self, coi_id: CoiId, mut relevances: Vec<Relevance>) {
         if let Some(old_relevances) = self
             .coi_to_relevance
             .insert(coi_id, relevances.iter().copied().collect())

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -102,6 +102,27 @@ impl RelevanceMaps {
             .iter()
             .map(|(&(relevance, coi_id), key_phrases)| (relevance, coi_id, key_phrases.as_slice()))
     }
+
+    pub fn insert(&mut self, coi_id: CoiId, relevance: Relevance, key_phrase: KeyPhrase) {
+        self.insert_relevance(coi_id, relevance);
+        self.insert_key_phrase(relevance, coi_id, key_phrase);
+    }
+
+    pub fn remove(&mut self, coi_id: CoiId) -> Option<BTreeSet<KeyPhrase>> {
+        self.remove_relevances(coi_id)
+            .map(|relevances| {
+                let key_phrases = relevances
+                    .into_iter()
+                    .map(|relevance| {
+                        self.remove_key_phrases(relevance, coi_id)
+                            .unwrap_or_default()
+                    })
+                    .flatten()
+                    .collect::<BTreeSet<_>>();
+                (!key_phrases.is_empty()).then(|| key_phrases)
+            })
+            .flatten()
+    }
 }
 
 impl Index<CoiId> for RelevanceMaps {

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -1,0 +1,159 @@
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    ops::Index,
+};
+
+use derive_more::Into;
+
+use crate::coi::{key_phrase::KeyPhrase, CoiError, CoiId};
+
+/// A finite relevance score.
+#[derive(Clone, Copy, Debug, Default, Into, PartialEq, PartialOrd)]
+pub(crate) struct Relevance(f32);
+
+impl Relevance {
+    /// Creates a relevance score.
+    ///
+    /// # Errors
+    /// Fails if the relevance isn't finite.
+    pub fn new(relevance: f32) -> Result<Self, CoiError> {
+        if relevance.is_finite() {
+            Ok(Relevance(relevance))
+        } else {
+            Err(CoiError::NonFiniteRelevance)
+        }
+    }
+}
+
+impl Eq for Relevance {
+    // never nan by construction
+}
+
+#[allow(clippy::derive_ord_xor_partial_ord)]
+impl Ord for Relevance {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap(/* never nan by construction */)
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct RelevanceMaps {
+    coi_to_relevance: HashMap<CoiId, BTreeSet<Relevance>>,
+    relevance_to_key_phrase: BTreeMap<(Relevance, CoiId), Vec<KeyPhrase>>,
+}
+
+impl RelevanceMaps {
+    pub fn get_mut_relevances(&mut self, coi_id: CoiId) -> Option<&mut BTreeSet<Relevance>> {
+        self.coi_to_relevance.get_mut(&coi_id)
+    }
+
+    pub fn insert_relevance(&mut self, coi_id: CoiId, relevance: Relevance) {
+        self.coi_to_relevance
+            .entry(coi_id)
+            .or_default()
+            .insert(relevance);
+    }
+
+    pub fn insert_relevances(
+        &mut self,
+        coi_id: CoiId,
+        relevances: BTreeSet<Relevance>,
+    ) -> Option<BTreeSet<Relevance>> {
+        self.coi_to_relevance.insert(coi_id, relevances)
+    }
+
+    pub fn remove_relevances(&mut self, coi_id: CoiId) -> Option<BTreeSet<Relevance>> {
+        self.coi_to_relevance.remove(&coi_id)
+    }
+
+    pub fn get_mut_key_phrases(
+        &mut self,
+        relevance: Relevance,
+        coi_id: CoiId,
+    ) -> Option<&mut Vec<KeyPhrase>> {
+        self.relevance_to_key_phrase.get_mut(&(relevance, coi_id))
+    }
+
+    pub fn insert_key_phrase(
+        &mut self,
+        relevance: Relevance,
+        coi_id: CoiId,
+        key_phrase: KeyPhrase,
+    ) {
+        self.relevance_to_key_phrase
+            .entry((relevance, coi_id))
+            .or_default()
+            .push(key_phrase);
+    }
+
+    pub fn remove_key_phrases(
+        &mut self,
+        relevance: Relevance,
+        coi_id: CoiId,
+    ) -> Option<Vec<KeyPhrase>> {
+        self.relevance_to_key_phrase.remove(&(relevance, coi_id))
+    }
+
+    pub fn iter_key_phrases(
+        &self,
+    ) -> impl Iterator<Item = (Relevance, CoiId, &[KeyPhrase])> + DoubleEndedIterator {
+        self.relevance_to_key_phrase
+            .iter()
+            .map(|(&(relevance, coi_id), key_phrases)| (relevance, coi_id, key_phrases.as_slice()))
+    }
+}
+
+impl Index<CoiId> for RelevanceMaps {
+    type Output = BTreeSet<Relevance>;
+
+    fn index(&self, coi_id: CoiId) -> &Self::Output {
+        &self.coi_to_relevance[&coi_id]
+    }
+}
+
+impl Index<(Relevance, CoiId)> for RelevanceMaps {
+    type Output = [KeyPhrase];
+
+    fn index(&self, (relevance, coi_id): (Relevance, CoiId)) -> &Self::Output {
+        &self.relevance_to_key_phrase[&(relevance, coi_id)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::once;
+
+    use ndarray::Ix;
+
+    use test_utils::ApproxEqIter;
+
+    use super::*;
+
+    impl RelevanceMaps {
+        pub fn relevances_len(&self) -> usize {
+            self.coi_to_relevance.len()
+        }
+
+        pub fn relevances_is_empty(&self) -> bool {
+            self.coi_to_relevance.is_empty()
+        }
+
+        pub fn key_phrases_len(&self) -> usize {
+            self.relevance_to_key_phrase.len()
+        }
+
+        pub fn key_phrases_is_empty(&self) -> bool {
+            self.relevance_to_key_phrase.is_empty()
+        }
+    }
+
+    impl<'a> ApproxEqIter<'a, f32> for &'a Relevance {
+        fn indexed_iter_logical_order(
+            self,
+            index_prefix: Vec<Ix>,
+        ) -> Box<dyn Iterator<Item = (Vec<Ix>, f32)> + 'a> {
+            Box::new(once((index_prefix, self.0)))
+        }
+    }
+}

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -72,7 +72,7 @@ impl CoiPointStats for NegativeCoi {
     fn update_stats(&mut self, _viewed: Duration) {}
 }
 
-/// Computes the relevance of the cois.
+/// Computes the relevances of the cois.
 ///
 /// The relevance of each coi is computed from its view count and view time relative to the
 /// other cois. It's an unnormalized score from the interval `[0, ∞)`.

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -176,7 +176,7 @@ mod tests {
         let penalty = Configuration::default().penalty;
 
         maps.compute_relevances(&cois, horizon, &penalty);
-        assert_eq!(maps.relevances_len(), 2);
+        assert_eq!(maps.relevances_len(), cois.len());
         assert_approx_eq!(f32, maps[cois[0].id], [0.]);
         assert_approx_eq!(f32, maps[cois[1].id], [0.]);
         assert!(maps.key_phrases_is_empty());
@@ -203,7 +203,7 @@ mod tests {
         let penalty = Configuration::default().penalty;
 
         maps.compute_relevances(&cois, horizon, &penalty);
-        assert_eq!(maps.relevances_len(), 3);
+        assert_eq!(maps.relevances_len(), cois.len());
         let penalty = dedup(penalty);
         assert_approx_eq!(
             f32,
@@ -236,7 +236,7 @@ mod tests {
         let penalty = Configuration::default().penalty;
 
         maps.compute_relevances(&cois, horizon, &penalty);
-        assert_eq!(maps.relevances_len(), 3);
+        assert_eq!(maps.relevances_len(), cois.len());
         let penalty = dedup(penalty);
         assert_approx_eq!(
             f32,
@@ -270,7 +270,7 @@ mod tests {
         let penalty = Configuration::default().penalty;
 
         maps.compute_relevances(&cois, horizon, &penalty);
-        assert_eq!(maps.relevances_len(), 3);
+        assert_eq!(maps.relevances_len(), cois.len());
         let penalty = dedup(penalty);
         assert_approx_eq!(
             f32,

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -3,7 +3,10 @@ use std::time::{Duration, SystemTime};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    coi::point::{CoiPoint, NegativeCoi, PositiveCoi},
+    coi::{
+        point::{CoiPoint, NegativeCoi, PositiveCoi},
+        relevance::{Relevance, RelevanceMaps},
+    },
     utils::{system_time_now, SECONDS_PER_DAY},
 };
 
@@ -72,28 +75,31 @@ impl CoiPointStats for NegativeCoi {
     fn update_stats(&mut self, _viewed: Duration) {}
 }
 
-/// Computes the relevances of the cois.
-///
-/// The relevance of each coi is computed from its view count and view time relative to the
-/// other cois. It's an unnormalized score from the interval `[0, ∞)`.
-#[allow(dead_code)]
-pub(super) fn compute_relevances<CP>(cois: &[CP], horizon: Duration) -> Vec<f32>
-where
-    CP: CoiPoint + CoiPointStats,
-{
-    let counts = cois.iter().map(|coi| coi.stats().view_count).sum::<usize>() as f32 + f32::EPSILON;
-    let times = cois
-        .iter()
-        .map(|coi| coi.stats().view_time)
-        .sum::<Duration>()
-        .as_secs_f32()
-        + f32::EPSILON;
-    let now = system_time_now();
-    const DAYS_SCALE: f32 = -0.1;
-    let horizon = (horizon.as_secs_f32() * DAYS_SCALE / SECONDS_PER_DAY).exp();
+impl RelevanceMaps {
+    /// Computes the relevances of the cois.
+    ///
+    /// The relevance of each coi is computed from its view count and view time relative to the
+    /// other cois. It's an unnormalized score from the interval `[0, ∞)`.
+    ///
+    /// The relevances in the maps are replaced by the penalized coi relevances.
+    #[allow(dead_code)]
+    pub(super) fn compute_relevances<CP>(&mut self, cois: &[CP], horizon: Duration, penalty: &[f32])
+    where
+        CP: CoiPoint + CoiPointStats,
+    {
+        let counts =
+            cois.iter().map(|coi| coi.stats().view_count).sum::<usize>() as f32 + f32::EPSILON;
+        let times = cois
+            .iter()
+            .map(|coi| coi.stats().view_time)
+            .sum::<Duration>()
+            .as_secs_f32()
+            + f32::EPSILON;
+        let now = system_time_now();
+        const DAYS_SCALE: f32 = -0.1;
+        let horizon = (horizon.as_secs_f32() * DAYS_SCALE / SECONDS_PER_DAY).exp();
 
-    cois.iter()
-        .map(|coi| {
+        for coi in cois {
             let CoiStats {
                 view_count: count,
                 view_time: time,
@@ -106,67 +112,179 @@ where
                 / SECONDS_PER_DAY)
                 .exp();
             let last = ((horizon - days) / (horizon - 1. - f32::EPSILON)).max(0.);
-            ((count + time) * last).max(0.).min(f32::MAX)
-        })
-        .collect()
+            let new_relevance = Relevance::new(((count + time) * last).max(0.).min(f32::MAX)).unwrap(/* finite by construction */);
+
+            let coi_id = coi.id();
+            let new_relevances = penalty
+                .iter()
+                .map(|&penalty| {
+                    Relevance::new(
+                    (f32::from(new_relevance) * penalty)
+                        .max(f32::MIN)
+                        .min(f32::MAX),
+                ).unwrap(/* finite by construction */)
+                })
+                .collect::<Vec<_>>();
+            if let Some(old_relevances) =
+                self.insert_relevances(coi_id, new_relevances.iter().copied().collect())
+            {
+                let key_phrases = old_relevances
+                    .into_iter()
+                    .map(|old_relevance| {
+                        self.remove_key_phrases(old_relevance, coi_id)
+                            .unwrap_or_default()
+                    })
+                    .flatten()
+                    .rev()
+                    .collect::<Vec<_>>();
+                for (new_relevance, key_phrase) in new_relevances.into_iter().zip(key_phrases) {
+                    self.insert_key_phrase(new_relevance, coi_id, key_phrase);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::coi::utils::tests::create_pos_cois;
+    use std::collections::BTreeSet;
+
+    use ndarray::Array1;
+
+    use crate::coi::{config::Configuration, utils::tests::create_pos_cois};
     use test_utils::assert_approx_eq;
 
     use super::*;
 
     #[test]
     fn test_compute_relevances_empty_cois() {
+        let mut maps = RelevanceMaps::default();
         let cois = create_pos_cois(&[[]]);
         let horizon = Duration::from_secs_f32(SECONDS_PER_DAY);
-        let weights = compute_relevances(&cois, horizon);
-        assert!(weights.is_empty());
+        let penalty = Configuration::default().penalty;
+
+        maps.compute_relevances(&cois, horizon, &penalty);
+        assert!(maps.relevances_is_empty());
+        assert!(maps.key_phrases_is_empty());
     }
 
     #[test]
     fn test_compute_relevances_zero_horizon() {
+        let mut maps = RelevanceMaps::default();
         let cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.]]);
         let horizon = Duration::ZERO;
-        let weights = compute_relevances(&cois, horizon);
-        assert_approx_eq!(f32, weights, [0., 0.]);
+        let penalty = Configuration::default().penalty;
+
+        maps.compute_relevances(&cois, horizon, &penalty);
+        assert_eq!(maps.relevances_len(), 2);
+        assert_approx_eq!(f32, maps[cois[0].id], [0.]);
+        assert_approx_eq!(f32, maps[cois[1].id], [0.]);
+        assert!(maps.key_phrases_is_empty());
+    }
+
+    fn dedup(vector: Vec<f32>) -> Array1<f32> {
+        assert!(vector.iter().copied().all(f32::is_finite));
+        vector
+            .iter()
+            .map(|&element| Relevance::new(element).unwrap())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(Into::into)
+            .collect()
     }
 
     #[test]
     fn test_compute_relevances_count() {
+        let mut maps = RelevanceMaps::default();
         let mut cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
         cois[1].stats.view_count += 1;
         cois[2].stats.view_count += 2;
         let horizon = Duration::from_secs_f32(SECONDS_PER_DAY);
-        let weights = compute_relevances(&cois, horizon);
-        assert_approx_eq!(f32, weights, [0.5, 0.6666667, 0.8333333], epsilon = 0.00001);
+        let penalty = Configuration::default().penalty;
+
+        maps.compute_relevances(&cois, horizon, &penalty);
+        assert_eq!(maps.relevances_len(), 3);
+        let penalty = dedup(penalty);
+        assert_approx_eq!(
+            f32,
+            maps[cois[0].id],
+            0.5 * penalty.clone(),
+            epsilon = 0.00001,
+        );
+        assert_approx_eq!(
+            f32,
+            maps[cois[1].id],
+            0.6666667 * penalty.clone(),
+            epsilon = 0.00001,
+        );
+        assert_approx_eq!(
+            f32,
+            maps[cois[2].id],
+            0.8333333 * penalty,
+            epsilon = 0.00001,
+        );
+        assert!(maps.key_phrases_is_empty());
     }
 
     #[test]
     fn test_compute_relevances_time() {
+        let mut maps = RelevanceMaps::default();
         let mut cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
         cois[1].stats.view_time += Duration::from_secs(10);
         cois[2].stats.view_time += Duration::from_secs(20);
         let horizon = Duration::from_secs_f32(SECONDS_PER_DAY);
-        let weights = compute_relevances(&cois, horizon);
-        assert_approx_eq!(f32, weights, [0.5, 0.6666667, 0.8333333], epsilon = 0.00001);
+        let penalty = Configuration::default().penalty;
+
+        maps.compute_relevances(&cois, horizon, &penalty);
+        assert_eq!(maps.relevances_len(), 3);
+        let penalty = dedup(penalty);
+        assert_approx_eq!(
+            f32,
+            maps[cois[0].id],
+            0.5 * penalty.clone(),
+            epsilon = 0.00001,
+        );
+        assert_approx_eq!(
+            f32,
+            maps[cois[1].id],
+            0.6666667 * penalty.clone(),
+            epsilon = 0.00001,
+        );
+        assert_approx_eq!(
+            f32,
+            maps[cois[2].id],
+            0.8333333 * penalty,
+            epsilon = 0.00001,
+        );
+        assert!(maps.key_phrases_is_empty());
     }
 
     #[test]
     fn test_compute_relevances_last() {
+        let mut maps = RelevanceMaps::default();
         let mut cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
         cois[0].stats.last_view -= Duration::from_secs_f32(0.5 * SECONDS_PER_DAY);
         cois[1].stats.last_view -= Duration::from_secs_f32(1.5 * SECONDS_PER_DAY);
         cois[2].stats.last_view -= Duration::from_secs_f32(2.5 * SECONDS_PER_DAY);
         let horizon = Duration::from_secs_f32(2. * SECONDS_PER_DAY);
-        let weights = compute_relevances(&cois, horizon);
+        let penalty = Configuration::default().penalty;
+
+        maps.compute_relevances(&cois, horizon, &penalty);
+        assert_eq!(maps.relevances_len(), 3);
+        let penalty = dedup(penalty);
         assert_approx_eq!(
             f32,
-            weights,
-            [0.48729968, 0.15438259, 0.],
+            maps[cois[0].id],
+            0.48729968 * penalty.clone(),
             epsilon = 0.00001,
         );
+        assert_approx_eq!(
+            f32,
+            maps[cois[1].id],
+            0.15438259 * penalty,
+            epsilon = 0.00001,
+        );
+        assert_approx_eq!(f32, maps[cois[2].id], [0.]);
+        assert!(maps.key_phrases_is_empty());
     }
 }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, ops::Deref, time::Duration};
+use std::{ops::Deref, time::Duration};
 
 use displaydoc::Display;
 use thiserror::Error;
@@ -9,6 +9,7 @@ use crate::{
         config::Configuration,
         key_phrase::CoiPointKeyPhrases,
         point::{find_closest_coi, find_closest_coi_mut, CoiPoint, UserInterests},
+        relevance::RelevanceMaps,
         stats::CoiPointStats,
         utils::{classify_documents_based_on_user_feedback, collect_matching_documents},
         CoiId,
@@ -31,12 +32,17 @@ pub(crate) enum CoiSystemError {
 pub(crate) struct CoiSystem {
     config: Configuration,
     smbert: SMBert,
+    relevance_maps: RelevanceMaps,
 }
 
 impl CoiSystem {
     /// Creates a new centre of interest system.
     pub(crate) fn new(config: Configuration, smbert: SMBert) -> Self {
-        Self { config, smbert }
+        Self {
+            config,
+            smbert,
+            relevance_maps: RelevanceMaps::default(),
+        }
     }
 }
 
@@ -50,16 +56,18 @@ impl systems::CoiSystem for CoiSystem {
     }
 
     fn update_user_interests(
-        &self,
+        &mut self,
         history: &[DocumentHistory],
         documents: &[&dyn CoiSystemData],
         user_interests: UserInterests,
     ) -> Result<UserInterests, Error> {
+        let smbert = &self.smbert;
         update_user_interests(
+            user_interests,
+            &mut self.relevance_maps,
             history,
             documents,
-            user_interests,
-            |key_phrase| self.smbert.run(key_phrase).map_err(Into::into),
+            |key_phrase| smbert.run(key_phrase).map_err(Into::into),
             &self.config,
         )
     }
@@ -115,10 +123,11 @@ fn update_coi<
     CP: CoiPoint + CoiPointKeyPhrases + CoiPointStats,
     F: Fn(&str) -> Result<Embedding, Error>,
 >(
+    mut cois: Vec<CP>,
+    relevance_maps: &mut RelevanceMaps,
     embedding: &Embedding,
     candidates: &[String],
     viewed: Duration,
-    mut cois: Vec<CP>,
     smbert: F,
     config: &Configuration,
 ) -> Vec<CP> {
@@ -126,17 +135,24 @@ fn update_coi<
         Some((coi, distance)) if distance < config.threshold => {
             coi.set_point(shift_coi_point(embedding, coi.point(), config.shift_factor));
             coi.set_id(Uuid::new_v4().into());
-            coi.select_key_phrases(candidates, smbert, config.max_key_phrases, config.gamma);
+            coi.select_key_phrases(
+                relevance_maps,
+                candidates,
+                smbert,
+                config.max_key_phrases,
+                config.gamma,
+            );
             coi.update_stats(viewed);
         }
         _ => {
-            let mut coi = CP::new(
-                Uuid::new_v4().into(),
-                embedding.clone(),
-                BTreeSet::default(),
-                viewed,
+            let coi = CP::new(Uuid::new_v4().into(), embedding.clone(), viewed);
+            coi.select_key_phrases(
+                relevance_maps,
+                candidates,
+                smbert,
+                config.max_key_phrases,
+                config.gamma,
             );
-            coi.select_key_phrases(candidates, smbert, config.max_key_phrases, config.gamma);
             cois.push(coi);
         }
     }
@@ -148,18 +164,19 @@ fn update_cois<
     CP: CoiPoint + CoiPointKeyPhrases + CoiPointStats,
     F: Copy + Fn(&str) -> Result<Embedding, Error>,
 >(
-    docs: &[&dyn CoiSystemData],
     cois: Vec<CP>,
+    relevance_maps: &mut RelevanceMaps,
+    docs: &[&dyn CoiSystemData],
     smbert: F,
     config: &Configuration,
 ) -> Vec<CP> {
     docs.iter().fold(cois, |cois, doc| {
-        let candidates = &[/* TODO: run KPE on doc */];
         update_coi(
-            &doc.smbert().embedding,
-            candidates,
-            doc.viewed(),
             cois,
+            relevance_maps,
+            &doc.smbert().embedding,
+            &[/* TODO: run KPE on doc */],
+            doc.viewed(),
             smbert,
             config,
         )
@@ -167,9 +184,10 @@ fn update_cois<
 }
 
 pub(crate) fn update_user_interests<F: Copy + Fn(&str) -> Result<Embedding, Error>>(
+    mut user_interests: UserInterests,
+    relevance_maps: &mut RelevanceMaps,
     history: &[DocumentHistory],
     documents: &[&dyn CoiSystemData],
-    mut user_interests: UserInterests,
     smbert: F,
     config: &Configuration,
 ) -> Result<UserInterests, Error> {
@@ -182,8 +200,20 @@ pub(crate) fn update_user_interests<F: Copy + Fn(&str) -> Result<Embedding, Erro
     let (positive_docs, negative_docs) =
         classify_documents_based_on_user_feedback(matching_documents);
 
-    user_interests.positive = update_cois(&positive_docs, user_interests.positive, smbert, config);
-    user_interests.negative = update_cois(&negative_docs, user_interests.negative, smbert, config);
+    user_interests.positive = update_cois(
+        user_interests.positive,
+        relevance_maps,
+        &positive_docs,
+        smbert,
+        config,
+    );
+    user_interests.negative = update_cois(
+        user_interests.negative,
+        relevance_maps,
+        &negative_docs,
+        smbert,
+        config,
+    );
 
     Ok(user_interests)
 }
@@ -212,7 +242,7 @@ impl systems::CoiSystem for NeutralCoiSystem {
     }
 
     fn update_user_interests(
-        &self,
+        &mut self,
         _history: &[DocumentHistory],
         _documents: &[&dyn CoiSystemData],
         _user_interests: UserInterests,
@@ -289,6 +319,7 @@ mod tests {
     #[test]
     fn test_update_coi_add_point() {
         let mut cois = create_pos_cois(&[[30., 0., 0.], [0., 20., 0.], [0., 0., 40.]]);
+        let mut maps = RelevanceMaps::default();
         let embedding = arr1(&[1., 1., 1.]).into();
         let viewed = Duration::from_secs(10);
         let config = Configuration::default();
@@ -299,18 +330,35 @@ mod tests {
         assert_approx_eq!(f32, distance, 26.747852);
         assert!(config.threshold < distance);
 
-        cois = update_coi(&embedding, &[], viewed, cois, |_| unreachable!(), &config);
+        cois = update_coi(
+            cois,
+            &mut maps,
+            &embedding,
+            &[],
+            viewed,
+            |_| unreachable!(),
+            &config,
+        );
         assert_eq!(cois.len(), 4);
     }
 
     #[test]
     fn test_update_coi_update_point() {
         let cois = create_pos_cois(&[[1., 1., 1.], [10., 10., 10.], [20., 20., 20.]]);
+        let mut maps = RelevanceMaps::default();
         let embedding = arr1(&[2., 3., 4.]).into();
         let viewed = Duration::from_secs(10);
         let config = Configuration::default();
 
-        let cois = update_coi(&embedding, &[], viewed, cois, |_| unreachable!(), &config);
+        let cois = update_coi(
+            cois,
+            &mut maps,
+            &embedding,
+            &[],
+            viewed,
+            |_| unreachable!(),
+            &config,
+        );
 
         assert_eq!(cois.len(), 3);
         assert_eq!(cois[0].point, arr1(&[1.1, 1.2, 1.3]));
@@ -332,11 +380,20 @@ mod tests {
     #[test]
     fn test_update_coi_threshold_exclusive() {
         let cois = create_pos_cois(&[[0., 0., 0.]]);
+        let mut maps = RelevanceMaps::default();
         let embedding = arr1(&[0., 0., 12.]).into();
         let viewed = Duration::from_secs(10);
         let config = Configuration::default();
 
-        let cois = update_coi(&embedding, &[], viewed, cois, |_| unreachable!(), &config);
+        let cois = update_coi(
+            cois,
+            &mut maps,
+            &embedding,
+            &[],
+            viewed,
+            |_| unreachable!(),
+            &config,
+        );
 
         assert_eq!(cois.len(), 2);
         assert_eq!(cois[0].point, arr1(&[0., 0., 0.]));
@@ -347,6 +404,7 @@ mod tests {
     fn test_update_cois_update_the_same_point_twice() {
         // checks that an updated coi is used in the next iteration
         let cois = create_pos_cois(&[[0., 0., 0.]]);
+        let mut maps = RelevanceMaps::default();
         let documents = create_data_with_rank(&[[0., 0., 4.9], [0., 0., 5.]]);
         let documents = to_vec_of_ref_of!(documents, &dyn CoiSystemData);
         let config = Configuration {
@@ -354,7 +412,7 @@ mod tests {
             ..Configuration::default()
         };
 
-        let cois = update_cois(documents.as_slice(), cois, |_| unreachable!(), &config);
+        let cois = update_cois(cois, &mut maps, &documents, |_| unreachable!(), &config);
 
         assert_eq!(cois.len(), 1);
         // updated coi after first embedding = [0., 0., 0.49]
@@ -437,9 +495,8 @@ mod tests {
     fn test_update_user_interests() {
         let positive = create_pos_cois(&[[3., 2., 1.], [1., 2., 3.]]);
         let negative = create_neg_cois(&[[4., 5., 6.]]);
-
         let user_interests = UserInterests { positive, negative };
-
+        let mut maps = RelevanceMaps::default();
         let history = create_document_history(vec![
             (Relevance::Low, UserFeedback::Irrelevant),
             (Relevance::Low, UserFeedback::Relevant),
@@ -453,10 +510,11 @@ mod tests {
         };
 
         let UserInterests { positive, negative } = update_user_interests(
+            user_interests,
+            &mut maps,
             &history,
             &documents,
-            user_interests,
-            |_| unreachable!(),
+            |_| todo!(/* mock once KPE is used */),
             &config,
         )
         .unwrap();
@@ -473,9 +531,10 @@ mod tests {
     #[test]
     fn test_update_user_interests_no_matches() {
         let error = update_user_interests(
-            &Vec::new(),
-            &Vec::new(),
             UserInterests::default(),
+            &mut RelevanceMaps::default(),
+            &[],
+            &[],
             |_| unreachable!(),
             &Configuration::default(),
         )

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -61,7 +61,7 @@ fn document_relevance(history: &DocumentHistory) -> DocumentRelevance {
 
 #[cfg(test)]
 pub(super) mod tests {
-    use std::{collections::BTreeSet, time::Duration};
+    use std::time::Duration;
 
     use ndarray::{arr1, FixedInitializer};
 
@@ -118,7 +118,6 @@ pub(super) mod tests {
                 CP::new(
                     CoiId::mocked(id),
                     arr1(point.as_init_slice()).into(),
-                    BTreeSet::default(),
                     Duration::from_secs(10),
                 )
             })

--- a/xayn-ai/src/reranker/mod.rs
+++ b/xayn-ai/src/reranker/mod.rs
@@ -219,7 +219,7 @@ where
     /// Updates cois from user feedback.
     fn learn_user_interests(&mut self, history: &[DocumentHistory]) {
         if let Some(prev_documents) = self.data.prev_documents.to_coi_system_data() {
-            match self.common_systems.coi().update_user_interests(
+            match self.common_systems.mut_coi().update_user_interests(
                 history,
                 &prev_documents,
                 self.data.sync_data.user_interests.clone(),

--- a/xayn-ai/src/reranker/public.rs
+++ b/xayn-ai/src/reranker/public.rs
@@ -56,6 +56,10 @@ impl CommonSystems for Systems {
         &self.coi
     }
 
+    fn mut_coi(&mut self) -> &mut dyn CoiSystem {
+        &mut self.coi
+    }
+
     fn ltr(&self) -> &dyn LtrSystem {
         &self.domain
     }

--- a/xayn-ai/src/reranker/systems.rs
+++ b/xayn-ai/src/reranker/systems.rs
@@ -60,7 +60,7 @@ pub(crate) trait CoiSystem {
 
     /// Update cois from history and documents
     fn update_user_interests<'a>(
-        &self,
+        &mut self,
         history: &[DocumentHistory],
         documents: &[&'a dyn CoiSystemData],
         user_interests: UserInterests,
@@ -100,6 +100,7 @@ pub(crate) trait CommonSystems {
     fn smbert(&self) -> &dyn SMBertSystem;
     fn qambert(&self) -> &dyn QAMBertSystem;
     fn coi(&self) -> &dyn CoiSystem;
+    fn mut_coi(&mut self) -> &mut dyn CoiSystem;
     fn ltr(&self) -> &dyn LtrSystem;
     fn context(&self) -> &dyn ContextSystem;
     fn analytics(&self) -> &dyn AnalyticsSystem;

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -102,7 +102,7 @@ fn mocked_coi_system() -> MockCoiSystem {
                 documents,
                 user_interests,
                 |_| unreachable!(),
-                config,
+                &config,
             )
         });
     system

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -2,7 +2,7 @@ use ndarray::arr1;
 
 use crate::{
     analytics::AnalyticsSystem as AnalyticsSys,
-    coi::{compute_coi, update_user_interests, Configuration as CoiConfig, RelevanceMaps},
+    coi::{compute_coi, update_user_interests, Configuration as CoiConfig, Relevances},
     context::Context,
     data::document_data::{
         DocumentDataWithQAMBert,
@@ -99,7 +99,7 @@ fn mocked_coi_system() -> MockCoiSystem {
         .returning(move |history, documents, user_interests| {
             update_user_interests(
                 user_interests,
-                &mut RelevanceMaps::default(),
+                &mut Relevances::default(),
                 history,
                 documents,
                 |_| todo!(/* mock once KPE is used */),

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -2,7 +2,7 @@ use ndarray::arr1;
 
 use crate::{
     analytics::AnalyticsSystem as AnalyticsSys,
-    coi::{compute_coi, update_user_interests, Configuration as CoiConfig},
+    coi::{compute_coi, update_user_interests, Configuration as CoiConfig, RelevanceMaps},
     context::Context,
     data::document_data::{
         DocumentDataWithQAMBert,
@@ -98,10 +98,11 @@ fn mocked_coi_system() -> MockCoiSystem {
         .expect_update_user_interests()
         .returning(move |history, documents, user_interests| {
             update_user_interests(
+                user_interests,
+                &mut RelevanceMaps::default(),
                 history,
                 documents,
-                user_interests,
-                |_| unreachable!(),
+                |_| todo!(/* mock once KPE is used */),
                 &config,
             )
         });
@@ -152,6 +153,10 @@ where
 
     fn coi(&self) -> &dyn CoiSystem {
         &self.coi
+    }
+
+    fn mut_coi(&mut self) -> &mut dyn CoiSystem {
+        &mut self.coi
     }
 
     fn ltr(&self) -> &dyn LtrSystem {

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, ops::Range, time::Duration};
+use std::{ops::Range, time::Duration};
 
 use ndarray::arr1;
 use uuid::Uuid;
@@ -107,7 +107,6 @@ fn cois_from_words<CP: CoiPoint>(
             CP::new(
                 CoiId::mocked(start_id + offset),
                 doc.smbert.embedding,
-                BTreeSet::default(),
                 Duration::from_secs(10),
             )
         })


### PR DESCRIPTION
**References**

- [TY-2209]
- #348
- #353
- #361

**Summary**

- rename `compute_weights()` to `compute_relevances()` to match the source
- move the `horizon` from `compute_relevances()` to the coi `Configuration` and make `max_key_phrases` a constant of the config
- add selection for the top key phrases of a set of cois:
  - move key phrase storing from the `CoiPoint` to the `CoiSystem`
  - update coi relevance and key phrase relevance computation
  - add tests and update all affected tests
- `assert_approx_eq!`: add `BTreeSet` support
- key phrases will not be addressed in merging of cois as this requires major redesign, we agreed on moving this to the new engine as synchronization is not really needed for now


[TY-2209]: https://xainag.atlassian.net/browse/TY-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ