### PR TITLE
[Merged by Bors] - TY-2230 feedback loop [0]

### DIFF
--- a/rubert/src/pooler.rs
+++ b/rubert/src/pooler.rs
@@ -1,3 +1,5 @@
+use std::ops::{AddAssign, Mul, MulAssign};
+
 use derive_more::{Deref, From};
 use displaydoc::Display;
 use float_cmp::{ApproxEq, F32Margin};
@@ -57,6 +59,35 @@ where
 {
     fn eq(&self, other: &Self) -> bool {
         self.eq(&other.0)
+    }
+}
+
+impl<D> AddAssign for Embedding<D>
+where
+    D: Dimension,
+{
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += &rhs.0;
+    }
+}
+
+impl<D> Mul<f32> for &Embedding<D>
+where
+    D: Dimension,
+{
+    type Output = Embedding<D>;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        (&self.0 * rhs).into()
+    }
+}
+
+impl<D> MulAssign<f32> for Embedding<D>
+where
+    D: Dimension,
+{
+    fn mul_assign(&mut self, rhs: f32) {
+        self.0 *= rhs;
     }
 }
 

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -77,6 +77,9 @@ pub(crate) trait CoiPoint {
     fn point(&self) -> &Embedding;
 
     fn set_point(&mut self, embedding: Embedding);
+
+    /// Shifts the coi towards another point by a factor.
+    fn shift_point(&mut self, towards: &Embedding, shift_factor: f32);
 }
 
 macro_rules! coi_point_default_impls {
@@ -95,6 +98,11 @@ macro_rules! coi_point_default_impls {
 
         fn set_point(&mut self, embedding: Embedding) {
             self.point = embedding;
+        }
+
+        fn shift_point(&mut self, towards: &Embedding, shift_factor: f32) {
+            self.point *= 1. - shift_factor;
+            self.point += towards * shift_factor;
         }
     };
 }
@@ -285,6 +293,16 @@ mod tests {
     use test_utils::assert_approx_eq;
 
     use super::*;
+
+    #[test]
+    fn test_shift_coi_point() {
+        let mut cois = create_pos_cois(&[[1., 1., 1.]]);
+        let towards = arr1(&[2., 3., 4.]).into();
+        let shift_factor = 0.1;
+
+        cois[0].shift_point(&towards, shift_factor);
+        assert_eq!(cois[0].point, arr1(&[1.1, 1.2, 1.3]));
+    }
 
     #[test]
     fn test_find_closest_coi_index() {

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -68,7 +68,7 @@ pub(crate) struct NegativeCoi {
 }
 
 pub(crate) trait CoiPoint {
-    fn new(id: CoiId, point: Embedding, viewed: Duration) -> Self;
+    fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, viewed: Duration) -> Self;
 
     fn id(&self) -> CoiId;
 
@@ -109,10 +109,10 @@ macro_rules! coi_point_default_impls {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_0_0 {
-    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
+    fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, _viewed: Duration) -> Self {
         Self {
-            id,
-            point,
+            id: id.into(),
+            point: point.into(),
             alpha: 1.,
             beta: 1.,
         }
@@ -123,10 +123,10 @@ impl CoiPoint for PositiveCoi_v0_0_0 {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_1_0 {
-    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
+    fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, _viewed: Duration) -> Self {
         Self {
-            id,
-            point,
+            id: id.into(),
+            point: point.into(),
             alpha: 1.,
             beta: 1.,
         }
@@ -137,18 +137,21 @@ impl CoiPoint for PositiveCoi_v0_1_0 {
 
 #[cfg(test)]
 impl CoiPoint for PositiveCoi_v0_2_0 {
-    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
-        Self { id, point }
+    fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, _viewed: Duration) -> Self {
+        Self {
+            id: id.into(),
+            point: point.into(),
+        }
     }
 
     coi_point_default_impls! {}
 }
 
 impl CoiPoint for PositiveCoi {
-    fn new(id: CoiId, point: Embedding, viewed: Duration) -> Self {
+    fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, viewed: Duration) -> Self {
         Self {
-            id,
-            point,
+            id: id.into(),
+            point: point.into(),
             stats: CoiStats::new(viewed),
         }
     }
@@ -157,8 +160,11 @@ impl CoiPoint for PositiveCoi {
 }
 
 impl CoiPoint for NegativeCoi {
-    fn new(id: CoiId, point: Embedding, _viewed: Duration) -> Self {
-        Self { id, point }
+    fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, _viewed: Duration) -> Self {
+        Self {
+            id: id.into(),
+            point: point.into(),
+        }
     }
 
     coi_point_default_impls! {}

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -31,6 +31,16 @@ pub(crate) struct PositiveCoi {
     pub(super) beta: f32,
 }
 
+impl PositiveCoi {
+    pub(crate) fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, viewed: Duration) -> Self {
+        Self {
+            id: id.into(),
+            point: point.into(),
+            stats: CoiStats::new(viewed),
+        }
+    }
+}
+
 impl From<PositiveCoi_v0_0_0> for PositiveCoi_v0_1_0 {
     fn from(coi: PositiveCoi_v0_0_0) -> Self {
         Self {
@@ -67,6 +77,15 @@ pub(crate) struct NegativeCoi {
     pub point: Embedding,
 }
 
+impl NegativeCoi {
+    pub(crate) fn new(id: impl Into<CoiId>, point: impl Into<Embedding>) -> Self {
+        Self {
+            id: id.into(),
+            point: point.into(),
+        }
+    }
+}
+
 pub(crate) trait CoiPoint {
     fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, viewed: Duration) -> Self;
 
@@ -78,7 +97,7 @@ pub(crate) trait CoiPoint {
 
     fn set_point(&mut self, embedding: Embedding);
 
-    /// Shifts the coi towards another point by a factor.
+    /// Shifts the coi point towards another point by a factor.
     fn shift_point(&mut self, towards: &Embedding, shift_factor: f32);
 }
 
@@ -149,11 +168,7 @@ impl CoiPoint for PositiveCoi_v0_2_0 {
 
 impl CoiPoint for PositiveCoi {
     fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, viewed: Duration) -> Self {
-        Self {
-            id: id.into(),
-            point: point.into(),
-            stats: CoiStats::new(viewed),
-        }
+        Self::new(id, point, viewed)
     }
 
     coi_point_default_impls! {}
@@ -161,10 +176,7 @@ impl CoiPoint for PositiveCoi {
 
 impl CoiPoint for NegativeCoi {
     fn new(id: impl Into<CoiId>, point: impl Into<Embedding>, _viewed: Duration) -> Self {
-        Self {
-            id: id.into(),
-            point: point.into(),
-        }
+        Self::new(id, point)
     }
 
     coi_point_default_impls! {}

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -136,7 +136,7 @@ fn update_coi<CP: CoiPointKeyPhrases + CoiPointStats, F: Fn(&str) -> Result<Embe
             coi.update_stats(viewed);
         }
         _ => {
-            let coi = CP::new(Uuid::new_v4().into(), embedding.clone(), viewed);
+            let coi = CP::new(Uuid::new_v4(), embedding.clone(), viewed);
             coi.select_key_phrases(
                 relevances,
                 candidates,

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -68,7 +68,7 @@ pub(super) mod tests {
     use super::*;
     use crate::{
         coi::{
-            point::{CoiPoint, NegativeCoi, PositiveCoi},
+            point::{tests::CoiPointConstructor, NegativeCoi, PositiveCoi},
             CoiId,
         },
         data::document_data::{
@@ -106,7 +106,9 @@ pub(super) mod tests {
         }
     }
 
-    fn create_cois<FI: FixedInitializer<Elem = f32>, CP: CoiPoint>(points: &[FI]) -> Vec<CP> {
+    fn create_cois<FI: FixedInitializer<Elem = f32>, CP: CoiPointConstructor>(
+        points: &[FI],
+    ) -> Vec<CP> {
         if FI::len() == 0 {
             return Vec::new();
         }

--- a/xayn-ai/src/coi/utils.rs
+++ b/xayn-ai/src/coi/utils.rs
@@ -117,7 +117,7 @@ pub(super) mod tests {
             .map(|(id, point)| {
                 CP::new(
                     CoiId::mocked(id),
-                    arr1(point.as_init_slice()).into(),
+                    arr1(point.as_init_slice()),
                     Duration::from_secs(10),
                 )
             })

--- a/xayn-ai/src/tests/utils.rs
+++ b/xayn-ai/src/tests/utils.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::{
     coi::{
         point::{
-            CoiPoint,
+            tests::CoiPointConstructor,
             NegativeCoi,
             PositiveCoi,
             PositiveCoi_v0_0_0,
@@ -76,7 +76,7 @@ pub(crate) fn documents_from_words(
     .collect()
 }
 
-fn cois_from_words<CP: CoiPoint>(
+fn cois_from_words<CP: CoiPointConstructor>(
     titles: &[&str],
     smbert: impl SMBertSystem,
     start_id: usize,


### PR DESCRIPTION
**References**

- [TY-2230]

**Summary**

preparation for the feedback loop impl:
- split `CoiPointConstructor` (only test convenience) from `CoiPoint`
- move coi point shifting into `CoiPoint`
- split update of positive/negative cois
- remove no-ops in negative coi updates
- remove unused `CoiPointStats`/`CoiPointKeyPhrases` traits

[TY-2230]: https://xainag.atlassian.net/browse/TY-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ