### PR TITLE
[Merged by Bors] - TY 2372 Sort when not enough coi

### DIFF
--- a/xayn-ai/src/ranker/document.rs
+++ b/xayn-ai/src/ranker/document.rs
@@ -7,20 +7,35 @@ pub trait Document {
 
     /// Gets the SMBert embedding of the document.
     fn smbert_embedding(&self) -> &Embedding;
+
+    /// Get the API score.
+    fn score(&self) -> Option<f32>;
+
+    /// Get the API rank.
+    fn rank(&self) -> usize;
 }
 
 #[cfg(test)]
 pub(super) struct TestDocument {
-    pub id: DocumentId,
-    pub smbert_embedding: Embedding,
+    pub(super) id: DocumentId,
+    pub(super) smbert_embedding: Embedding,
+    pub(super) score: Option<f32>,
+    pub(super) rank: usize,
 }
 
 #[cfg(test)]
 impl TestDocument {
-    pub(super) fn new(id: u128, embedding: impl Into<Embedding>) -> Self {
+    pub(super) fn new(
+        id: u128,
+        embedding: impl Into<Embedding>,
+        score: Option<f32>,
+        rank: usize,
+    ) -> Self {
         Self {
             id: DocumentId::from_u128(id),
             smbert_embedding: embedding.into(),
+            score,
+            rank,
         }
     }
 }
@@ -33,5 +48,15 @@ impl Document for TestDocument {
 
     fn smbert_embedding(&self) -> &Embedding {
         &self.smbert_embedding
+    }
+
+    /// Get the API score.
+    fn score(&self) -> Option<f32> {
+        self.score
+    }
+
+    /// Get the API rank.
+    fn rank(&self) -> usize {
+        self.rank
     }
 }

--- a/xayn-ai/src/ranker/system.rs
+++ b/xayn-ai/src/ranker/system.rs
@@ -12,7 +12,8 @@ use crate::{
     error::Error,
     ranker::{
         context::{compute_score_for_docs, Error as ContextError},
-        Config, Document,
+        Config,
+        Document,
     },
     utils::nan_safe_f32_cmp,
 };
@@ -149,7 +150,10 @@ fn rank(
     } else {
         documents.sort_unstable_by(|a, b| {
             a.score()
-                .and_then(|a_score| b.score().map(|b_score| nan_safe_f32_cmp(&b_score, &a_score)))
+                .and_then(|a_score| {
+                    b.score()
+                        .map(|b_score| nan_safe_f32_cmp(&b_score, &a_score))
+                })
                 .unwrap_or_else(|| a.rank().cmp(&b.rank()))
         });
     }


### PR DESCRIPTION
If we don't have enough coi we use the score or the rank to sort.
If both document have the score we use the score, otherwise we use the rank.
Higher score is better. Lower rank is better.