### PR TITLE
[Merged by Bors] - TY-2303 change relevance maps [1]

### DIFF
--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -348,6 +348,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
         assert_eq!(relevances.relevances_len(), key_phrases.len());
         assert_eq!(
@@ -390,6 +391,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
         assert_eq!(relevances.relevances_len(), key_phrases.len());
         assert_eq!(
@@ -434,6 +436,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.7905694, 0.91287094, 1.]);
         assert_eq!(relevances.relevances_len(), config.max_key_phrases());
         assert_eq!(
@@ -482,6 +485,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
         assert_eq!(relevances.relevances_len(), key_phrases.len());
         assert_eq!(
@@ -524,6 +528,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.]);
         assert_eq!(relevances.relevances_len(), 1);
         assert_eq!(
@@ -562,6 +567,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.8164967, 1.]);
         assert_eq!(relevances.relevances_len(), key_phrases.len());
         assert_eq!(
@@ -604,6 +610,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0.]);
         assert_eq!(relevances.relevances_len(), 1);
         assert_eq!(
@@ -642,6 +649,7 @@ mod tests {
             config.gamma(),
         );
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_kp());
         assert_approx_eq!(f32, relevances[cois[0].id], [0., 1.]);
         assert_eq!(relevances.relevances_len(), key_phrases.len());
         assert_eq!(
@@ -685,6 +693,9 @@ mod tests {
         );
         assert!(top_key_phrases.is_empty());
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_coi());
+        assert!(relevances[cois[1].id].is_coi());
+        assert!(relevances[cois[2].id].is_coi());
         assert!(relevances.relevances_is_empty());
     }
 
@@ -707,6 +718,9 @@ mod tests {
             relevances.select_top_key_phrases(&cois, 0, config.horizon(), config.penalty());
         assert!(top_key_phrases.is_empty());
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_coi());
+        assert!(relevances[cois[1].id].is_coi());
+        assert!(relevances[cois[2].id].is_coi());
         assert_eq!(relevances.relevances_len(), key_phrases.len());
     }
 

--- a/xayn-ai/src/coi/mod.rs
+++ b/xayn-ai/src/coi/mod.rs
@@ -8,7 +8,7 @@ mod utils;
 
 #[cfg(test)]
 pub(crate) use self::{
-    relevance::Relevances,
+    relevance::RelevanceMap,
     system::{compute_coi, update_user_interests, CoiSystemError},
     utils::tests::create_pos_cois,
 };

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -33,9 +33,12 @@ impl Ord for F32 {
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct Relevance(Rel);
 
+/// Relevance score variants.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum Rel {
+    /// A coi relevance score.
     Coi(F32),
+    /// A key phrase relevance score.
     Kp(F32),
 }
 
@@ -78,9 +81,12 @@ impl From<Relevance> for f32 {
 #[derive(Debug)]
 pub(crate) struct Relevances(Rels);
 
+/// Relevance scores variants.
 #[derive(Debug)]
 enum Rels {
+    /// Coi relevance scores.
     Coi(F32),
+    /// Key phrases relevance scores.
     Kps(BTreeSet<F32>),
 }
 

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -286,6 +286,11 @@ mod tests {
         pub(crate) fn is_coi(&self) -> bool {
             matches!(self, Self(Rels::Coi(_)))
         }
+
+        /// Checks if these are key phrase relevances.
+        pub(crate) fn is_kp(&self) -> bool {
+            matches!(self, Self(Rels::Kps(_)))
+        }
     }
 
     impl RelevanceMap {

--- a/xayn-ai/src/coi/relevance.rs
+++ b/xayn-ai/src/coi/relevance.rs
@@ -7,49 +7,91 @@ use derive_more::Into;
 
 use crate::coi::{key_phrase::KeyPhrase, CoiError, CoiId};
 
-/// A finite relevance score.
+/// A finite f32.
 #[derive(Clone, Copy, Debug, Default, Into, PartialEq, PartialOrd)]
-pub(crate) struct Relevance(f32);
+// invariant: the wrapped value must always be finite
+struct F32(f32);
+
+impl PartialEq<f32> for F32 {
+    fn eq(&self, other: &f32) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl Eq for F32 {
+    // never nan by invariant
+}
+
+#[allow(clippy::derive_ord_xor_partial_ord)]
+impl Ord for F32 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap(/* never nan by invariant */)
+    }
+}
+
+/// A relevance score.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct Relevance(Rel);
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum Rel {
+    Coi(F32),
+    Kp(F32),
+}
 
 impl Relevance {
-    /// Creates a relevance score.
+    /// Creates a coi relevance.
     ///
     /// # Errors
     /// Fails if the relevance isn't finite.
-    pub fn new(relevance: f32) -> Result<Self, CoiError> {
+    pub(crate) fn coi(relevance: f32) -> Result<Self, CoiError> {
         if relevance.is_finite() {
-            Ok(Relevance(relevance))
+            Ok(Self(Rel::Coi(F32(relevance))))
+        } else {
+            Err(CoiError::NonFiniteRelevance)
+        }
+    }
+
+    /// Creates a key phrase relevance.
+    ///
+    /// # Errors
+    /// Fails if the relevance isn't finite.
+    pub(crate) fn kp(relevance: f32) -> Result<Self, CoiError> {
+        if relevance.is_finite() {
+            Ok(Self(Rel::Kp(F32(relevance))))
         } else {
             Err(CoiError::NonFiniteRelevance)
         }
     }
 }
 
-impl PartialEq<f32> for Relevance {
-    fn eq(&self, other: &f32) -> bool {
-        self.0.eq(other)
+impl From<Relevance> for f32 {
+    fn from(relevance: Relevance) -> Self {
+        match relevance {
+            Relevance(Rel::Coi(F32(relevance))) => relevance,
+            Relevance(Rel::Kp(F32(relevance))) => relevance,
+        }
     }
 }
 
-impl Eq for Relevance {
-    // never nan by construction
-}
+/// Relevance scores.
+#[derive(Debug)]
+pub(crate) struct Relevances(Rels);
 
-#[allow(clippy::derive_ord_xor_partial_ord)]
-impl Ord for Relevance {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap(/* never nan by construction */)
-    }
+#[derive(Debug)]
+enum Rels {
+    Coi(F32),
+    Kps(BTreeSet<F32>),
 }
 
 /// Sorted maps from cois to relevances to key phrases.
 #[derive(Debug, Default)]
-pub(crate) struct Relevances {
-    coi_to_relevance: HashMap<CoiId, BTreeSet<Relevance>>,
+pub(crate) struct RelevanceMap {
+    coi_to_relevance: HashMap<CoiId, Relevances>,
     relevance_to_key_phrase: BTreeMap<(Relevance, CoiId), Vec<KeyPhrase>>,
 }
 
-impl Relevances {
+impl RelevanceMap {
     /// Iterates over all tuples with matching ids in ascending relevance.
     pub(super) fn filter(
         &self,
@@ -67,10 +109,24 @@ impl Relevances {
 
     /// Inserts the tuple.
     pub(super) fn insert(&mut self, coi_id: CoiId, relevance: Relevance, key_phrase: KeyPhrase) {
-        self.coi_to_relevance
-            .entry(coi_id)
-            .or_default()
-            .insert(relevance);
+        match relevance {
+            Relevance(Rel::Coi(relevance)) => {
+                self.coi_to_relevance
+                    .insert(coi_id, Relevances(Rels::Coi(relevance)));
+            }
+            Relevance(Rel::Kp(relevance)) => {
+                if let Some(Relevances(Rels::Kps(relevances))) =
+                    self.coi_to_relevance.get_mut(&coi_id)
+                {
+                    relevances.insert(relevance);
+                } else {
+                    self.coi_to_relevance.insert(
+                        coi_id,
+                        Relevances(Rels::Kps(IntoIterator::into_iter([relevance]).collect())),
+                    );
+                }
+            }
+        }
         self.relevance_to_key_phrase
             .entry((relevance, coi_id))
             .or_default()
@@ -82,15 +138,22 @@ impl Relevances {
         self.coi_to_relevance
             .remove(&coi_id)
             .map(|relevances| {
-                let key_phrases = relevances
-                    .into_iter()
-                    .map(|relevance| {
-                        self.relevance_to_key_phrase
-                            .remove(&(relevance, coi_id))
-                            .unwrap_or_default()
-                    })
-                    .flatten()
-                    .collect::<BTreeSet<_>>();
+                let key_phrases = match relevances {
+                    Relevances(Rels::Coi(relevance)) => self
+                        .relevance_to_key_phrase
+                        .remove(&(Relevance(Rel::Coi(relevance)), coi_id))
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect::<BTreeSet<_>>(),
+                    Relevances(Rels::Kps(relevances)) => relevances
+                        .into_iter()
+                        .filter_map(|relevance| {
+                            self.relevance_to_key_phrase
+                                .remove(&(Relevance(Rel::Kp(relevance)), coi_id))
+                        })
+                        .flatten()
+                        .collect::<BTreeSet<_>>(),
+                };
                 (!key_phrases.is_empty()).then(|| key_phrases)
             })
             .flatten()
@@ -102,12 +165,22 @@ impl Relevances {
             key_phrases.retain(|this| this != key_phrase);
             if key_phrases.is_empty() {
                 self.relevance_to_key_phrase.remove(&(relevance, coi_id));
-                if let Some(relevances) = self.coi_to_relevance.get_mut(&coi_id) {
-                    relevances.remove(&relevance);
+            }
+        }
+        if let Some(relevances) = self.coi_to_relevance.get_mut(&coi_id) {
+            match (relevances, relevance) {
+                (Relevances(Rels::Coi(relevances)), Relevance(Rel::Coi(ref relevance)))
+                    if relevances == relevance =>
+                {
+                    self.coi_to_relevance.remove(&coi_id);
+                }
+                (Relevances(Rels::Kps(relevances)), Relevance(Rel::Kp(ref relevance))) => {
+                    relevances.remove(relevance);
                     if relevances.is_empty() {
                         self.coi_to_relevance.remove(&coi_id);
                     }
                 }
+                _ => {}
             }
         }
     }
@@ -116,32 +189,50 @@ impl Relevances {
     ///
     /// If old key phrases exist, then their order is preserved under the new relevance.
     pub(super) fn replace(&mut self, coi_id: CoiId, relevance: Relevance) {
-        if let Some(old_relevances) = self
-            .coi_to_relevance
-            .insert(coi_id, IntoIterator::into_iter([relevance]).collect())
-        {
-            let len = old_relevances
-                .iter()
-                .filter_map(|&old_relevance| {
-                    self.relevance_to_key_phrase
-                        .get(&(old_relevance, coi_id))
-                        .map(|key_phrases| key_phrases.len())
-                })
-                .sum::<usize>();
-            if len > 0 {
-                self.relevance_to_key_phrase
-                    .entry((relevance, coi_id))
-                    .and_modify(|key_phrases| key_phrases.reserve_exact(len))
-                    .or_insert_with(|| Vec::with_capacity(len));
-                for old_relevance in old_relevances {
+        let new_relevances = match relevance {
+            Relevance(Rel::Coi(relevance)) => Relevances(Rels::Coi(relevance)),
+            Relevance(Rel::Kp(relevance)) => {
+                Relevances(Rels::Kps(IntoIterator::into_iter([relevance]).collect()))
+            }
+        };
+        if let Some(old_relevances) = self.coi_to_relevance.insert(coi_id, new_relevances) {
+            match old_relevances {
+                Relevances(Rels::Coi(old_relevance)) => {
                     if let Some(old_key_phrases) = self
                         .relevance_to_key_phrase
-                        .remove(&(old_relevance, coi_id))
+                        .remove(&(Relevance(Rel::Coi(old_relevance)), coi_id))
                     {
                         self.relevance_to_key_phrase
                             .entry((relevance, coi_id))
                             .or_default()
                             .extend(old_key_phrases);
+                    }
+                }
+                Relevances(Rels::Kps(old_relevances)) => {
+                    let len = old_relevances
+                        .iter()
+                        .filter_map(|&old_relevance| {
+                            self.relevance_to_key_phrase
+                                .get(&(Relevance(Rel::Kp(old_relevance)), coi_id))
+                                .map(|key_phrases| key_phrases.len())
+                        })
+                        .sum::<usize>();
+                    if len > 0 {
+                        self.relevance_to_key_phrase
+                            .entry((relevance, coi_id))
+                            .and_modify(|key_phrases| key_phrases.reserve_exact(len))
+                            .or_insert_with(|| Vec::with_capacity(len));
+                        for old_relevance in old_relevances {
+                            if let Some(old_key_phrases) = self
+                                .relevance_to_key_phrase
+                                .remove(&(Relevance(Rel::Kp(old_relevance)), coi_id))
+                            {
+                                self.relevance_to_key_phrase
+                                    .entry((relevance, coi_id))
+                                    .or_default()
+                                    .extend(old_key_phrases);
+                            }
+                        }
                     }
                 }
             }
@@ -164,7 +255,42 @@ mod tests {
     use super::*;
 
     impl Relevances {
-        pub(crate) fn new<const N: usize>(
+        /// Gets the number of relevances.
+        pub(crate) fn len(&self) -> usize {
+            match self {
+                Self(Rels::Coi(_)) => 1,
+                Self(Rels::Kps(relevances)) => relevances.len(),
+            }
+        }
+
+        /// Copies the relevance at the given index.
+        ///
+        /// # Panics
+        /// Panics if the index is out of bounds.
+        pub(crate) fn to_relevance(&self, index: usize) -> Relevance {
+            assert!(
+                index < self.len(),
+                "index {} out of bounds for {:?}",
+                index,
+                self,
+            );
+            match self {
+                Self(Rels::Coi(relevance)) => Relevance(Rel::Coi(*relevance)),
+                Self(Rels::Kps(relevances)) => {
+                    Relevance(Rel::Kp(*relevances.iter().nth(index).unwrap()))
+                }
+            }
+        }
+
+        /// Checks if this is a coi relevance.
+        pub(crate) fn is_coi(&self) -> bool {
+            matches!(self, Self(Rels::Coi(_)))
+        }
+    }
+
+    impl RelevanceMap {
+        /// Creates a map with key phrase relevances.
+        pub(crate) fn kp<const N: usize>(
             ids: [CoiId; N],
             relevances: [f32; N],
             key_phrases: Vec<KeyPhrase>,
@@ -180,14 +306,20 @@ mod tests {
 
             let mut this = Self::default();
             for (coi_id, relevance, key_phrase) in izip!(ids, relevances, key_phrases) {
-                let relevance = Relevance::new(relevance).unwrap();
+                let relevance = F32(relevance);
                 this.coi_to_relevance
                     .entry(coi_id)
-                    .or_default()
-                    .insert(relevance);
+                    .and_modify(|relevances| {
+                        if let Relevances(Rels::Kps(relevances)) = relevances {
+                            relevances.insert(relevance);
+                        }
+                    })
+                    .or_insert_with(|| {
+                        Relevances(Rels::Kps(IntoIterator::into_iter([relevance]).collect()))
+                    });
                 if let Some(key_phrase) = key_phrase {
                     this.relevance_to_key_phrase
-                        .entry((relevance, coi_id))
+                        .entry((Relevance(Rel::Kp(relevance)), coi_id))
                         .or_default()
                         .push(key_phrase);
                 }
@@ -196,32 +328,36 @@ mod tests {
             this
         }
 
+        /// Gets the number of cois.
         pub(crate) fn cois_len(&self) -> usize {
             self.coi_to_relevance.len()
         }
 
+        /// Checks if there are no cois.
         pub(crate) fn cois_is_empty(&self) -> bool {
             self.coi_to_relevance.is_empty()
         }
 
+        /// Gets the number of relevances.
         pub(crate) fn relevances_len(&self) -> usize {
             self.relevance_to_key_phrase.len()
         }
 
+        /// Checks if there are no relevances.
         pub(crate) fn relevances_is_empty(&self) -> bool {
             self.relevance_to_key_phrase.is_empty()
         }
     }
 
-    impl Index<CoiId> for Relevances {
-        type Output = BTreeSet<Relevance>;
+    impl Index<CoiId> for RelevanceMap {
+        type Output = Relevances;
 
         fn index(&self, coi_id: CoiId) -> &Self::Output {
             &self.coi_to_relevance[&coi_id]
         }
     }
 
-    impl Index<(CoiId, Relevance)> for Relevances {
+    impl Index<(CoiId, Relevance)> for RelevanceMap {
         type Output = [KeyPhrase];
 
         fn index(&self, (coi_id, relevance): (CoiId, Relevance)) -> &Self::Output {
@@ -229,12 +365,28 @@ mod tests {
         }
     }
 
-    impl<'a> ApproxEqIter<'a, f32> for &'a Relevance {
+    impl<'a> ApproxEqIter<'a, f32> for &'a F32 {
         fn indexed_iter_logical_order(
             self,
             index_prefix: Vec<Ix>,
         ) -> Box<dyn Iterator<Item = (Vec<Ix>, f32)> + 'a> {
             Box::new(once((index_prefix, self.0)))
+        }
+    }
+
+    impl<'a> ApproxEqIter<'a, f32> for &'a Relevances {
+        fn indexed_iter_logical_order(
+            self,
+            index_prefix: Vec<Ix>,
+        ) -> Box<dyn Iterator<Item = (Vec<Ix>, f32)> + 'a> {
+            match self {
+                Relevances(Rels::Coi(relevance)) => {
+                    relevance.indexed_iter_logical_order(index_prefix)
+                }
+                Relevances(Rels::Kps(relevances)) => {
+                    relevances.indexed_iter_logical_order(index_prefix)
+                }
+            }
         }
     }
 }

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -125,6 +125,8 @@ mod tests {
 
         relevances.compute_relevances(&cois, config.horizon());
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_coi());
+        assert!(relevances[cois[1].id].is_coi());
         assert_approx_eq!(f32, relevances[cois[0].id], 0.);
         assert_approx_eq!(f32, relevances[cois[1].id], 0.);
         assert!(relevances.relevances_is_empty());
@@ -141,6 +143,9 @@ mod tests {
 
         relevances.compute_relevances(&cois, config.horizon());
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_coi());
+        assert!(relevances[cois[1].id].is_coi());
+        assert!(relevances[cois[2].id].is_coi());
         assert_approx_eq!(f32, relevances[cois[0].id], 0.5, epsilon = 1e-5);
         assert_approx_eq!(f32, relevances[cois[1].id], 0.6666667, epsilon = 1e-5);
         assert_approx_eq!(f32, relevances[cois[2].id], 0.8333333, epsilon = 1e-5);
@@ -158,6 +163,9 @@ mod tests {
 
         relevances.compute_relevances(&cois, config.horizon());
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_coi());
+        assert!(relevances[cois[1].id].is_coi());
+        assert!(relevances[cois[2].id].is_coi());
         assert_approx_eq!(f32, relevances[cois[0].id], 0.5, epsilon = 1e-5);
         assert_approx_eq!(f32, relevances[cois[1].id], 0.6666667, epsilon = 1e-5);
         assert_approx_eq!(f32, relevances[cois[2].id], 0.8333333, epsilon = 1e-5);
@@ -176,6 +184,9 @@ mod tests {
 
         relevances.compute_relevances(&cois, config.horizon());
         assert_eq!(relevances.cois_len(), cois.len());
+        assert!(relevances[cois[0].id].is_coi());
+        assert!(relevances[cois[1].id].is_coi());
+        assert!(relevances[cois[2].id].is_coi());
         assert_approx_eq!(f32, relevances[cois[0].id], 0.48729968, epsilon = 1e-5);
         assert_approx_eq!(f32, relevances[cois[1].id], 0.15438259, epsilon = 1e-5);
         assert_approx_eq!(f32, relevances[cois[2].id], 0.);

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -2,7 +2,7 @@ use ndarray::arr1;
 
 use crate::{
     analytics::AnalyticsSystem as AnalyticsSys,
-    coi::{compute_coi, update_user_interests, Relevances},
+    coi::{compute_coi, update_user_interests, RelevanceMap},
     context::Context,
     data::document_data::{
         DocumentDataWithQAMBert,
@@ -100,7 +100,7 @@ fn mocked_coi_system() -> MockCoiSystem {
         .returning(move |history, documents, user_interests| {
             update_user_interests(
                 user_interests,
-                &mut Relevances::default(),
+                &mut RelevanceMap::default(),
                 history,
                 documents,
                 |_| todo!(/* mock once KPE is used */),


### PR DESCRIPTION
**References**

- [TY-2303]
- #398

**Summary**

- add type safety for relevance variants: the new `Relevance`/`s` wrappers internally maintain two variants for coi and key phrase relevances respectively
- some renaming: `Relevance -> F32`, `Relevances -> RelevanceMap`


[TY-2303]: https://xainag.atlassian.net/browse/TY-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ