### PR TITLE
[Merged by Bors] - TY-2309 Define configuration to build the Ranker

### DIFF
--- a/xayn-ai/src/coi/key_phrase.rs
+++ b/xayn-ai/src/coi/key_phrase.rs
@@ -304,7 +304,7 @@ mod tests {
 
     use ndarray::arr1;
 
-    use crate::{coi::utils::tests::create_pos_cois, ranker::Configuration};
+    use crate::{coi::utils::tests::create_pos_cois, ranker::Config};
     use test_utils::assert_approx_eq;
 
     use super::*;
@@ -315,7 +315,7 @@ mod tests {
         let cois = create_pos_cois(&[[1., 0., 0.]]);
         let candidates = &[];
         let smbert = |_: &str| unreachable!();
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -338,7 +338,7 @@ mod tests {
         let mut relevances = RelevanceMap::kp([cois[0].id; 2], [0.; 2], key_phrases.to_vec());
         let candidates = &[];
         let smbert = |_: &str| unreachable!();
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -381,7 +381,7 @@ mod tests {
                 })
                 .unwrap()
         };
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -426,7 +426,7 @@ mod tests {
                 })
                 .unwrap()
         };
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -475,7 +475,7 @@ mod tests {
                 })
                 .unwrap()
         };
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -518,7 +518,7 @@ mod tests {
                 })
                 .unwrap()
         };
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -557,7 +557,7 @@ mod tests {
                 })
                 .unwrap()
         };
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -600,7 +600,7 @@ mod tests {
                 })
                 .unwrap()
         };
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -639,7 +639,7 @@ mod tests {
                 })
                 .unwrap()
         };
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.select_key_phrases(
             &cois[0],
@@ -666,7 +666,7 @@ mod tests {
     fn test_select_top_key_phrases_empty_cois() {
         let cois = create_pos_cois(&[] as &[[f32; 0]]);
         let mut relevances = RelevanceMap::default();
-        let config = Configuration::default();
+        let config = Config::default();
 
         let top_key_phrases = relevances.select_top_key_phrases(
             &cois,
@@ -683,7 +683,7 @@ mod tests {
     fn test_select_top_key_phrases_empty_key_phrases() {
         let cois = create_pos_cois(&[[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]]);
         let mut relevances = RelevanceMap::default();
-        let config = Configuration::default();
+        let config = Config::default();
 
         let top_key_phrases = relevances.select_top_key_phrases(
             &cois,
@@ -712,7 +712,7 @@ mod tests {
             [0.; 3],
             key_phrases.to_vec(),
         );
-        let config = Configuration::default();
+        let config = Config::default();
 
         let top_key_phrases =
             relevances.select_top_key_phrases(&cois, 0, config.horizon(), config.penalty());
@@ -749,7 +749,7 @@ mod tests {
             [0.; 9],
             key_phrases.into(),
         );
-        let config = Configuration::default();
+        let config = Config::default();
 
         let top_key_phrases = relevances.select_top_key_phrases(
             &cois,

--- a/xayn-ai/src/coi/stats.rs
+++ b/xayn-ai/src/coi/stats.rs
@@ -129,7 +129,7 @@ mod tests {
 
     use crate::{
         coi::{key_phrase::KeyPhrase, utils::tests::create_pos_cois},
-        ranker::Configuration,
+        ranker::Config,
     };
     use test_utils::assert_approx_eq;
 
@@ -139,7 +139,7 @@ mod tests {
     fn test_compute_relevances_empty_cois() {
         let mut relevances = RelevanceMap::default();
         let cois = create_pos_cois(&[[]]);
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert!(relevances.cois_is_empty());
@@ -150,7 +150,7 @@ mod tests {
     fn test_compute_relevances_zero_horizon() {
         let mut relevances = RelevanceMap::default();
         let cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.]]);
-        let config = Configuration::default().with_horizon(Duration::ZERO);
+        let config = Config::default().with_horizon(Duration::ZERO);
 
         relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
@@ -167,8 +167,7 @@ mod tests {
         let mut cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
         cois[1].stats.view_count += 1;
         cois[2].stats.view_count += 2;
-        let config =
-            Configuration::default().with_horizon(Duration::from_secs_f32(SECONDS_PER_DAY));
+        let config = Config::default().with_horizon(Duration::from_secs_f32(SECONDS_PER_DAY));
 
         relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
@@ -187,8 +186,7 @@ mod tests {
         let mut cois = create_pos_cois(&[[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]);
         cois[1].stats.view_time += Duration::from_secs(10);
         cois[2].stats.view_time += Duration::from_secs(20);
-        let config =
-            Configuration::default().with_horizon(Duration::from_secs_f32(SECONDS_PER_DAY));
+        let config = Config::default().with_horizon(Duration::from_secs_f32(SECONDS_PER_DAY));
 
         relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
@@ -208,8 +206,7 @@ mod tests {
         cois[0].stats.last_view -= Duration::from_secs_f32(0.5 * SECONDS_PER_DAY);
         cois[1].stats.last_view -= Duration::from_secs_f32(1.5 * SECONDS_PER_DAY);
         cois[2].stats.last_view -= Duration::from_secs_f32(2.5 * SECONDS_PER_DAY);
-        let config =
-            Configuration::default().with_horizon(Duration::from_secs_f32(2. * SECONDS_PER_DAY));
+        let config = Config::default().with_horizon(Duration::from_secs_f32(2. * SECONDS_PER_DAY));
 
         relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), cois.len());
@@ -239,7 +236,7 @@ mod tests {
             [0., 0., 1., 0., 0., 0.],
             key_phrases.to_vec(),
         );
-        let config = Configuration::default();
+        let config = Config::default();
 
         relevances.compute_relevances(&cois, config.horizon(), system_time_now());
         assert_eq!(relevances.cois_len(), 3);

--- a/xayn-ai/src/lib.rs
+++ b/xayn-ai/src/lib.rs
@@ -35,6 +35,7 @@ pub use crate::{
 
 // We need to re-export these, since they encapsulate the arguments
 // required for pipeline construction, and are passed to builders.
+pub use kpe::Configuration as KpeConfig;
 pub use rubert::{QAMBertConfig, SMBertConfig};
 
 #[cfg(test)]

--- a/xayn-ai/src/ranker/config.rs
+++ b/xayn-ai/src/ranker/config.rs
@@ -8,7 +8,7 @@ use crate::utils::{nan_safe_f32_cmp_desc, SECONDS_PER_DAY};
 
 /// The configuration of the ranker.
 #[derive(Clone, Debug)]
-pub struct Configuration {
+pub struct Config {
     shift_factor: f32,
     threshold: f32,
     horizon: Duration,
@@ -36,7 +36,7 @@ pub enum Error {
     MinNegativeCois,
 }
 
-impl Configuration {
+impl Config {
     /// The shift factor by how much a Coi is shifted towards a new point.
     pub fn shift_factor(&self) -> f32 {
         self.shift_factor
@@ -182,7 +182,7 @@ impl Configuration {
     }
 }
 
-impl Default for Configuration {
+impl Default for Config {
     fn default() -> Self {
         Self {
             shift_factor: 0.1,

--- a/xayn-ai/src/ranker/context.rs
+++ b/xayn-ai/src/ranker/context.rs
@@ -96,7 +96,7 @@ fn has_enough_cois(
 /// # Errors
 /// Fails if the required number of positive or negative cois is not present.
 pub(super) fn compute_score_for_docs(
-    documents: &mut [impl Document],
+    documents: &[impl Document],
     user_interests: &UserInterests,
     relevances: &mut RelevanceMap,
     config: &Configuration,

--- a/xayn-ai/src/ranker/context.rs
+++ b/xayn-ai/src/ranker/context.rs
@@ -14,7 +14,7 @@ use crate::{
         RelevanceMap,
     },
     embedding::utils::Embedding,
-    ranker::{document::Document, Configuration},
+    ranker::{document::Document, Config},
     utils::system_time_now,
     CoiId,
     DocumentId,
@@ -99,7 +99,7 @@ pub(super) fn compute_score_for_docs(
     documents: &[impl Document],
     user_interests: &UserInterests,
     relevances: &mut RelevanceMap,
-    config: &Configuration,
+    config: &Config,
 ) -> Result<HashMap<DocumentId, f32>, Error> {
     if !has_enough_cois(
         user_interests,

--- a/xayn-ai/src/ranker/mod.rs
+++ b/xayn-ai/src/ranker/mod.rs
@@ -14,3 +14,4 @@ pub use crate::{
     embedding::utils::{ArcEmbedding, Embedding},
     DocumentId,
 };
+pub use rubert::AveragePooler;

--- a/xayn-ai/src/ranker/mod.rs
+++ b/xayn-ai/src/ranker/mod.rs
@@ -5,7 +5,7 @@ mod public;
 mod system;
 
 pub use self::{
-    config::Configuration,
+    config::Config,
     document::Document,
     public::{Builder, Ranker},
 };

--- a/xayn-ai/src/ranker/public.rs
+++ b/xayn-ai/src/ranker/public.rs
@@ -7,7 +7,7 @@ use crate::{
     coi::{key_phrase::KeyPhrase, point::UserInterests, CoiSystem},
     embedding::{smbert::SMBert, utils::Embedding},
     error::Error,
-    ranker::{config::Configuration, document::Document},
+    ranker::{config::Config, document::Document},
     UserFeedback,
 };
 
@@ -64,7 +64,7 @@ pub struct Builder<'a, P> {
     smbert_config: SMBertConfig<'a, P>,
     kpe_config: KpeConfiguration<'a>,
     user_interests: UserInterests,
-    ranker_config: Configuration,
+    ranker_config: Config,
 }
 
 impl<'a> Builder<'a, AveragePooler> {
@@ -73,7 +73,7 @@ impl<'a> Builder<'a, AveragePooler> {
             smbert_config: smbert,
             kpe_config: kpe,
             user_interests: UserInterests::default(),
-            ranker_config: Configuration::default(),
+            ranker_config: Config::default(),
         }
     }
 
@@ -87,8 +87,8 @@ impl<'a> Builder<'a, AveragePooler> {
         Ok(self)
     }
 
-    /// Sets the ranker [`Configuration`] to use.
-    pub fn with_ranker_config(mut self, config: Configuration) -> Self {
+    /// Sets the ranker [`Config`] to use.
+    pub fn with_ranker_config(mut self, config: Config) -> Self {
         self.ranker_config = config;
         self
     }

--- a/xayn-ai/src/ranker/system.rs
+++ b/xayn-ai/src/ranker/system.rs
@@ -12,7 +12,7 @@ use crate::{
     error::Error,
     ranker::{
         context::{compute_score_for_docs, Error as ContextError},
-        Configuration,
+        Config,
         Document,
     },
     utils::nan_safe_f32_cmp,
@@ -27,7 +27,7 @@ pub(crate) enum RankerError {
 /// The Ranker.
 pub(crate) struct Ranker {
     /// Ranker configuration.
-    config: Configuration,
+    config: Config,
     /// SMBert system.
     smbert: SMBert,
     /// CoI system.
@@ -41,7 +41,7 @@ pub(crate) struct Ranker {
 impl Ranker {
     /// Creates a new `Ranker`.
     pub(crate) fn new(
-        config: Configuration,
+        config: Config,
         smbert: SMBert,
         coi: CoiSystem,
         kpe: KPE,
@@ -132,7 +132,7 @@ fn rank(
     documents: &mut [impl Document],
     user_interests: &UserInterests,
     relevances: &mut RelevanceMap,
-    config: &Configuration,
+    config: &Config,
 ) -> Result<(), Error> {
     if documents.len() < 2 {
         return Ok(());
@@ -171,7 +171,7 @@ mod tests {
             TestDocument::new(3, arr1(&[5., 0., 0.])),
         ];
 
-        let config = Configuration::default()
+        let config = Config::default()
             .with_min_positive_cois(1)
             .unwrap()
             .with_min_negative_cois(1)
@@ -202,7 +202,7 @@ mod tests {
             TestDocument::new(1, arr1(&[0., 0., 0.])),
         ];
 
-        let config = Configuration::default().with_min_positive_cois(1).unwrap();
+        let config = Config::default().with_min_positive_cois(1).unwrap();
 
         let res = rank(
             &mut documents,
@@ -223,7 +223,7 @@ mod tests {
             &mut [] as &mut [TestDocument],
             &UserInterests::default(),
             &mut RelevanceMap::default(),
-            &Configuration::default(),
+            &Config::default(),
         );
         assert!(res.is_ok())
     }

--- a/xayn-ai/src/reranker/public.rs
+++ b/xayn-ai/src/reranker/public.rs
@@ -10,7 +10,7 @@ use crate::{
     embedding::smbert::SMBert,
     error::Error,
     ltr::{DomainReranker, DomainRerankerBuilder},
-    ranker::Configuration,
+    ranker::Config,
     reranker::{
         database::{Database, Db},
         systems::{
@@ -182,7 +182,7 @@ impl<'a, SP, QP, DM> Builder<'a, SP, QP, DM> {
             .with_lowercase(true)
             .with_pooling(AveragePooler);
 
-        let coi = CoiSystemImpl::new(Configuration::default(), smbert.clone());
+        let coi = CoiSystemImpl::new(Config::default(), smbert.clone());
         let domain = self.domain.build()?;
 
         super::Reranker::new(Systems {

--- a/xayn-ai/src/tests/systems.rs
+++ b/xayn-ai/src/tests/systems.rs
@@ -11,7 +11,7 @@ use crate::{
         SMBertComponent,
     },
     ltr::ConstLtr,
-    ranker::Configuration,
+    ranker::Config,
     reranker::{
         database::Database,
         systems::{
@@ -86,7 +86,7 @@ pub(crate) fn mocked_qambert_system() -> MockQAMBertSystem {
 }
 
 fn mocked_coi_system() -> MockCoiSystem {
-    let config = Configuration::default();
+    let config = Config::default();
 
     let mut system = MockCoiSystem::new();
     system


### PR DESCRIPTION
Ticket:

- [TY-2309]

part of: [TY-2282]

Summary:

- export kpe configuration and AveragePooler
- remove smbert/kpe configuration overrides (those will move to the DE)
- add the possibility to pass a custom ranker config to the builder
- impl the builder for `P: AveragePooler` to avoid introducing `<P>` in
```rust 
pub struct SMBert<P>(Arc<rubert::Pipeline<kinds::SMBert, P>>)
```
as this would require changes in the reranker methods and those will be removed soon

[TY-2309]: https://xainag.atlassian.net/browse/TY-2309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TY-2282]: https://xainag.atlassian.net/browse/TY-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ