### PR TITLE
[Merged by Bors] - TY-2292 add last_view to NegativeCoi

### DIFF
--- a/xayn-ai/src/coi/merge.rs
+++ b/xayn-ai/src/coi/merge.rs
@@ -34,8 +34,13 @@ impl CoiPointMerge for PositiveCoi {
 impl CoiPointMerge for NegativeCoi {
     fn merge(self, other: Self, id: CoiId) -> Self {
         let point = mean(self.point.view(), other.point.view()).into();
+        let last_view = self.last_view.max(other.last_view);
 
-        Self { id, point }
+        Self {
+            id,
+            point,
+            last_view,
+        }
     }
 }
 

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     coi::{stats::CoiStats, CoiId},
     embedding::utils::{l2_distance, Embedding},
-    utils::nan_safe_f32_cmp,
+    utils::{nan_safe_f32_cmp, system_time_now},
 };
 
 #[obake::versioned]
@@ -76,6 +76,7 @@ impl From<PositiveCoi_v0_2_0> for PositiveCoi {
 pub(crate) struct NegativeCoi {
     pub(super) id: CoiId,
     pub(super) point: Embedding,
+    pub(super) last_view: SystemTime,
 }
 
 impl NegativeCoi {
@@ -83,6 +84,7 @@ impl NegativeCoi {
         Self {
             id: id.into(),
             point: point.into(),
+            last_view: system_time_now(),
         }
     }
 }

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -72,10 +72,12 @@ impl From<PositiveCoi_v0_2_0> for PositiveCoi {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
+#[derivative(PartialEq)]
 pub(crate) struct NegativeCoi {
     pub(super) id: CoiId,
     pub(super) point: Embedding,
+    #[derivative(PartialEq = "ignore")]
     pub(super) last_view: SystemTime,
 }
 


### PR DESCRIPTION
Ticket: 
- [TY-2292]

Summary:
- adds `last_view` field to `NegativeCoi` struct
- `last_view` is used later in the context calculation

[TY-2292]: https://xainag.atlassian.net/browse/TY-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ