### PR TITLE
[Merged by Bors] - TY-2190 add compute_smbert method

### DIFF
--- a/xayn-ai/src/ranker/mod.rs
+++ b/xayn-ai/src/ranker/mod.rs
@@ -3,6 +3,7 @@ use rubert::SMBert;
 
 use crate::{
     coi::{point::UserInterests, CoiSystem},
+    embedding::utils::Embedding,
     error::Error,
 };
 
@@ -35,5 +36,10 @@ impl Ranker {
     /// Creates a byte representation of the internal state of the ranker.
     pub(crate) fn serialize(&self) -> Result<Vec<u8>, Error> {
         bincode::serialize(&self.user_interests).map_err(Into::into)
+    }
+
+    /// Computes the SMBert embedding of the given `sequence`.
+    pub(crate) fn compute_smbert(&self, sequence: &str) -> Result<Embedding, Error> {
+        self.smbert.run(sequence).map_err(Into::into)
     }
 }


### PR DESCRIPTION
Ticket:

- [TY-2190]

Summary:
- adds `compute_smbert` method
- We decided to go with the signature `fn compute_smbert(&self, sequence: &str) -> Result<Embedding, Error>`. That way we don’t depend on the layout of `Document`.

[TY-2190]: https://xainag.atlassian.net/browse/TY-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ