### PR TITLE
[Merged by Bors] - TY-2280 coi config checks

### DIFF
--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -19,7 +19,7 @@ impl Configuration {
         self.shift_factor
     }
 
-    /// Sets the shift factor for values in the unit interval.
+    /// Sets the shift factor for values from the unit interval.
     #[allow(dead_code)]
     pub(crate) fn with_shift_factor(self, shift_factor: f32) -> Result<Self, CoiError> {
         if (0. ..=1.).contains(&shift_factor) {
@@ -79,7 +79,7 @@ impl Configuration {
         self.gamma
     }
 
-    /// Sets the gamma for values in the unit interval.
+    /// Sets the gamma for values from the unit interval.
     #[allow(dead_code)]
     pub(crate) fn with_gamma(self, gamma: f32) -> Result<Self, CoiError> {
         if (0. ..=1.).contains(&gamma) {

--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -1,29 +1,117 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::time::Duration;
 
-use crate::utils::SECONDS_PER_DAY;
+use crate::{coi::CoiError, utils::SECONDS_PER_DAY};
 
 #[derive(Clone)]
 pub(crate) struct Configuration {
+    shift_factor: f32,
+    threshold: f32,
+    neighbors: usize,
+    horizon: Duration,
+    max_key_phrases: usize,
+    gamma: f32,
+    penalty: Vec<f32>,
+}
+
+impl Configuration {
     /// The shift factor by how much a Coi is shifted towards a new point.
-    pub shift_factor: f32,
+    pub(crate) fn shift_factor(&self) -> f32 {
+        self.shift_factor
+    }
+
+    /// Sets the shift factor for values in the unit interval.
+    #[allow(dead_code)]
+    pub(crate) fn with_shift_factor(self, shift_factor: f32) -> Result<Self, CoiError> {
+        if (0. ..=1.).contains(&shift_factor) {
+            Ok(Self {
+                shift_factor,
+                ..self
+            })
+        } else {
+            Err(CoiError::InvalidShiftFactor(shift_factor))
+        }
+    }
+
     /// The minimum distance between distinct cois.
-    pub threshold: f32,
+    pub(crate) fn threshold(&self) -> f32 {
+        self.threshold
+    }
+
+    /// Sets the threshold for non-negative values.
+    #[cfg(test)]
+    pub(crate) fn with_threshold(self, threshold: f32) -> Result<Self, CoiError> {
+        if threshold >= 0. {
+            Ok(Self { threshold, ..self })
+        } else {
+            Err(CoiError::InvalidThreshold(threshold))
+        }
+    }
+
     /// The positive number of neighbors for the k-nearest-neighbors distance.
-    pub neighbors: NonZeroUsize,
+    pub(crate) fn neighbors(&self) -> usize {
+        self.neighbors
+    }
+
+    /// Sets the neighbors for positive values.
+    #[allow(dead_code)]
+    pub(crate) fn with_neighbors(self, neighbors: usize) -> Result<Self, CoiError> {
+        if neighbors > 0 {
+            Ok(Self { neighbors, ..self })
+        } else {
+            Err(CoiError::InvalidNeighbors(neighbors))
+        }
+    }
+
     /// The time since the last view after which a coi becomes irrelevant.
-    #[allow(dead_code)]
-    pub horizon: Duration,
-    /// The maximum number of key phrases picked during the coi key phrase selection. A coi may have
-    /// more key phrases than this, eg because of merging.
-    #[allow(dead_code)]
-    pub max_key_phrases: usize,
+    #[cfg(test)]
+    pub(crate) fn horizon(&self) -> Duration {
+        self.horizon
+    }
+
+    /// Sets the horizon.
+    #[cfg(test)]
+    pub(crate) fn with_horizon(self, horizon: Duration) -> Self {
+        Self { horizon, ..self }
+    }
+
     /// The weighting between coi and pairwise candidate similarites in the key phrase selection.
+    pub(crate) fn gamma(&self) -> f32 {
+        self.gamma
+    }
+
+    /// Sets the gamma for values in the unit interval.
     #[allow(dead_code)]
-    pub gamma: f32,
+    pub(crate) fn with_gamma(self, gamma: f32) -> Result<Self, CoiError> {
+        if (0. ..=1.).contains(&gamma) {
+            Ok(Self { gamma, ..self })
+        } else {
+            Err(CoiError::InvalidGamma(gamma))
+        }
+    }
+
     /// The penalty for less relevant key phrases of a coi in increasing order (ie. lowest penalty
     /// for the most relevant key phrase first and highest penalty for the least relevant key phrase
-    /// last).
-    pub penalty: Vec<f32>,
+    /// last). The length of the penalty also serves as the maximum number of key phrases.
+    #[cfg(test)]
+    pub(crate) fn penalty(&self) -> &[f32] {
+        self.penalty.as_slice()
+    }
+
+    /// Sets the penalty for non-empty, finite values.
+    #[allow(dead_code)]
+    pub(crate) fn with_penalty(self, penalty: &[f32]) -> Result<Self, CoiError> {
+        let penalty = penalty.to_vec();
+        if !penalty.is_empty() && penalty.iter().copied().all(f32::is_finite) {
+            Ok(Self { penalty, ..self })
+        } else {
+            Err(CoiError::InvalidPenalty(penalty))
+        }
+    }
+
+    /// The maximum number of key phrases picked during the coi key phrase selection.
+    pub(crate) fn max_key_phrases(&self) -> usize {
+        self.penalty.len()
+    }
 }
 
 impl Default for Configuration {
@@ -31,7 +119,7 @@ impl Default for Configuration {
         Self {
             shift_factor: 0.1,
             threshold: 12.0,
-            neighbors: NonZeroUsize::new(4).unwrap(),
+            neighbors: 4,
             horizon: Duration::from_secs(SECONDS_PER_DAY as u64 * 30),
             max_key_phrases: 3,
             gamma: 0.9,

--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -34,7 +34,7 @@ impl Configuration {
                 ..self
             })
         } else {
-            Err(CoiError::InvalidShiftFactor(shift_factor))
+            Err(CoiError::InvalidShiftFactor)
         }
     }
 
@@ -52,7 +52,7 @@ impl Configuration {
         if threshold >= 0. {
             Ok(Self { threshold, ..self })
         } else {
-            Err(CoiError::InvalidThreshold(threshold))
+            Err(CoiError::InvalidThreshold)
         }
     }
 
@@ -70,7 +70,7 @@ impl Configuration {
         if neighbors > 0 {
             Ok(Self { neighbors, ..self })
         } else {
-            Err(CoiError::InvalidNeighbors(neighbors))
+            Err(CoiError::InvalidNeighbors)
         }
     }
 
@@ -100,7 +100,7 @@ impl Configuration {
         if (0. ..=1.).contains(&gamma) {
             Ok(Self { gamma, ..self })
         } else {
-            Err(CoiError::InvalidGamma(gamma))
+            Err(CoiError::InvalidGamma)
         }
     }
 
@@ -112,7 +112,7 @@ impl Configuration {
         &self.penalty
     }
 
-    /// Sets the penalty for non-empty, finite, sorted values.
+    /// Sets the penalty.
     ///
     /// # Errors
     /// Fails if the penalty is empty, has non-finite values or is unsorted.
@@ -125,14 +125,16 @@ impl Configuration {
             vector == slice
         }
 
-        let penalty = penalty.to_vec();
         if !penalty.is_empty()
             && penalty.iter().copied().all(f32::is_finite)
-            && is_sorted_by(&penalty, nan_safe_f32_cmp_desc)
+            && is_sorted_by(penalty, nan_safe_f32_cmp_desc)
         {
-            Ok(Self { penalty, ..self })
+            Ok(Self {
+                penalty: penalty.to_vec(),
+                ..self
+            })
         } else {
-            Err(CoiError::InvalidPenalty(penalty))
+            Err(CoiError::InvalidPenalty)
         }
     }
 

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -351,8 +351,8 @@ mod tests {
             &cois[0],
             candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert!(relevances.cois_is_empty());
         assert!(relevances.relevances_is_empty());
@@ -392,8 +392,8 @@ mod tests {
             &cois[0],
             candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
@@ -436,8 +436,8 @@ mod tests {
             &cois[0],
             &candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
@@ -482,12 +482,12 @@ mod tests {
             &cois[0],
             &candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.7905694, 0.91287094, 1.]);
-        assert_eq!(relevances.relevances_len(), config.max_key_phrases);
+        assert_eq!(relevances.relevances_len(), config.max_key_phrases());
         let mut relevance = relevances[cois[0].id].iter().copied();
         assert_eq!(
             relevances[(cois[0].id, relevance.next().unwrap())],
@@ -532,8 +532,8 @@ mod tests {
             &cois[0],
             &candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
@@ -576,8 +576,8 @@ mod tests {
             &cois[0],
             &candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.]);
@@ -616,8 +616,8 @@ mod tests {
             &cois[0],
             &candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
@@ -660,8 +660,8 @@ mod tests {
             &cois[0],
             &candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.]);
@@ -700,8 +700,8 @@ mod tests {
             &cois[0],
             &candidates,
             smbert,
-            config.max_key_phrases,
-            config.gamma,
+            config.max_key_phrases(),
+            config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
         assert_approx_eq!(f32, relevances[cois[0].id], [0., 1.]);
@@ -724,8 +724,12 @@ mod tests {
         let mut relevances = Relevances::default();
         let config = Configuration::default();
 
-        let top_key_phrases =
-            relevances.select_top_key_phrases(&cois, usize::MAX, config.horizon, &config.penalty);
+        let top_key_phrases = relevances.select_top_key_phrases(
+            &cois,
+            usize::MAX,
+            config.horizon(),
+            config.penalty(),
+        );
         assert!(top_key_phrases.is_empty());
         assert!(relevances.cois_is_empty());
         assert!(relevances.relevances_is_empty());
@@ -737,8 +741,12 @@ mod tests {
         let mut relevances = Relevances::default();
         let config = Configuration::default();
 
-        let top_key_phrases =
-            relevances.select_top_key_phrases(&cois, usize::MAX, config.horizon, &config.penalty);
+        let top_key_phrases = relevances.select_top_key_phrases(
+            &cois,
+            usize::MAX,
+            config.horizon(),
+            config.penalty(),
+        );
         assert!(top_key_phrases.is_empty());
         assert_eq!(relevances.cois_len(), cois.len());
         assert!(relevances.relevances_is_empty());
@@ -760,7 +768,7 @@ mod tests {
         let config = Configuration::default();
 
         let top_key_phrases =
-            relevances.select_top_key_phrases(&cois, 0, config.horizon, &config.penalty);
+            relevances.select_top_key_phrases(&cois, 0, config.horizon(), config.penalty());
         assert!(top_key_phrases.is_empty());
         assert_eq!(relevances.cois_len(), cois.len());
         assert_eq!(relevances.relevances_len(), key_phrases.len());
@@ -793,8 +801,12 @@ mod tests {
         );
         let config = Configuration::default();
 
-        let top_key_phrases =
-            relevances.select_top_key_phrases(&cois, usize::MAX, config.horizon, &config.penalty);
+        let top_key_phrases = relevances.select_top_key_phrases(
+            &cois,
+            usize::MAX,
+            config.horizon(),
+            config.penalty(),
+        );
         assert_eq!(
             top_key_phrases,
             ["enough", "stuff", "words", "not", "more", "phrase", "still", "and", "key"],

--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -13,7 +13,7 @@ use crate::{
 
 const MERGE_THRESHOLD_DIST: f32 = 4.5;
 
-pub(crate) trait CoiPointMerge: CoiPoint {
+pub(crate) trait CoiPointMerge {
     fn merge(self, other: Self, id: CoiId) -> Self;
 }
 

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -49,4 +49,15 @@ pub(crate) enum CoiError {
     NonFiniteKeyPhrase(ArcEmbedding),
     /// A computed relevance score isn't finite.
     NonFiniteRelevance,
+    /// Invalid coi shift factor, expected value from `[0., 1.]`, got {0}
+    InvalidShiftFactor(f32),
+    /// Invalid coi threshold, expected value `>= 0.`, got {0}
+    #[cfg(test)]
+    InvalidThreshold(f32),
+    /// Invalid coi neighbors, expected value `> 0`, got {0}
+    InvalidNeighbors(usize),
+    /// Invalid coi gamma, expected value from `[0., 1.]`, got {0}
+    InvalidGamma(f32),
+    /// Invalid coi penalty, expected non-empty and finite values, got {0:?}
+    InvalidPenalty(Vec<f32>),
 }

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -49,15 +49,15 @@ pub(crate) enum CoiError {
     NonFiniteKeyPhrase(ArcEmbedding),
     /// A computed relevance score isn't finite.
     NonFiniteRelevance,
-    /// Invalid coi shift factor, expected value from the unit interval, got {0}
-    InvalidShiftFactor(f32),
-    /// Invalid coi threshold, expected non-negative value, got {0}
+    /// Invalid coi shift factor, expected value from the unit interval
+    InvalidShiftFactor,
+    /// Invalid coi threshold, expected non-negative value
     #[cfg(test)]
-    InvalidThreshold(f32),
-    /// Invalid coi neighbors, expected positive value, got {0}
-    InvalidNeighbors(usize),
-    /// Invalid coi gamma, expected value from the unit interval, got {0}
-    InvalidGamma(f32),
-    /// Invalid coi penalty, expected non-empty, finite and sorted values, got {0:?}
-    InvalidPenalty(Vec<f32>),
+    InvalidThreshold,
+    /// Invalid coi neighbors, expected positive value
+    InvalidNeighbors,
+    /// Invalid coi gamma, expected value from the unit interval
+    InvalidGamma,
+    /// Invalid coi penalty, expected non-empty, finite and sorted values
+    InvalidPenalty,
 }

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -58,6 +58,6 @@ pub(crate) enum CoiError {
     InvalidNeighbors(usize),
     /// Invalid coi gamma, expected value from the unit interval, got {0}
     InvalidGamma(f32),
-    /// Invalid coi penalty, expected non-empty and finite values, got {0:?}
+    /// Invalid coi penalty, expected non-empty, finite and sorted values, got {0:?}
     InvalidPenalty(Vec<f32>),
 }

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -49,14 +49,14 @@ pub(crate) enum CoiError {
     NonFiniteKeyPhrase(ArcEmbedding),
     /// A computed relevance score isn't finite.
     NonFiniteRelevance,
-    /// Invalid coi shift factor, expected value from `[0., 1.]`, got {0}
+    /// Invalid coi shift factor, expected value from the unit interval, got {0}
     InvalidShiftFactor(f32),
-    /// Invalid coi threshold, expected value `>= 0.`, got {0}
+    /// Invalid coi threshold, expected non-negative value, got {0}
     #[cfg(test)]
     InvalidThreshold(f32),
-    /// Invalid coi neighbors, expected value `> 0`, got {0}
+    /// Invalid coi neighbors, expected positive value, got {0}
     InvalidNeighbors(usize),
-    /// Invalid coi gamma, expected value from `[0., 1.]`, got {0}
+    /// Invalid coi gamma, expected value from the unit interval, got {0}
     InvalidGamma(f32),
     /// Invalid coi penalty, expected non-empty and finite values, got {0:?}
     InvalidPenalty(Vec<f32>),

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -175,9 +175,9 @@ type PositiveCois_v0_3_0 = Vec<PositiveCoi>;
 pub(crate) struct UserInterests {
     #[obake(inherit)]
     #[obake(cfg(">=0.0"))]
-    pub positive: PositiveCois,
+    pub(crate) positive: PositiveCois,
     #[obake(cfg(">=0.0"))]
-    pub negative: Vec<NegativeCoi>,
+    pub(crate) negative: Vec<NegativeCoi>,
 }
 
 impl From<UserInterests_v0_0_0> for UserInterests_v0_1_0 {

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -149,19 +149,19 @@ mod tests {
     use super::*;
 
     impl Relevances {
-        pub fn cois_len(&self) -> usize {
+        pub(crate) fn cois_len(&self) -> usize {
             self.coi_to_relevance.len()
         }
 
-        pub fn cois_is_empty(&self) -> bool {
+        pub(crate) fn cois_is_empty(&self) -> bool {
             self.coi_to_relevance.is_empty()
         }
 
-        pub fn relevances_len(&self) -> usize {
+        pub(crate) fn relevances_len(&self) -> usize {
             self.relevance_to_key_phrase.len()
         }
 
-        pub fn relevances_is_empty(&self) -> bool {
+        pub(crate) fn relevances_is_empty(&self) -> bool {
             self.relevance_to_key_phrase.is_empty()
         }
     }

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -25,6 +25,12 @@ impl Relevance {
     }
 }
 
+impl PartialEq<f32> for Relevance {
+    fn eq(&self, other: &f32) -> bool {
+        self.0.eq(other)
+    }
+}
+
 impl Eq for Relevance {
     // never nan by construction
 }

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -132,11 +132,12 @@ impl Relevances {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use ndarray::Array1;
 
-    use crate::coi::{config::Configuration, utils::tests::create_pos_cois};
+    use crate::{
+        coi::{config::Configuration, utils::tests::create_pos_cois},
+        utils::nan_safe_f32_cmp,
+    };
     use test_utils::assert_approx_eq;
 
     use super::*;
@@ -167,14 +168,10 @@ mod tests {
     }
 
     fn dedup_penalty(config: Configuration) -> Array1<f32> {
-        config
-            .penalty()
-            .iter()
-            .map(|&penalty| Relevance::new(penalty).unwrap())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .map(Into::into)
-            .collect()
+        let mut penalty = config.penalty().to_vec();
+        penalty.sort_unstable_by(nan_safe_f32_cmp);
+        penalty.dedup();
+        penalty.into()
     }
 
     #[test]

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -86,7 +86,7 @@ pub(crate) fn mocked_qambert_system() -> MockQAMBertSystem {
 
 fn mocked_coi_system() -> MockCoiSystem {
     let config = CoiConfig::default();
-    let neighbors = config.neighbors.get();
+    let neighbors = config.neighbors();
 
     let mut system = MockCoiSystem::new();
     system


### PR DESCRIPTION
**References**

- [TY-2280]
- #355

**Summary**

- add getters and validated setters for the coi configuration
- fix redundant `max_key_phrases` field from #355


[TY-2280]: https://xainag.atlassian.net/browse/TY-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ