### PR TITLE
[Merged by Bors] - TY-2240 weighted ranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,7 +2411,6 @@ dependencies = [
  "js-sys",
  "kpe",
  "layer",
- "maplit",
  "mockall",
  "ndarray",
  "obake",

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -33,7 +33,6 @@ js-sys = "0.3.55"
 
 [dev-dependencies]
 csv = "1.1.6"
-maplit = "1.0.2"
 mockall = "0.11.0"
 once_cell = "1.9.0"
 paste = "1.0.6"

--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     embedding::utils::{pairwise_cosine_similarity, ArcEmbedding, Embedding},
     error::Error,
+    utils::system_time_now,
 };
 
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
@@ -110,7 +111,7 @@ impl RelevanceMap {
         horizon: Duration,
         penalty: &[f32],
     ) -> Vec<KeyPhrase> {
-        self.compute_relevances(cois, horizon);
+        self.compute_relevances(cois, horizon, system_time_now());
 
         // TODO: refactor once pop_last() etc are stabilized for BTreeMap
         let mut relevances = self

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -8,12 +8,14 @@ mod utils;
 
 #[cfg(test)]
 pub(crate) use self::{
-    relevance::RelevanceMap,
     system::{compute_coi, update_user_interests, CoiSystemError},
-    utils::tests::create_pos_cois,
+    utils::tests::{create_neg_cois, create_pos_cois},
 };
 pub(crate) use merge::reduce_cois;
-pub(crate) use system::{compute_coi_for_embedding, CoiSystem, NeutralCoiSystem};
+pub(crate) use point::find_closest_coi;
+pub(crate) use relevance::RelevanceMap;
+pub(crate) use stats::compute_coi_decay_factor;
+pub(crate) use system::{CoiSystem, NeutralCoiSystem};
 pub(crate) use utils::DocumentRelevance;
 
 use derive_more::From;

--- a/xayn-ai/src/coi/point.rs
+++ b/xayn-ai/src/coi/point.rs
@@ -23,7 +23,7 @@ pub(crate) struct PositiveCoi {
     pub(super) point: Embedding,
     #[obake(cfg(">=0.3"))]
     #[derivative(PartialEq = "ignore")]
-    pub(super) stats: CoiStats,
+    pub(crate) stats: CoiStats,
 
     // removed fields go below this line
     #[obake(cfg(">=0.0, <0.2"))]
@@ -78,7 +78,7 @@ pub(crate) struct NegativeCoi {
     pub(super) id: CoiId,
     pub(super) point: Embedding,
     #[derivative(PartialEq = "ignore")]
-    pub(super) last_view: SystemTime,
+    pub(crate) last_view: SystemTime,
 }
 
 impl NegativeCoi {
@@ -223,7 +223,7 @@ pub(super) fn find_closest_coi_index(
 ///
 /// Returns an immutable reference to the CoI along with the weighted distance between the given
 /// embedding and the k nearest CoIs. If no CoIs were given, `None` will be returned.
-pub(super) fn find_closest_coi<'coi, CP>(
+pub(crate) fn find_closest_coi<'coi, CP>(
     cois: &'coi [CP],
     embedding: &Embedding,
     neighbors: usize,

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -244,6 +244,13 @@ impl RelevanceMap {
             }
         }
     }
+
+    pub(crate) fn relevance_for_coi(&self, id: &CoiId) -> Option<f32> {
+        match self.coi_to_relevance.get(id) {
+            Some(Relevances(Rels::Coi(F32(relevance)))) => Some(*relevance),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -64,7 +64,12 @@ impl RelevanceMap {
     /// other cois. It's an unnormalized score from the interval `[0, ∞)`.
     ///
     /// The relevances in the maps are replaced by the coi relevances.
-    pub(crate) fn compute_relevances(&mut self, cois: &[PositiveCoi], horizon: Duration) {
+    pub(crate) fn compute_relevances(
+        &mut self,
+        cois: &[PositiveCoi],
+        horizon: Duration,
+        now: SystemTime,
+    ) {
         let counts =
             cois.iter().map(|coi| coi.stats.view_count).sum::<usize>() as f32 + f32::EPSILON;
         let times = cois
@@ -73,7 +78,6 @@ impl RelevanceMap {
             .sum::<Duration>()
             .as_secs_f32()
             + f32::EPSILON;
-        let now = system_time_now();
 
         for coi in cois {
             let count = coi.stats.view_count as f32 / counts;
@@ -123,7 +127,7 @@ mod tests {
         let cois = create_pos_cois(&[[]]);
         let config = Configuration::default();
 
-        relevances.compute_relevances(&cois, config.horizon());
+        relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert!(relevances.cois_is_empty());
         assert!(relevances.relevances_is_empty());
     }
@@ -134,7 +138,7 @@ mod tests {
         let cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.]]);
         let config = Configuration::default().with_horizon(Duration::ZERO);
 
-        relevances.compute_relevances(&cois, config.horizon());
+        relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
         assert!(relevances[cois[0].id].is_coi());
         assert!(relevances[cois[1].id].is_coi());
@@ -152,7 +156,7 @@ mod tests {
         let config =
             Configuration::default().with_horizon(Duration::from_secs_f32(SECONDS_PER_DAY));
 
-        relevances.compute_relevances(&cois, config.horizon());
+        relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
         assert!(relevances[cois[0].id].is_coi());
         assert!(relevances[cois[1].id].is_coi());
@@ -172,7 +176,7 @@ mod tests {
         let config =
             Configuration::default().with_horizon(Duration::from_secs_f32(SECONDS_PER_DAY));
 
-        relevances.compute_relevances(&cois, config.horizon());
+        relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
         assert!(relevances[cois[0].id].is_coi());
         assert!(relevances[cois[1].id].is_coi());
@@ -193,7 +197,7 @@ mod tests {
         let config =
             Configuration::default().with_horizon(Duration::from_secs_f32(2. * SECONDS_PER_DAY));
 
-        relevances.compute_relevances(&cois, config.horizon());
+        relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
         assert!(relevances[cois[0].id].is_coi());
         assert!(relevances[cois[1].id].is_coi());
@@ -223,7 +227,7 @@ mod tests {
         );
         let config = Configuration::default();
 
-        relevances.compute_relevances(&cois, config.horizon());
+        relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), 3);
         assert!(relevances[cois[0].id].is_coi());
         assert!(relevances[cois[1].id].is_coi());

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -93,6 +93,11 @@ impl CoiSystem {
         self.relevances
             .select_top_key_phrases(cois, top, config.horizon(), config.penalty())
     }
+
+    /// Returns a mutable reference to the inner [`RelevanceMap`].
+    pub(crate) fn relevances_mut(&mut self) -> &mut RelevanceMap {
+        &mut self.relevances
+    }
 }
 
 impl systems::CoiSystem for CoiSystem {

--- a/xayn-ai/src/ranker/config.rs
+++ b/xayn-ai/src/ranker/config.rs
@@ -15,8 +15,8 @@ pub(crate) struct Configuration {
     max_key_phrases: usize,
     gamma: f32,
     penalty: Vec<f32>,
-    min_positive_cois: u32,
-    min_negative_cois: u32,
+    min_positive_cois: usize,
+    min_negative_cois: usize,
 }
 
 /// Potential errors of the ranker configuration.
@@ -165,7 +165,7 @@ impl Configuration {
     }
 
     /// The minimum number of positive cois required for the context calculation.
-    pub(crate) fn min_positive_cois(&self) -> u32 {
+    pub(crate) fn min_positive_cois(&self) -> usize {
         self.min_positive_cois
     }
 
@@ -174,7 +174,7 @@ impl Configuration {
     /// # Errors
     /// Fails if the minimum number is zero.
     #[allow(dead_code)]
-    pub(crate) fn with_min_positive_cois(self, min_positive_cois: u32) -> Result<Self, Error> {
+    pub(crate) fn with_min_positive_cois(self, min_positive_cois: usize) -> Result<Self, Error> {
         if min_positive_cois > 0 {
             Ok(Self {
                 min_positive_cois,
@@ -186,7 +186,7 @@ impl Configuration {
     }
 
     /// The minimum number of negative cois required for the context calculation.
-    pub(crate) fn min_negative_cois(&self) -> u32 {
+    pub(crate) fn min_negative_cois(&self) -> usize {
         self.min_negative_cois
     }
 
@@ -195,7 +195,7 @@ impl Configuration {
     /// # Errors
     /// Fails if the minimum number is zero.
     #[allow(dead_code)]
-    pub(crate) fn with_min_negative_cois(self, min_negative_cois: u32) -> Result<Self, Error> {
+    pub(crate) fn with_min_negative_cois(self, min_negative_cois: usize) -> Result<Self, Error> {
         if min_negative_cois > 0 {
             Ok(Self {
                 min_negative_cois,

--- a/xayn-ai/src/ranker/config.rs
+++ b/xayn-ai/src/ranker/config.rs
@@ -15,6 +15,8 @@ pub(crate) struct Configuration {
     max_key_phrases: usize,
     gamma: f32,
     penalty: Vec<f32>,
+    min_positive_cois: u32,
+    min_negative_cois: u32,
 }
 
 /// Potential errors of the ranker configuration.
@@ -31,6 +33,10 @@ pub(crate) enum Error {
     Gamma,
     /// Invalid coi penalty, expected non-empty, finite and sorted values
     Penalty,
+    /// Invalid minimum number of positive cois, expected positive value
+    MinPositiveCois,
+    /// Invalid minimum number of negative cois, expected positive value
+    MinNegativeCois,
 }
 
 impl Configuration {
@@ -102,7 +108,7 @@ impl Configuration {
         Self { horizon, ..self }
     }
 
-    /// The weighting between coi and pairwise candidate similarites in the key phrase selection.
+    /// The weighting between coi and pairwise candidate similarities in the key phrase selection.
     pub(crate) fn gamma(&self) -> f32 {
         self.gamma
     }
@@ -157,6 +163,48 @@ impl Configuration {
     pub(crate) fn max_key_phrases(&self) -> usize {
         self.penalty.len()
     }
+
+    /// The minimum number of positive cois required for the context calculation
+    pub(crate) fn min_positive_cois(&self) -> u32 {
+        self.min_positive_cois
+    }
+
+    /// Sets the minimum number of positive cois.
+    ///
+    /// # Errors
+    /// Fails if the minimum number is zero.
+    #[allow(dead_code)]
+    pub(crate) fn with_min_positive_cois(self, min_positive_cois: u32) -> Result<Self, Error> {
+        if min_positive_cois > 0 {
+            Ok(Self {
+                min_positive_cois,
+                ..self
+            })
+        } else {
+            Err(Error::MinPositiveCois)
+        }
+    }
+
+    /// The minimum number of negative cois required for the context calculation.
+    pub(crate) fn min_negative_cois(&self) -> u32 {
+        self.min_negative_cois
+    }
+
+    /// Sets the minimum number of negative cois.
+    ///
+    /// # Errors
+    /// Fails if the minimum number is zero.
+    #[allow(dead_code)]
+    pub(crate) fn with_min_negative_cois(self, min_negative_cois: u32) -> Result<Self, Error> {
+        if min_negative_cois > 0 {
+            Ok(Self {
+                min_negative_cois,
+                ..self
+            })
+        } else {
+            Err(Error::MinNegativeCois)
+        }
+    }
 }
 
 impl Default for Configuration {
@@ -169,6 +217,8 @@ impl Default for Configuration {
             max_key_phrases: 3,
             gamma: 0.9,
             penalty: vec![1., 0.75, 0.66],
+            min_positive_cois: 2,
+            min_negative_cois: 2,
         }
     }
 }

--- a/xayn-ai/src/ranker/config.rs
+++ b/xayn-ai/src/ranker/config.rs
@@ -164,7 +164,7 @@ impl Configuration {
         self.penalty.len()
     }
 
-    /// The minimum number of positive cois required for the context calculation
+    /// The minimum number of positive cois required for the context calculation.
     pub(crate) fn min_positive_cois(&self) -> u32 {
         self.min_positive_cois
     }

--- a/xayn-ai/src/ranker/context.rs
+++ b/xayn-ai/src/ranker/context.rs
@@ -33,13 +33,13 @@ pub(crate) enum Error {
 
 /// Helper struct for [`find_closest_cois`].
 struct ClosestCois {
-    /// The ID of the positive centre of interest
+    /// The ID of the closest positive centre of interest
     pos_id: CoiId,
-    /// Distance from the positive centre of interest
+    /// Distance from the closest positive centre of interest
     pos_distance: f32,
     pos_last_view: SystemTime,
 
-    /// Distance from the negative centre of interest
+    /// Distance from the closest negative centre of interest
     neg_distance: f32,
     neg_last_view: SystemTime,
 }

--- a/xayn-ai/src/ranker/context.rs
+++ b/xayn-ai/src/ranker/context.rs
@@ -1,119 +1,231 @@
-use crate::{data::document_data::CoiComponent, ranker::DocumentId};
+use std::{
+    collections::HashMap,
+    time::{Duration, SystemTime},
+};
 
-/// The context used to calculate a document's score.
-/// <https://xainag.atlassian.net/wiki/spaces/M2D/pages/770670607/Production+AI+Workflow#3.2-Context-calculations>.
-/// outlines the calculation of positive and negative distance factor.
-pub(crate) struct Context {
-    /// Average positive distance.
-    pos_avg: f32,
-    /// Maximum negative distance.
-    neg_max: f32,
+use displaydoc::Display;
+use thiserror::Error;
+
+use crate::{
+    coi::{
+        compute_coi_decay_factor,
+        find_closest_coi,
+        point::{CoiPoint, UserInterests},
+        RelevanceMap,
+    },
+    embedding::utils::Embedding,
+    ranker::{document::Document, Configuration},
+    utils::system_time_now,
+    CoiId,
+    DocumentId,
+};
+
+#[derive(Error, Debug, Display)]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum Error {
+    /// Not enough positive cois (expected {expected:?}, has {has:?})
+    NotEnoughPositiveCois { expected: u32, has: u32 },
+    /// Not enough negative cois (expected {expected:?}, has {has:?})
+    NotEnoughNegativeCois { expected: u32, has: u32 },
+    /// Failed to find the closest cois
+    FailedToFindTheClosestCois,
 }
 
-impl Context {
-    pub(crate) fn from_cois(cois: &[(DocumentId, CoiComponent)]) -> Self {
-        let cois_len = cois.len() as f32;
-        let pos_avg = cois.iter().map(|(_, coi)| coi.pos_distance).sum::<f32>() / cois_len;
-        let neg_max = cois
-            .iter()
-            .map(|(_, coi)| coi.neg_distance)
-            .fold(f32::MIN, f32::max); // NOTE f32::max considers NaN as smallest value
+/// Helper struct for [`find_closest_cois`].
+struct ClosestCois {
+    /// The ID of the positive centre of interest
+    pos_id: CoiId,
+    /// Distance from the positive centre of interest
+    pos_distance: f32,
+    pos_last_view: SystemTime,
 
-        Self { pos_avg, neg_max }
+    /// Distance from the negative centre of interest
+    neg_distance: f32,
+    neg_last_view: SystemTime,
+}
+
+fn find_closest_cois(
+    embedding: &Embedding,
+    user_interests: &UserInterests,
+    neighbors: usize,
+) -> Option<ClosestCois> {
+    let (pos_coi, pos_distance) = find_closest_coi(&user_interests.positive, embedding, neighbors)?;
+    let (neg_coi, neg_distance) = find_closest_coi(&user_interests.negative, embedding, neighbors)?;
+
+    ClosestCois {
+        pos_id: pos_coi.id(),
+        pos_distance,
+        pos_last_view: pos_coi.stats.last_view,
+        neg_distance,
+        neg_last_view: neg_coi.last_view,
+    }
+    .into()
+}
+
+fn compute_score_for_embedding(
+    embedding: &Embedding,
+    user_interests: &UserInterests,
+    relevances: &mut RelevanceMap,
+    neighbors: usize,
+    horizon: Duration,
+    now: SystemTime,
+) -> Result<f32, Error> {
+    let cois = find_closest_cois(embedding, user_interests, neighbors)
+        .ok_or(Error::FailedToFindTheClosestCois)?;
+
+    let pos_decay = compute_coi_decay_factor(horizon, now, cois.pos_last_view);
+    let neg_decay = compute_coi_decay_factor(horizon, now, cois.neg_last_view);
+
+    relevances.compute_relevances(&user_interests.positive, horizon);
+    let pos_coi_relevance = relevances
+        .relevance_for_coi(&cois.pos_id).unwrap(/* we calculate relevance for all positive cois one line above */);
+
+    let score = cois.pos_distance * pos_decay + pos_coi_relevance - cois.neg_distance * neg_decay;
+
+    Ok(score)
+}
+
+fn has_enough_cois(
+    user_interests: &UserInterests,
+    min_positive_cois: u32,
+    min_negative_cois: u32,
+) -> Result<(), Error> {
+    let pos_cois = user_interests.positive.len() as u32;
+    if pos_cois < min_positive_cois {
+        return Err(Error::NotEnoughPositiveCois {
+            expected: min_positive_cois,
+            has: pos_cois,
+        });
     }
 
-    /// Calculates score from given positive distance and negative distance.
-    /// Both positive and negative distance must be >= 0.
-    pub(crate) fn calculate_score(&self, pos: f32, neg: f32) -> f32 {
-        debug_assert!(pos >= 0. && neg >= 0.);
-        let frac_pos = (self.pos_avg > 0.)
-            .then(|| (1. + pos / self.pos_avg).recip())
-            .unwrap_or(1.);
-        let frac_neg = (1. + (self.neg_max - neg)).recip();
-
-        (frac_pos + frac_neg) / 2.
+    let neg_cois = user_interests.negative.len() as u32;
+    if neg_cois < min_negative_cois {
+        return Err(Error::NotEnoughNegativeCois {
+            expected: min_negative_cois,
+            has: neg_cois,
+        });
     }
+    Ok(())
+}
+
+/// Computes the score for all documents based on the given information.
+///
+/// <https://xainag.atlassian.net/wiki/spaces/M2D/pages/2240708609/Discovery+engine+workflow#The-weighting-of-the-CoI>
+/// outlines parts of the score calculation.
+///
+/// # Errors
+/// Fails if the required number of positive or negative cois is not present or
+/// if coi relevance is not present in the relevances map.
+pub(super) fn compute_score_for_docs(
+    documents: &mut [impl Document],
+    user_interests: &UserInterests,
+    relevances: &mut RelevanceMap,
+    config: &Configuration,
+) -> Result<HashMap<DocumentId, f32>, Error> {
+    has_enough_cois(
+        user_interests,
+        config.min_positive_cois(),
+        config.min_negative_cois(),
+    )?;
+
+    let now = system_time_now();
+    documents
+        .iter()
+        .map(|document| {
+            let score = compute_score_for_embedding(
+                document.smbert_embedding(),
+                user_interests,
+                relevances,
+                config.neighbors(),
+                config.horizon(),
+                now,
+            )?;
+            Ok((document.id(), score))
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        data::document_data::CoiComponent,
-        ranker::{context::Context, DocumentId},
-        CoiId,
-    };
+    use ndarray::arr1;
     use test_utils::assert_approx_eq;
 
-    #[allow(clippy::eq_op)]
+    use crate::{
+        coi::{create_neg_cois, create_pos_cois},
+        utils::SECONDS_PER_DAY,
+    };
+
+    use super::*;
+
     #[test]
-    fn test_calculate() {
-        let calc = Context {
-            pos_avg: 4.,
-            neg_max: 8.,
-        };
+    fn test_has_enough_cois() {
+        let user_interests = UserInterests::default();
 
-        // In the `assert_approx_eq!`s below, the result expectations are
-        // expressions instead of constants to make it easier to understand how
-        // the values come into existence. The format is (frac_pos + frac_neg) / 2.
-
-        let cxt = calc.calculate_score(0., calc.neg_max);
-        assert_approx_eq!(f32, cxt, (1. + 1.) / 2.);
-
-        let cxt = calc.calculate_score(1., calc.neg_max);
-        assert_approx_eq!(f32, cxt, ((4. / 5.) + 1.) / 2.);
-
-        let cxt = calc.calculate_score(calc.pos_avg, calc.neg_max);
-        assert_approx_eq!(f32, cxt, (1. / 2. + 1.) / 2.);
-
-        let cxt = calc.calculate_score(8., 7.);
-        assert_approx_eq!(f32, cxt, ((1. / 3.) + (1. / 2.)) / 2.);
-    }
-
-    #[allow(clippy::eq_op)]
-    #[test]
-    fn test_calculate_neg_max_f32_max() {
-        // when calculating the negative distance in the `CoiSystem`,
-        // we assign `f32::MAX` if we don't have negative cois
-        let calc = Context {
-            pos_avg: 4.,
-            neg_max: f32::MAX,
-        };
-
-        let ctx = calc.calculate_score(0., calc.neg_max);
-        assert_approx_eq!(f32, ctx, (1. + 1.) / 2.);
+        assert!(has_enough_cois(&user_interests, 0, 0).is_ok());
+        assert!(matches!(
+            has_enough_cois(&user_interests, 1, 0).unwrap_err(),
+            Error::NotEnoughPositiveCois {
+                has: 0,
+                expected: 1
+            }
+        ));
+        assert!(matches!(
+            has_enough_cois(&user_interests, 0, 1).unwrap_err(),
+            Error::NotEnoughNegativeCois {
+                has: 0,
+                expected: 1
+            }
+        ));
     }
 
     #[test]
-    fn test_from_cois() {
-        let cois = vec![
-            (
-                DocumentId::from_u128(0),
-                CoiComponent {
-                    id: CoiId::mocked(1),
-                    pos_distance: 1.,
-                    neg_distance: 10.,
-                },
-            ),
-            (
-                DocumentId::from_u128(0),
-                CoiComponent {
-                    id: CoiId::mocked(2),
-                    pos_distance: 6.,
-                    neg_distance: 4.,
-                },
-            ),
-            (
-                DocumentId::from_u128(0),
-                CoiComponent {
-                    id: CoiId::mocked(3),
-                    pos_distance: 8.,
-                    neg_distance: 2.,
-                },
-            ),
-        ];
+    fn test_compute_score_for_embedding() {
+        let embedding = arr1(&[0., 0., 0.]).into();
 
-        let calc = Context::from_cois(cois.as_slice());
-        assert_approx_eq!(f32, calc.pos_avg, 5.);
-        assert_approx_eq!(f32, calc.neg_max, 10.);
+        let epoch = SystemTime::UNIX_EPOCH;
+        let now = epoch + Duration::from_secs_f32(2. * SECONDS_PER_DAY);
+
+        let mut positive = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.]]);
+        positive[0].stats.last_view -= Duration::from_secs_f32(0.5 * SECONDS_PER_DAY);
+        positive[1].stats.last_view -= Duration::from_secs_f32(1.5 * SECONDS_PER_DAY);
+
+        let mut negative = create_neg_cois(&[[100., 0., 0.]]);
+        negative[0].last_view = epoch;
+        let user_interests = UserInterests { positive, negative };
+
+        let mut relevances = RelevanceMap::default();
+        let horizon = Duration::from_secs_f32(2. * SECONDS_PER_DAY);
+
+        let score = compute_score_for_embedding(
+            &embedding,
+            &user_interests,
+            &mut relevances,
+            1,
+            horizon,
+            now,
+        )
+        .unwrap();
+        // 1.1185127 * 0.99999934 + 0.73094887 - 0 * 100 = 12
+        assert_approx_eq!(f32, score, 1.8494608, epsilon = 1e-5);
+    }
+
+    #[test]
+    fn test_compute_score_for_embedding_no_cois() {
+        let embedding = arr1(&[0., 0., 0.]).into();
+        let horizon = Duration::from_secs_f32(SECONDS_PER_DAY);
+
+        let res = compute_score_for_embedding(
+            &embedding,
+            &UserInterests::default(),
+            &mut RelevanceMap::default(),
+            1,
+            horizon,
+            system_time_now(),
+        );
+
+        assert!(matches!(
+            res.unwrap_err(),
+            Error::FailedToFindTheClosestCois
+        ));
     }
 }

--- a/xayn-ai/src/ranker/context.rs
+++ b/xayn-ai/src/ranker/context.rs
@@ -111,7 +111,7 @@ pub(super) fn compute_score_for_docs(
     }
 
     let now = system_time_now();
-    relevances.compute_relevances(&user_interests.positive, config.horizon());
+    relevances.compute_relevances(&user_interests.positive, config.horizon(), now);
     documents
         .iter()
         .map(|document| {
@@ -167,18 +167,18 @@ mod tests {
         let mut relevances = RelevanceMap::default();
         let horizon = Duration::from_secs_f32(2. * SECONDS_PER_DAY);
 
-        relevances.compute_relevances(&user_interests.positive, horizon);
+        relevances.compute_relevances(&user_interests.positive, horizon, now);
         let score = compute_score_for_embedding(
             &embedding,
             &user_interests,
-            &mut relevances,
+            &relevances,
             1,
             horizon,
             now,
         )
         .unwrap();
-        // 1.1185127 * 0.99999934 + 0.73094887 - 0 * 100 = 1.8494608
-        assert_approx_eq!(f32, score, 1.8494608, epsilon = 1e-5);
+        // 1.1185127 * 0.99999934 + 0.99999934 - 0 * 100 = 2.1185114
+        assert_approx_eq!(f32, score, 2.1185114, epsilon = 1e-5);
     }
 
     #[test]
@@ -189,7 +189,7 @@ mod tests {
         let res = compute_score_for_embedding(
             &embedding,
             &UserInterests::default(),
-            &mut RelevanceMap::default(),
+            &RelevanceMap::default(),
             1,
             horizon,
             system_time_now(),

--- a/xayn-ai/src/ranker/context.rs
+++ b/xayn-ai/src/ranker/context.rs
@@ -80,7 +80,7 @@ fn compute_score_for_embedding(
     let pos_coi_relevance = relevances
         .relevance_for_coi(&cois.pos_id).unwrap(/* we calculate relevance for all positive cois one line above */);
 
-    let score = cois.pos_distance * pos_decay + pos_coi_relevance - cois.neg_distance * neg_decay;
+    Ok(cois.pos_distance * pos_decay + pos_coi_relevance - cois.neg_distance * neg_decay)
 
     Ok(score)
 }

--- a/xayn-ai/src/ranker/mod.rs
+++ b/xayn-ai/src/ranker/mod.rs
@@ -213,7 +213,7 @@ mod tests {
 
         assert!(matches!(
             res.unwrap_err().downcast_ref(),
-            Some(ContextError::NotEnoughPositiveCois { has: 0, .. })
+            Some(ContextError::NotEnoughCois)
         ));
     }
 

--- a/xayn-ai/src/ranker/mod.rs
+++ b/xayn-ai/src/ranker/mod.rs
@@ -85,7 +85,7 @@ impl Ranker {
         rank(
             documents,
             &self.user_interests,
-            &mut self.coi.relevances_mut(),
+            self.coi.relevances_mut(),
             &self.config,
         )
     }

--- a/xayn-ai/src/ranker/public.rs
+++ b/xayn-ai/src/ranker/public.rs
@@ -27,8 +27,8 @@ impl Ranker {
     ///
     /// # Errors
     ///
-    /// Fails if no user interests are known.
-    pub fn rank(&self, items: &mut [impl Document]) -> Result<(), Error> {
+    /// Fails if the scores of the documents cannot be computed.
+    pub fn rank(&mut self, items: &mut [impl Document]) -> Result<(), Error> {
         self.0.rank(items)
     }
 


### PR DESCRIPTION
Ticket:

- [TY-2240]

part of [TY-2138]

- replaces the current context calcualtion with the new weighted context calcualtion
- [python counterpart](https://github.com/xaynetwork/xayn_ai_research/blob/5c97c8f96511bcc69e8b2bc74853346afe37d3f4/xayn_ai/backend/rerankers/coi/coi_reranker_3_factor.py#L107)

[TY-2240]: https://xainag.atlassian.net/browse/TY-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TY-2138]: https://xainag.atlassian.net/browse/TY-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ