### PR TITLE
TY-2208 update key phrases [3]

### DIFF
--- a/rubert/src/lib.rs
+++ b/rubert/src/lib.rs
@@ -36,7 +36,15 @@ pub use crate::{
     builder::{Builder, BuilderError},
     model::kinds,
     pipeline::{Pipeline, PipelineError},
-    pooler::{AveragePooler, Embedding1, Embedding2, FirstPooler, NonePooler},
+    pooler::{
+        ArcEmbedding1,
+        ArcEmbedding2,
+        AveragePooler,
+        Embedding1,
+        Embedding2,
+        FirstPooler,
+        NonePooler,
+    },
 };
 
 /// A sentence (embedding) multilingual Bert pipeline.

--- a/rubert/src/pooler.rs
+++ b/rubert/src/pooler.rs
@@ -1,7 +1,7 @@
 use derive_more::{Deref, From};
 use displaydoc::Display;
 use float_cmp::{ApproxEq, F32Margin};
-use ndarray::{s, Array, Array1, ArrayBase, Data, Dimension, Ix1, Ix2, Zip};
+use ndarray::{s, ArcArray, Array, Array1, ArrayBase, Data, Dimension, Ix1, Ix2, Zip};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tract_onnx::prelude::TractError;
@@ -59,6 +59,22 @@ where
         self.eq(&other.0)
     }
 }
+
+/// A shared d-dimensional sequence embedding.
+#[derive(Clone, Debug, Deref, From, Serialize, Deserialize, PartialEq)]
+pub struct ArcEmbedding<D>(ArcArray<f32, D>)
+where
+    D: Dimension;
+
+/// A shared 1-dimensional sequence embedding.
+///
+/// The embedding is of shape `(embedding_size,)`.
+pub type ArcEmbedding1 = ArcEmbedding<Ix1>;
+
+/// A shared 2-dimensional sequence embedding.
+///
+/// The embedding is of shape `(token_size, embedding_size)`.
+pub type ArcEmbedding2 = ArcEmbedding<Ix2>;
 
 /// The potential errors of the pooler.
 #[derive(Debug, Display, Error)]

--- a/rubert/src/pooler.rs
+++ b/rubert/src/pooler.rs
@@ -76,6 +76,33 @@ pub type ArcEmbedding1 = ArcEmbedding<Ix1>;
 /// The embedding is of shape `(token_size, embedding_size)`.
 pub type ArcEmbedding2 = ArcEmbedding<Ix2>;
 
+impl<D> From<Array<f32, D>> for ArcEmbedding<D>
+where
+    D: Dimension,
+{
+    fn from(array: Array<f32, D>) -> Self {
+        ArcArray::from(array).into()
+    }
+}
+
+impl<D> From<Embedding<D>> for ArcEmbedding<D>
+where
+    D: Dimension,
+{
+    fn from(embedding: Embedding<D>) -> Self {
+        embedding.0.into()
+    }
+}
+
+impl<D> From<ArcEmbedding<D>> for Embedding<D>
+where
+    D: Dimension,
+{
+    fn from(embedding: ArcEmbedding<D>) -> Self {
+        embedding.0.into_owned().into()
+    }
+}
+
 /// The potential errors of the pooler.
 #[derive(Debug, Display, Error)]
 pub enum PoolerError {

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Borrow, collections::BTreeSet, mem::swap};
+use std::{borrow::Borrow, collections::BTreeSet};
 
 use derivative::Derivative;
 use lazy_static::lazy_static;
@@ -88,7 +88,7 @@ impl Borrow<str> for KeyPhrase {
 pub(crate) trait CoiPointKeyPhrases {
     fn key_phrases(&self) -> &BTreeSet<KeyPhrase>;
 
-    fn swap_key_phrases(&mut self, candidates: BTreeSet<KeyPhrase>) -> BTreeSet<KeyPhrase>;
+    fn set_key_phrases(&mut self, key_phrases: BTreeSet<KeyPhrase>);
 }
 
 impl CoiPointKeyPhrases for PositiveCoi {
@@ -96,9 +96,8 @@ impl CoiPointKeyPhrases for PositiveCoi {
         &self.key_phrases
     }
 
-    fn swap_key_phrases(&mut self, mut candidates: BTreeSet<KeyPhrase>) -> BTreeSet<KeyPhrase> {
-        swap(&mut self.key_phrases, &mut candidates);
-        candidates
+    fn set_key_phrases(&mut self, key_phrases: BTreeSet<KeyPhrase>) {
+        self.key_phrases = key_phrases;
     }
 }
 
@@ -107,7 +106,5 @@ impl CoiPointKeyPhrases for NegativeCoi {
         &EMPTY_KEY_PHRASES
     }
 
-    fn swap_key_phrases(&mut self, _candidates: BTreeSet<KeyPhrase>) -> BTreeSet<KeyPhrase> {
-        BTreeSet::default()
-    }
+    fn set_key_phrases(&mut self, _key_phrases: BTreeSet<KeyPhrase>) {}
 }

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -9,7 +9,7 @@ use crate::{
         point::{NegativeCoi, PositiveCoi},
         CoiError,
     },
-    embedding::utils::Embedding,
+    embedding::utils::ArcEmbedding,
 };
 
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
@@ -17,7 +17,7 @@ use crate::{
 pub(crate) struct KeyPhrase {
     words: String,
     #[derivative(Ord = "ignore", PartialEq = "ignore", PartialOrd = "ignore")]
-    point: Embedding,
+    point: ArcEmbedding,
     #[derivative(Ord = "ignore", PartialEq = "ignore", PartialOrd = "ignore")]
     relevance: f32,
 }
@@ -30,7 +30,7 @@ lazy_static! {
 impl KeyPhrase {
     pub(crate) fn new(
         words: impl Into<String>,
-        point: impl Into<Embedding>,
+        point: impl Into<ArcEmbedding>,
     ) -> Result<Self, CoiError> {
         let words = words.into();
         let point = point.into();
@@ -63,7 +63,7 @@ impl KeyPhrase {
         &self.words
     }
 
-    pub(crate) fn point(&self) -> &Embedding {
+    pub(crate) fn point(&self) -> &ArcEmbedding {
         &self.point
     }
 

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::embedding::utils::Embedding;
+use crate::embedding::utils::ArcEmbedding;
 #[cfg(test)]
 use crate::tests::mock_uuid;
 
@@ -42,7 +42,7 @@ pub(crate) enum CoiError {
     /// A key phrase is empty
     EmptyKeyPhrase,
     /// A key phrase has non-finite embedding values: {0:#?}
-    NonFiniteKeyPhrase(Embedding),
+    NonFiniteKeyPhrase(ArcEmbedding),
     /// A key phrase has a non-normalized relevance score: {0}
     NonNormalizedKeyPhrase(f32),
 }

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -953,7 +953,7 @@ mod tests {
             key_phrases
                 .iter()
                 .find_map(|key_phrase| {
-                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone()))
+                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone().into()))
                 })
                 .unwrap()
         };
@@ -991,7 +991,7 @@ mod tests {
             key_phrases
                 .iter()
                 .find_map(|key_phrase| {
-                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone()))
+                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone().into()))
                 })
                 .unwrap()
         };
@@ -1036,7 +1036,7 @@ mod tests {
             key_phrases
                 .iter()
                 .find_map(|key_phrase| {
-                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone()))
+                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone().into()))
                 })
                 .unwrap()
         };
@@ -1072,7 +1072,7 @@ mod tests {
             key_phrases
                 .iter()
                 .find_map(|key_phrase| {
-                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone()))
+                    (key_phrase.words() == words).then(|| Ok(key_phrase.point().clone().into()))
                 })
                 .unwrap()
         };

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -1,5 +1,5 @@
 use std::{
-    borrow::Borrow,
+    borrow::{Borrow, Cow},
     collections::BTreeSet,
     convert::identity,
     iter::once,
@@ -421,15 +421,21 @@ impl CoiSystem {
                     .unwrap_or_default()
             });
 
-            let key_phrases = coi.swap_key_phrases(BTreeSet::default());
             let key_phrases = selected
                 .iter()
-                .zip(key_phrases.into_iter().chain(candidates))
-                .filter_map(|(is_selected, key_phrase)| is_selected.then(|| key_phrase))
+                .zip(
+                    coi.key_phrases()
+                        .iter()
+                        .map(Cow::Borrowed)
+                        .chain(candidates.into_iter().map(Cow::Owned)),
+                )
+                .filter_map(|(is_selected, key_phrase)| {
+                    is_selected.then(|| key_phrase.into_owned())
+                })
                 .zip(relevance)
                 .filter_map(|(key_phrase, relevance)| key_phrase.with_relevance(relevance).ok())
                 .collect();
-            coi.swap_key_phrases(key_phrases);
+            coi.set_key_phrases(key_phrases);
         }
 
         let candidates = unique_candidates(coi, candidates, smbert);
@@ -900,7 +906,7 @@ mod tests {
         let key_phrases =
             IntoIterator::into_iter([KeyPhrase::new("key", arr1(&[1., 1., 0.])).unwrap()])
                 .collect::<BTreeSet<_>>();
-        coi[0].swap_key_phrases(key_phrases.clone());
+        coi[0].set_key_phrases(key_phrases.clone());
         let candidates = &[];
         let smbert = |_: &str| unreachable!();
         CoiSystem::default().select_key_phrases(&mut coi[0], candidates, smbert);
@@ -920,7 +926,7 @@ mod tests {
             KeyPhrase::new("phrase", arr1(&[1., 1., 1.])).unwrap(),
         ])
         .collect::<BTreeSet<_>>();
-        coi[0].swap_key_phrases(key_phrases.clone());
+        coi[0].set_key_phrases(key_phrases.clone());
         let candidates = &[];
         let smbert = |_: &str| unreachable!();
         CoiSystem::default().select_key_phrases(&mut coi[0], candidates, smbert);
@@ -981,7 +987,7 @@ mod tests {
             KeyPhrase::new("words", arr1(&[2., 1., 0.])).unwrap(),
         ])
         .collect::<BTreeSet<_>>();
-        coi[0].swap_key_phrases(key_phrases.iter().cloned().take(2).collect());
+        coi[0].set_key_phrases(key_phrases.iter().cloned().take(2).collect());
         let candidates = key_phrases
             .iter()
             .skip(2)
@@ -1024,7 +1030,7 @@ mod tests {
             KeyPhrase::new("phrase", arr1(&[1., 1., 1.])).unwrap(),
         ])
         .collect::<BTreeSet<_>>();
-        coi[0].swap_key_phrases(key_phrases.iter().cloned().take(1).collect());
+        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
         let candidates = key_phrases
             .iter()
             .skip(1)
@@ -1062,7 +1068,7 @@ mod tests {
             KeyPhrase::new("phrase", arr1(&[0., 0., 1.])).unwrap(),
         ])
         .collect::<BTreeSet<_>>();
-        coi[0].swap_key_phrases(key_phrases.iter().cloned().take(1).collect());
+        coi[0].set_key_phrases(key_phrases.iter().cloned().take(1).collect());
         let candidates = key_phrases
             .iter()
             .skip(1)

--- a/xayn-ai/src/embedding/utils.rs
+++ b/xayn-ai/src/embedding/utils.rs
@@ -1,8 +1,9 @@
 use itertools::Itertools;
 use ndarray::{Array1, Array2, ArrayBase, Data, Ix1, RawDataClone};
-use rubert::Embedding1;
+use rubert::{ArcEmbedding1, Embedding1};
 
 pub(crate) type Embedding = Embedding1;
+pub(crate) type ArcEmbedding = ArcEmbedding1;
 
 /// Computes the l2 norm (euclidean metric) of a vector.
 ///


### PR DESCRIPTION
**References**

- [TY-2208]
- #348
- follow up to https://github.com/xaynetwork/xayn_ai/pull/348#discussion_r777260388

**Summary**

- implement `ArcEmbedding`
- replace swapping of key phrases with setting them as they are now cheaper to clone


[TY-2208]: https://xainag.atlassian.net/browse/TY-2208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ