### PR TITLE
[Merged by Bors] - TY-2389 update kpe bert model

### DIFF
--- a/download_data.sh
+++ b/download_data.sh
@@ -39,4 +39,4 @@ download qambert v0001
 download ltr v0000
 download bench_matmul v0000
 download ltr_test_data v0001
-download kpe v0000
+download kpe v0001

--- a/test-utils/src/kpe.rs
+++ b/test-utils/src/kpe.rs
@@ -2,7 +2,7 @@ use std::{io::Result, path::PathBuf};
 
 use crate::asset::{resolve_path, DATA_DIR};
 
-const ASSET: &str = "kpe_v0000";
+const ASSET: &str = "kpe_v0001";
 
 /// Resolves the path to the Bert vocabulary.
 pub fn vocab() -> Result<PathBuf> {


### PR DESCRIPTION
**References**

- [TY-2389]

**Summary**

- remove `type_ids` from the kpe bert model api
- change kpe download to `v0001` (the distilled quantized kpe model is already uploaded to the bucket as `kpe_v0001`), once we get the new files from pink we just have to exchange them in the bucket


[TY-2389]: https://xainag.atlassian.net/browse/TY-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ