### PR TITLE
[Merged by Bors] - TY-2288 select top key phrases

### DIFF
--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -17,7 +17,7 @@ use crate::{
 
 #[derive(Clone, Debug, Derivative, Deserialize, Serialize)]
 #[derivative(Eq, Ord, PartialEq, PartialOrd)]
-pub(crate) struct KeyPhrase {
+pub struct KeyPhrase {
     words: String,
     #[derivative(Ord = "ignore", PartialEq = "ignore", PartialOrd = "ignore")]
     point: ArcEmbedding,
@@ -103,7 +103,6 @@ impl Relevances {
     /// Selects the top key phrases from the positive cois, sorted in descending relevance.
     ///
     /// The selected key phrases and their relevances are removed from the maps.
-    #[allow(dead_code)]
     pub(super) fn select_top_key_phrases(
         &mut self,
         cois: &[PositiveCoi],

--- a/xayn-ai/src/coi/system.rs
+++ b/xayn-ai/src/coi/system.rs
@@ -26,6 +26,8 @@ use crate::{
     Error,
 };
 
+use super::key_phrase::KeyPhrase;
+
 #[derive(Error, Debug, Display)]
 pub(crate) enum CoiSystemError {
     /// No CoI could be found for the given embedding
@@ -79,6 +81,17 @@ impl CoiSystem {
         config: &Configuration,
     ) {
         update_negative_coi(cois, embedding, config);
+    }
+
+    /// Selects the top key phrases from the positive cois, sorted in descending relevance.
+    pub(crate) fn select_top_key_phrases(
+        &mut self,
+        cois: &[PositiveCoi],
+        config: &Configuration,
+        top: usize,
+    ) -> Vec<KeyPhrase> {
+        self.relevances
+            .select_top_key_phrases(cois, top, config.horizon(), config.penalty())
     }
 }
 

--- a/xayn-ai/src/ranker/config.rs
+++ b/xayn-ai/src/ranker/config.rs
@@ -92,7 +92,6 @@ impl Configuration {
     }
 
     /// The time since the last view after which a coi becomes irrelevant.
-    #[cfg(test)]
     pub(crate) fn horizon(&self) -> Duration {
         self.horizon
     }
@@ -124,7 +123,6 @@ impl Configuration {
     /// The penalty for less relevant key phrases of a coi in increasing order (ie. lowest penalty
     /// for the most relevant key phrase first and highest penalty for the least relevant key phrase
     /// last). The length of the penalty also serves as the maximum number of key phrases.
-    #[cfg(test)]
     pub(crate) fn penalty(&self) -> &[f32] {
         &self.penalty
     }

--- a/xayn-ai/src/ranker/mod.rs
+++ b/xayn-ai/src/ranker/mod.rs
@@ -11,7 +11,13 @@ use kpe::Pipeline as KPE;
 use thiserror::Error;
 
 use crate::{
-    coi::{compute_coi_for_embedding, point::UserInterests, CoiSystem, DocumentRelevance},
+    coi::{
+        compute_coi_for_embedding,
+        key_phrase::KeyPhrase,
+        point::UserInterests,
+        CoiSystem,
+        DocumentRelevance,
+    },
     data::{
         document::{Relevance, UserFeedback},
         document_data::CoiComponent,
@@ -112,6 +118,12 @@ impl Ranker {
                 &self.config,
             ),
         }
+    }
+
+    /// Selects the top key phrases from the positive cois, sorted in descending relevance.
+    pub(crate) fn select_top_key_phrases(&mut self, top: usize) -> Vec<KeyPhrase> {
+        self.coi
+            .select_top_key_phrases(&self.user_interests.positive, &self.config, top)
     }
 }
 

--- a/xayn-ai/src/ranker/public.rs
+++ b/xayn-ai/src/ranker/public.rs
@@ -9,7 +9,7 @@ use layer::io::BinParams;
 use rubert::{AveragePooler, SMBertBuilder};
 
 use crate::{
-    coi::{point::UserInterests, CoiSystem},
+    coi::{key_phrase::KeyPhrase, point::UserInterests, CoiSystem},
     embedding::{smbert::SMBert, utils::Embedding},
     error::Error,
     ranker::{config::Configuration, utils::Document},
@@ -35,6 +35,11 @@ impl Ranker {
     /// Fails if no user interests are known.
     pub fn rank(&self, items: &mut [Document]) -> Result<(), Error> {
         self.0.rank(items)
+    }
+
+    /// Selects the top key phrases from the positive cois, sorted in descending relevance.
+    pub fn select_top_key_phrases(&mut self, top: usize) -> Vec<KeyPhrase> {
+        self.0.select_top_key_phrases(top)
     }
 }
 


### PR DESCRIPTION
Ticket:
- [TY-2288]

part of [TY-2138]

Summary:
- exports the `select_top_key_phrases` method (will be later used in the DE)

[TY-2288]: https://xainag.atlassian.net/browse/TY-2288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TY-2138]: https://xainag.atlassian.net/browse/TY-2138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ