### PR TITLE
[Merged by Bors] - TY-2448 serde ranker config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,7 @@ dependencies = [
  "rstest_reuse",
  "rubert",
  "serde",
+ "serde_json",
  "serde_repr",
  "smallvec",
  "test-utils",

--- a/xayn-ai/Cargo.toml
+++ b/xayn-ai/Cargo.toml
@@ -38,6 +38,7 @@ once_cell = "1.9.0"
 paste = "1.0.6"
 rstest = "0.12.0"
 rstest_reuse = "0.1.3"
+serde_json = "1.0.79"
 test-utils = { path = "../test-utils" }
 
 [features]

--- a/xayn-ai/src/coi/config.rs
+++ b/xayn-ai/src/coi/config.rs
@@ -4,18 +4,22 @@ use displaydoc::Display;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{embedding::utils::COSINE_SIMILARITY_RANGE, utils::nan_safe_f32_cmp_desc};
-
-const SECONDS_PER_DAY: u64 = crate::utils::SECONDS_PER_DAY as u64;
+use crate::{
+    embedding::utils::COSINE_SIMILARITY_RANGE,
+    utils::{nan_safe_f32_cmp_desc, serde_duration_as_days, SECONDS_PER_DAY},
+};
 
 /// The configuration of the cois.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 struct CoiConfig {
     shift_factor: f32,
     threshold: f32,
     min_positive_cois: usize,
     min_negative_cois: usize,
 }
+
+// the f32 fields are never NaN by construction
+impl Eq for CoiConfig {}
 
 impl Default for CoiConfig {
     fn default() -> Self {
@@ -29,13 +33,16 @@ impl Default for CoiConfig {
 }
 
 /// The configuration of the kpe.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 struct KPEConfig {
-    #[serde(with = "serde_horizon_days")]
+    #[serde(with = "serde_duration_as_days")]
     horizon: Duration,
     gamma: f32,
     penalty: Vec<f32>,
 }
+
+// the f32 fields are never NaN by construction
+impl Eq for KPEConfig {}
 
 impl Default for KPEConfig {
     fn default() -> Self {
@@ -48,7 +55,7 @@ impl Default for KPEConfig {
 }
 
 /// The configuration of the coi system.
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Config {
     coi: CoiConfig,
     kpe: KPEConfig,
@@ -206,63 +213,5 @@ impl Config {
     /// The maximum number of key phrases picked during the coi key phrase selection.
     pub fn max_key_phrases(&self) -> usize {
         self.kpe.penalty.len()
-    }
-}
-
-mod serde_horizon_days {
-    use std::time::Duration;
-
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-    use super::SECONDS_PER_DAY;
-
-    pub(super) fn serialize<S>(horizon: &Duration, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        (horizon.as_secs() / SECONDS_PER_DAY).serialize(serializer)
-    }
-
-    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        u64::deserialize(deserializer).map(|days| Duration::from_secs(SECONDS_PER_DAY * days))
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use std::error::Error;
-
-        use serde_json::{from_str, to_string};
-
-        use super::*;
-
-        #[derive(Deserialize, Serialize)]
-        struct Days(#[serde(with = "super")] Duration);
-
-        #[test]
-        fn test_less() -> Result<(), Box<dyn Error>> {
-            let horizon = Duration::from_secs(SECONDS_PER_DAY - 1);
-            let days = from_str::<Days>(&to_string(&Days(horizon))?)?;
-            assert_eq!(days.0, Duration::ZERO);
-            Ok(())
-        }
-
-        #[test]
-        fn test_equal() -> Result<(), Box<dyn Error>> {
-            let horizon = Duration::from_secs(SECONDS_PER_DAY);
-            let days = from_str::<Days>(&to_string(&Days(horizon))?)?;
-            assert_eq!(days.0, horizon);
-            Ok(())
-        }
-
-        #[test]
-        fn test_greater() -> Result<(), Box<dyn Error>> {
-            let horizon = Duration::from_secs(SECONDS_PER_DAY + 1);
-            let days = from_str::<Days>(&to_string(&Days(horizon))?)?;
-            assert_eq!(days.0, Duration::from_secs(SECONDS_PER_DAY));
-            Ok(())
-        }
     }
 }


### PR DESCRIPTION
**References**

- [TY-2448]
- requires #426
- followed by https://github.com/xaynetwork/xayn_discovery_engine/pull/164

**Summary**

- add serde for the ranker `Config`
- `horizon` is serialized as whole days (potentially rounding down) as this is the requirement of the config in [TY-2143]
- the `Config` can be deserialized from the following kind of JSON:

```
{
    "coi": {
        "shift_factor": 0.1,
        "threshold": 0.67,
        "min_positive_cois": 2,
        "min_negative_cois": 2
    },
    "kpe": {
        "horizon": 30,
        "gamma": 0.9,
        "penalty": [1., 0.75, 0.66]
    }
}
```


[TY-2448]: https://xainag.atlassian.net/browse/TY-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TY-2143]: https://xainag.atlassian.net/browse/TY-2143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ