### PR TITLE
[Merged by Bors] - DEVOPS-670 Adding support for different bases than master

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,8 +2,6 @@ name: PR WIP Label Assigner
 
 on:
   pull_request:
-    branches:
-      - master
     types: [opened, converted_to_draft, ready_for_review]
   workflow_dispatch:
 


### PR DESCRIPTION
Whenever a PR is opened with any base the labeler ci will run. 